### PR TITLE
export: add bands alias next to buckets

### DIFF
--- a/scripts/export_environment_v1.py
+++ b/scripts/export_environment_v1.py
@@ -118,6 +118,7 @@ def main() -> int:
                 "total": total,
                 "max_total": MAX_TOTAL,
                 "buckets": totals,
+                "bands": totals,
                 # Keep the underlying check structure for deeper views:
                 "categories": (item.get("categories") or {}),
             }


### PR DESCRIPTION
Non-breaking change: keep buckets for existing consumers and add bands as an alias for clearer terminology.