### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/chrisdudley-dev/market-health-cli/security/code-scanning/7](https://github.com/chrisdudley-dev/market-health-cli/security/code-scanning/7)

In general, to fix this problem you should explicitly declare a `permissions` block either at the workflow root (applies to all jobs) or on individual jobs, granting only the access scopes the workflow needs. For a standard CI workflow that only checks out code and runs tests, `contents: read` is typically sufficient, as it allows reading repository contents without write access.

For this specific workflow in `.github/workflows/ci.yml`, the single best fix without changing functionality is to add a minimal `permissions` block at the top level of the workflow, just under the `name: CI` line. This will apply to the `test` job (and any future jobs that don’t override permissions) and will constrain the `GITHUB_TOKEN` to read-only access to repository contents. No new methods, imports, or other definitions are needed because this is purely a configuration change in the GitHub Actions workflow YAML.

Concretely:
- Edit `.github/workflows/ci.yml`.
- After line 1 (`name: CI`), insert:

```yaml
permissions:
  contents: read
```

This satisfies CodeQL’s requirement and GitHub’s recommendation for explicit least-privilege token permissions, while not altering the behavior of the existing steps.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
