### PR TITLE
M5: A/C/D scoring flags + UI contract docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,3 +280,8 @@ Key entry points:
 - `scripts/export_recommendations_v1.py`
 - `market_health/market_ui.py`
 
+## Docs
+
+- `docs/SCORING.md` — scoring semantics + A/C/D feature flags
+- `docs/UI_CONTRACT.md` — UI contract fields + example
+- `docs/TESTING.md` — local gates + fixture regeneration

--- a/docs/SCORING.md
+++ b/docs/SCORING.md
@@ -1,0 +1,59 @@
+# Scoring (A-F) and A/C/D upgraded inputs
+
+This project computes sector "Market Health" using 6 dimensions (A-F). Each dimension contains a fixed set of checks, and each check produces a non-negative integer score. Totals are sums of check scores.
+
+## Dimensions
+
+- A (Narrative): news / analysts / events / insiders / peers-macro / guidance context.
+- B (Trend): trend-structure signals (MAs, relative strength, breaks).
+- C (Flow): positioning/flow style signals (OI/flow, blocks, leadership breadth).
+- D (Risk): risk/volatility inputs (ATR/IV/correlation/event risk/sizing).
+- E (Regime): macro/regime drivers (SPY trend, sector rank, breadth, VIX).
+- F (Plan): execution plan checks (trigger/invalidation/targets/time stop, etc).
+
+## Safe fallbacks (default behavior)
+
+By default, scoring uses built-in proxies and safe fallbacks:
+- Missing data for a dimension yields reasonable defaults (no crashes).
+- The output shape stays stable (no schema changes).
+
+## A/C/D upgraded inputs (feature-flagged)
+
+The engine supports optional per-check overrides for A, C, and D using extra columns present in the *latest row* of the sector dataframe (`df_sym`). This is behind environment flags so behavior is unchanged unless you opt in.
+
+Enable flags:
+- `MH_FEATURE_A_V1=1`
+- `MH_FEATURE_C_V1=1`
+- `MH_FEATURE_D_V1=1`
+
+When enabled, if an override column exists, its numeric value is coerced to an integer score and replaces the corresponding check score for that label. If the column is missing/invalid, the original proxy score is preserved.
+
+### A override columns (label -> candidate columns)
+- News -> `a_news`, `news_score`, `news`
+- Analysts -> `a_analysts`, `analysts_score`, `analysts`
+- Event -> `a_event`, `event_score`, `event`
+- Insiders -> `a_insiders`, `insiders_score`, `insiders`
+- Peers/Macro -> `a_peers_macro`, `peers_macro_score`, `peers_macro`
+- Guidance -> `a_guidance`, `guidance_score`, `guidance`
+
+### C override columns (label -> candidate columns)
+- EM Fit -> `c_em_fit`, `em_fit_score`, `em_fit`
+- OI/Flow -> `c_oi_flow`, `oi_flow_score`, `oi_flow`
+- Blocks/DP -> `c_blocks_dp`, `blocks_dp_score`, `blocks_dp`
+- Leaders%>20D -> `c_leaders_20d`, `leaders_20d_score`, `leaders_20d`
+- Money Flow -> `c_money_flow`, `money_flow_score`, `money_flow`
+- SI/Days -> `c_si_days`, `si_days_score`, `si_days`
+
+### D override columns (label -> candidate columns)
+- ATR% -> `d_atr_pct`, `atr_pct_score`, `atr_pct`
+- IV% -> `d_iv_pct`, `iv_pct_score`, `iv_pct`
+- Correlation -> `d_corr`, `corr_score`, `corr`
+- Event Risk -> `d_event_risk`, `event_risk_score`, `event_risk`
+- Gap Plan -> `d_gap_plan`, `gap_plan_score`, `gap_plan`
+- Sizing/RR -> `d_sizing_rr`, `sizing_rr_score`, `sizing_rr`
+
+## Missing data handling
+
+- If the dataframe is empty, proxy checks are used.
+- Overrides are applied only when enabled and the override column exists and is numeric.
+- Overrides do not introduce new fields; they only update scores for existing labels.

--- a/docs/UI_CONTRACT.md
+++ b/docs/UI_CONTRACT.md
@@ -1,0 +1,81 @@
+# UI contract: market_health.ui.v1.json
+
+The UI is driven by a single JSON contract file written to:
+
+- `~/.cache/jerboa/market_health.ui.v1.json`
+
+This contract is intended to be stable. Breaking changes should be accompanied by a contract version bump and updated tests/fixtures.
+
+## Top-level keys
+
+Required:
+- `schema` (string)
+- `asof` (string timestamp)
+- `meta` (object)
+- `summary` (object)
+- `data` (object)
+
+Optional:
+- `generated_at` (string timestamp)
+- `status_line` (string, legacy/compat)
+
+Note: some historical schema strings may be prefixed (e.g. `jerboa.market_health.ui.v1`).
+
+## meta (cache artifact metadata)
+
+`meta` contains cache-file descriptors. Each entry is an object with at least:
+
+Required:
+- `path` (string)
+- `exists` (boolean)
+
+Common optional fields:
+- `bytes` (int)
+- `mtime` (int)
+- `schema` (string) depending on artifact type
+
+Expected entries:
+- `environment`
+- `positions`
+- `sectors`
+- `state`
+- `recommendations`
+- `events_provider`
+
+## summary (rollups + statuses)
+
+`summary` is small and stable; it contains counts and status flags used by the UI.
+
+Required:
+- `positions_count` (int)
+- `events_count` (int)
+- `recommendations_status` (string; one of `ok`, `missing`, `unreadable`)
+
+Optional (may not be present in all exporters):
+- `sectors_count` (int)
+- other rollups
+
+## data (payload for the UI)
+
+Required payload keys used by the UI:
+- `environment` (object)
+- `positions` (object)
+- `sectors` (array)
+- `state` (object)
+- `recommendations` (object)
+
+Additional common payload:
+- `dimensions_meta` (object; A-F label metadata)
+- `categories_meta` / `dimensions_meta` at top-level may exist for compatibility
+
+## Example contract JSON
+
+See: `docs/examples/market_health.ui.v1.example.json`
+
+## Contract stability tests
+
+- Required fields/types: `tests/test_ui_contract_required_fields_v1.py`
+- Shape signature: `tests/fixtures/expected/ui_contract.signature.tsv`
+- Scoring regression snapshots: `tests/fixtures/expected/sector_totals.*.json`
+
+Regeneration steps are documented in `docs/TESTING.md`.

--- a/docs/examples/market_health.ui.v1.example.json
+++ b/docs/examples/market_health.ui.v1.example.json
@@ -1,0 +1,32 @@
+{
+  "schema": "jerboa.market_health.ui.v1",
+  "asof": "2026-02-23T00:00:00Z",
+  "meta": {
+    "environment": { "path": "~/.cache/jerboa/environment.v1.json", "exists": true },
+    "positions": { "path": "~/.cache/jerboa/positions.v1.json", "exists": true },
+    "sectors": { "path": "~/.cache/jerboa/market_health.sectors.json", "exists": true },
+    "state": { "path": "~/.cache/jerboa/state/market_health_refresh_all.state.json", "exists": true },
+    "recommendations": { "path": "~/.cache/jerboa/recommendations.v1.json", "exists": true },
+    "events_provider": { "path": "~/.cache/jerboa/events_provider.v1.json", "exists": false }
+  },
+  "summary": {
+    "positions_count": 3,
+    "events_count": 0,
+    "recommendations_status": "ok"
+  },
+  "data": {
+    "dimensions_meta": {
+      "A": { "display_name": "Narrative", "description": "News/analysts/events/insiders/peers/guidance context." },
+      "B": { "display_name": "Trend", "description": "Trend/momentum signals." },
+      "C": { "display_name": "Flow", "description": "Flow/positioning signals." },
+      "D": { "display_name": "Risk", "description": "Risk/volatility inputs." },
+      "E": { "display_name": "Regime", "description": "Macro/regime drivers." },
+      "F": { "display_name": "Plan", "description": "Execution plan checks." }
+    },
+    "environment": { "schema": "environment.v1" },
+    "positions": { "schema": "positions.v1", "positions": [] },
+    "sectors": [],
+    "state": { "schema": "state.v1" },
+    "recommendations": { "schema": "recommendations.v1" }
+  }
+}

--- a/market_health/engine.py
+++ b/market_health/engine.py
@@ -80,6 +80,95 @@ PRICE_FIELDS = {
     "Stock Splits",
 }
 
+
+def _flag(name: str) -> bool:
+    v = os.environ.get(name, "")
+    return v.lower() in {"1", "true", "yes", "on"}
+
+
+def _latest_int(df, col: str):
+    """Best-effort: get last-row numeric, coerce to int. Returns None if missing/invalid."""
+    try:
+        if not hasattr(df, "columns") or col not in df.columns:
+            return None
+        v = df[col].iloc[-1]
+        # handle pandas/numpy scalars
+        if v is None:
+            return None
+        # NaN check without importing math/numpy explicitly
+        try:
+            if v != v:  # NaN
+                return None
+        except Exception:
+            pass
+        return int(round(float(v)))
+    except Exception:
+        return None
+
+
+# Optional per-check overrides sourced from df_sym's last row.
+# These are only applied when feature flags are enabled AND the override columns exist.
+_A_COLS: dict[str, list[str]] = {
+    "News": ["a_news", "news_score", "news"],
+    "Analysts": ["a_analysts", "analysts_score", "analysts"],
+    "Event": ["a_event", "event_score", "event"],
+    "Insiders": ["a_insiders", "insiders_score", "insiders"],
+    "Peers/Macro": ["a_peers_macro", "peers_macro_score", "peers_macro"],
+    "Guidance": ["a_guidance", "guidance_score", "guidance"],
+}
+
+_C_COLS: dict[str, list[str]] = {
+    "EM Fit": ["c_em_fit", "em_fit_score", "em_fit"],
+    "OI/Flow": ["c_oi_flow", "oi_flow_score", "oi_flow"],
+    "Blocks/DP": ["c_blocks_dp", "blocks_dp_score", "blocks_dp"],
+    "Leaders%>20D": ["c_leaders_20d", "leaders_20d_score", "leaders_20d"],
+    "Money Flow": ["c_money_flow", "money_flow_score", "money_flow"],
+    "SI/Days": ["c_si_days", "si_days_score", "si_days"],
+}
+
+_D_COLS: dict[str, list[str]] = {
+    "ATR%": ["d_atr_pct", "atr_pct_score", "atr_pct"],
+    "IV%": ["d_iv_pct", "iv_pct_score", "iv_pct"],
+    "Correlation": ["d_correlation", "correlation_score", "correlation"],
+    "Event Risk": ["d_event_risk", "event_risk_score", "event_risk"],
+    "Gap Plan": ["d_gap_plan", "gap_plan_score", "gap_plan"],
+    "Sizing/RR": ["d_sizing_rr", "sizing_rr_score", "sizing_rr"],
+}
+
+
+def _apply_dimension_overrides(code: str, checks: list[dict], df_sym) -> list[dict]:
+    mapping = {"A": _A_COLS, "C": _C_COLS, "D": _D_COLS}.get(code)
+    if not mapping:
+        return checks
+
+    out: list[dict] = []
+    for chk in checks:
+        if not isinstance(chk, dict):
+            out.append(chk)
+            continue
+        label = chk.get("label")
+        if not isinstance(label, str) or label not in mapping:
+            out.append(chk)
+            continue
+
+        score = None
+        for col in mapping[label]:
+            score = _latest_int(df_sym, col)
+            if score is not None:
+                break
+
+        if score is None:
+            out.append(chk)
+            continue
+
+        # keep schema stable: only replace existing score field
+        c2 = dict(chk)
+        c2["score"] = max(0, int(score))
+        out.append(c2)
+
+    return out
+
+
 CHECK_LABELS: Dict[str, List[str]] = {
     "A": ["News", "Analysts", "Event", "Insiders", "Peers/Macro", "Guidance"],
     "B": ["Stacked MAs", "RS vs SPY", "BB Mid", "20D Break", "Vol x", "Hold 20EMA"],
@@ -730,6 +819,18 @@ def compute_scores(
         except Exception:
             a_checks = [{"label": lab, "score": 1} for lab in CHECK_LABELS["A"]]
 
+        # Optional A/C/D upgraded inputs (behind flags, safe fallbacks)
+        try:
+            c_checks = compute_position_flow_checks(df_sym)
+        except Exception:
+            c_checks = [{"label": lab, "score": 1} for lab in CHECK_LABELS["C"]]
+        if _flag("MH_FEATURE_A_V1"):
+            a_checks = _apply_dimension_overrides("A", a_checks, df_sym)
+        if _flag("MH_FEATURE_C_V1"):
+            c_checks = _apply_dimension_overrides("C", c_checks, df_sym)
+        if _flag("MH_FEATURE_D_V1"):
+            d_checks = _apply_dimension_overrides("D", d_checks, df_sym)
+
         def neutral() -> List[int]:
             return [1, 1, 1, 1, 1, 1]
 
@@ -741,7 +842,7 @@ def compute_scores(
                     for label, score in zip(CHECK_LABELS["B"], b_scores)
                 ]
             },
-            "C": {"checks": compute_position_flow_checks(df_sym)},
+            "C": {"checks": c_checks},
             "D": {"checks": d_checks},
             "E": {
                 "checks": [


### PR DESCRIPTION
Closes #31
Closes #32

Adds feature-flagged A/C/D score overrides with safe fallbacks and documents scoring + UI contract (with a small example JSON).