### PR TITLE
UI: render Dimension headings from ui.v1 metadata

### DIFF
--- a/market_health/market_ui.py
+++ b/market_health/market_ui.py
@@ -18,10 +18,9 @@ from rich import box
 # Pull scores + default sectors from the engine (do not re-define here)
 from market_health.engine import compute_scores, SECTORS_DEFAULT
 
-CATEGORY_NAMES: Dict[str, str] = {
-    "A": "Catalyst Health", "B": "Trend & Structure", "C": "Position & Flow",
-    "D": "Risk & Volatility", "E": "Environment & Regime", "F": "Execution & Frictions",
-}
+from market_health.ui_contract_meta import dimension_heading
+
+
 CHECK_LABELS: Dict[str, List[str]] = {
     "A": ["News", "Analysts", "Event", "Insiders", "Peers/Macro", "Guidance"],
     "B": ["Stacked MAs", "RS vs SPY", "BB Mid", "20D Break", "Vol x", "Hold 20EMA"],
@@ -193,7 +192,7 @@ def render_details(console: Console, rows: List[SectorRow], top_k: int, mono: bo
         t.add_column("Cat Total", justify="center")
         for key in "ABCDEF":
             cat = row_data.categories[key]
-            row_cells: List[Text] = [Text(f"{key}  {CATEGORY_NAMES[key]}")]
+            row_cells: List[Text] = [Text(dimension_heading(key))]
             row_cells.extend([chip(ch.score, mono) for ch in cat.checks])
             row_cells.append(score_cell(cat.total, MAX_PER_CATEGORY, mono))
             t.add_row(*row_cells)

--- a/market_health/ui_contract_meta.py
+++ b/market_health/ui_contract_meta.py
@@ -1,0 +1,31 @@
+# Dimension display names come from ui.v1 contract metadata (no hardcoded UI strings).
+# Reads ~/.cache/jerboa/market_health.ui.v1.json by default (or $JERBOA_UI_JSON).
+
+from __future__ import annotations
+
+_DIM_META_CACHE = None
+
+def _load_dimensions_meta():
+    global _DIM_META_CACHE
+    if _DIM_META_CACHE is not None:
+        return _DIM_META_CACHE
+    try:
+        import json, os
+        from pathlib import Path
+        ui_json = os.environ.get("JERBOA_UI_JSON", "~/.cache/jerboa/market_health.ui.v1.json")
+        p = Path(os.path.expanduser(ui_json))
+        d = json.loads(p.read_text("utf-8"))
+        meta = d.get("dimensions_meta") or d.get("categories_meta") or {}
+        _DIM_META_CACHE = meta if isinstance(meta, dict) else {}
+    except Exception:
+        _DIM_META_CACHE = {}
+    return _DIM_META_CACHE
+
+def dimension_heading(code: str) -> str:
+    meta = _load_dimensions_meta()
+    name = ""
+    if isinstance(meta, dict):
+        m = meta.get(code)
+        if isinstance(m, dict):
+            name = m.get("display_name") or ""
+    return f"{code}  {name}" if name else code

--- a/market_ui.py
+++ b/market_ui.py
@@ -28,10 +28,9 @@ from market_health.engine import compute_scores, SECTORS_DEFAULT
 
 LAST_BANDS = {}  # symbol -> last committed band index (0..4) for hysteresis
 
-CATEGORY_NAMES: Dict[str, str] = {
-    "A": "Catalyst Health", "B": "Trend & Structure", "C": "Position & Flow",
-    "D": "Risk & Volatility", "E": "Environment & Regime", "F": "Execution & Frictions",
-}
+from market_health.ui_contract_meta import dimension_heading
+
+
 CHECK_LABELS: Dict[str, List[str]] = {
     "A": ["News", "Analysts", "Event", "Insiders", "Peers/Macro", "Guidance"],
     "B": ["Stacked MAs", "RS vs SPY", "BB Mid", "20D Break", "Vol x", "Hold 20EMA"],
@@ -248,7 +247,7 @@ def render_details(console: Console, rows: List[SectorRow], top_k: int, mono: bo
         t.add_column("Cat Total", justify="center")
         for key in "ABCDEF":
             cat = row_data.categories[key]
-            row_cells: List[Text] = [Text(f"{key}  {CATEGORY_NAMES[key]}")]
+            row_cells: List[Text] = [Text(dimension_heading(key))]
             row_cells.extend([chip(ch.score, mono) for ch in cat.checks])
             row_cells.append(score_cell(cat.total, MAX_PER_CATEGORY, mono))
             t.add_row(*row_cells)


### PR DESCRIPTION
Implements #46.

- Removes hardcoded Dimension names from terminal UI
- Reads display names from ui.v1 metadata (dimensions_meta / categories_meta fallback)
- Safe fallback for unmapped codes (e.g., F)

Fixes #46