### PR TITLE
Issue #107: Forecast provider uses A–E check modules

### DIFF
--- a/market_health/forecast_checks_a_announcements.py
+++ b/market_health/forecast_checks_a_announcements.py
@@ -46,47 +46,73 @@ def a1_catalyst_window(*, H: int, calendar: Optional[Dict[str, Any]]) -> Forecas
         return neutral_check("Catalyst Window", meaning, "No calendar feed; neutral.")
     in_window = bool(calendar.get("catalysts_in_window", False))
     score = 0 if in_window else 2
-    return ForecastCheck("Catalyst Window", meaning, score, {"H": H, "catalysts_in_window": in_window})
+    return ForecastCheck(
+        "Catalyst Window", meaning, score, {"H": H, "catalysts_in_window": in_window}
+    )
 
 
-def a2_macro_calendar_pressure(*, H: int, vix_features: Dict[str, Any]) -> ForecastCheck:
-    meaning = "Is upcoming macro uncertainty likely to pressure decision quality into H?"
+def a2_macro_calendar_pressure(
+    *, H: int, vix_features: Dict[str, Any]
+) -> ForecastCheck:
+    meaning = (
+        "Is upcoming macro uncertainty likely to pressure decision quality into H?"
+    )
     if not vix_features:
-        return neutral_check("Macro Calendar Pressure", meaning, "No VIX feed; neutral.")
+        return neutral_check(
+            "Macro Calendar Pressure", meaning, "No VIX feed; neutral."
+        )
     vix_slope = vix_features.get("vix_slope_10", [])
     vix_rank = vix_features.get("vix_rank_60", [])
     slope_now = vix_slope[-1] if isinstance(vix_slope, list) and vix_slope else None
     rank_now = vix_rank[-1] if isinstance(vix_rank, list) and vix_rank else None
-    elevated = (rank_now is not None and rank_now >= 0.75)
-    rising = (slope_now is not None and slope_now > 0.0)
+    elevated = rank_now is not None and rank_now >= 0.75
+    rising = slope_now is not None and slope_now > 0.0
     if elevated and rising:
         sc = 0
     elif elevated or rising:
         sc = 1
     else:
         sc = 2
-    return ForecastCheck("Macro Calendar Pressure", meaning, sc, {"H": H, "vix_rank_60": rank_now, "vix_slope_10": slope_now})
+    return ForecastCheck(
+        "Macro Calendar Pressure",
+        meaning,
+        sc,
+        {"H": H, "vix_rank_60": rank_now, "vix_slope_10": slope_now},
+    )
 
 
 def a3_earnings_cluster(*, H: int, calendar: Optional[Dict[str, Any]]) -> ForecastCheck:
     meaning = "Are many major constituents reporting soon, increasing variance and headline risk into H?"
     if not calendar:
-        return neutral_check("Earnings Cluster", meaning, "No earnings calendar; neutral.")
+        return neutral_check(
+            "Earnings Cluster", meaning, "No earnings calendar; neutral."
+        )
     cluster = bool(calendar.get("earnings_cluster", False))
     sc = 0 if cluster else 2
-    return ForecastCheck("Earnings Cluster", meaning, sc, {"H": H, "earnings_cluster": cluster})
+    return ForecastCheck(
+        "Earnings Cluster", meaning, sc, {"H": H, "earnings_cluster": cluster}
+    )
 
 
 def a4_policy_reg_risk(*, H: int, calendar: Optional[Dict[str, Any]]) -> ForecastCheck:
     meaning = "Are sector-relevant policy or regulatory decisions approaching inside H?"
     if not calendar:
-        return neutral_check("Policy / Regulation Risk", meaning, "No policy calendar; neutral.")
+        return neutral_check(
+            "Policy / Regulation Risk", meaning, "No policy calendar; neutral."
+        )
     policy_risk = bool(calendar.get("policy_decision_in_window", False))
     sc = 0 if policy_risk else 2
-    return ForecastCheck("Policy / Regulation Risk", meaning, sc, {"H": H, "policy_decision_in_window": policy_risk})
+    return ForecastCheck(
+        "Policy / Regulation Risk",
+        meaning,
+        sc,
+        {"H": H, "policy_decision_in_window": policy_risk},
+    )
 
 
-def a5_headline_shock_proxy(*, ext_z: Optional[float], bb_width: Optional[float], atrp14: Optional[float]) -> ForecastCheck:
+def a5_headline_shock_proxy(
+    *, ext_z: Optional[float], bb_width: Optional[float], atrp14: Optional[float]
+) -> ForecastCheck:
     meaning = "Is the sector recently shock-prone (gappy/unstable), implying higher surprise risk?"
     z = ext_z if ext_z is not None else 0.0
     width = bb_width if bb_width is not None else 0.0
@@ -97,13 +123,22 @@ def a5_headline_shock_proxy(*, ext_z: Optional[float], bb_width: Optional[float]
         sc = 1
     else:
         sc = 2
-    return ForecastCheck("Headline Shock Proxy", meaning, sc, {"ext_z_20": ext_z, "bb_width": bb_width, "atrp14": atrp14})
+    return ForecastCheck(
+        "Headline Shock Proxy",
+        meaning,
+        sc,
+        {"ext_z_20": ext_z, "bb_width": bb_width, "atrp14": atrp14},
+    )
 
 
-def a6_narrative_momentum(*, rs_slope_10: Optional[float], returns: Optional[Sequence[Optional[float]]]) -> ForecastCheck:
+def a6_narrative_momentum(
+    *, rs_slope_10: Optional[float], returns: Optional[Sequence[Optional[float]]]
+) -> ForecastCheck:
     meaning = "Is the narrative sticking (RS improving, few fast reversals) rather than constantly fading?"
     if rs_slope_10 is None:
-        return neutral_check("Narrative Momentum", meaning, "Insufficient RS history; neutral.")
+        return neutral_check(
+            "Narrative Momentum", meaning, "Insufficient RS history; neutral."
+        )
     rev = recent_reversal_rate(returns, window=10) if returns is not None else None
     rev_val = rev if rev is not None else 0.5
     slope = rs_slope_10
@@ -113,10 +148,17 @@ def a6_narrative_momentum(*, rs_slope_10: Optional[float], returns: Optional[Seq
         sc = 1
     else:
         sc = 0
-    return ForecastCheck("Narrative Momentum", meaning, sc, {"rs_slope_10": rs_slope_10, "reversal_rate_10": rev})
+    return ForecastCheck(
+        "Narrative Momentum",
+        meaning,
+        sc,
+        {"rs_slope_10": rs_slope_10, "reversal_rate_10": rev},
+    )
 
 
-def recent_reversal_rate(returns: Optional[Sequence[Optional[float]]], window: int) -> Optional[float]:
+def recent_reversal_rate(
+    returns: Optional[Sequence[Optional[float]]], window: int
+) -> Optional[float]:
     if returns is None:
         return None
     if window <= 2 or len(returns) < window:

--- a/market_health/forecast_checks_b_backdrop.py
+++ b/market_health/forecast_checks_b_backdrop.py
@@ -34,33 +34,64 @@ def compute_b_checks(
     vol_rank_20: Optional[float] = None,
 ) -> List[ForecastCheck]:
     return [
-        b1_trend_persistence(close=close, ema20=ema20, sma50=sma50, slope_close_10=slope_close_10),
+        b1_trend_persistence(
+            close=close, ema20=ema20, sma50=sma50, slope_close_10=slope_close_10
+        ),
         b2_follow_through_setup(close=close, hi20=hi20, clv=clv),
         b3_rs_momentum(rs_slope_10=rs_slope_10, rs_z_20=rs_z_20),
         b4_support_cushion(close=close, ema20=ema20, atrp14=atrp14),
-        b5_participation_trend(up_down_vol_ratio_20=up_down_vol_ratio_20, rs_slope_10=rs_slope_10),
-        b6_acceleration_vs_exhaustion(ext_z_20=ext_z_20, slope_close_10=slope_close_10, vol_rank_20=vol_rank_20),
+        b5_participation_trend(
+            up_down_vol_ratio_20=up_down_vol_ratio_20, rs_slope_10=rs_slope_10
+        ),
+        b6_acceleration_vs_exhaustion(
+            ext_z_20=ext_z_20, slope_close_10=slope_close_10, vol_rank_20=vol_rank_20
+        ),
     ]
 
 
-def b1_trend_persistence(*, close: Optional[float], ema20: Optional[float], sma50: Optional[float], slope_close_10: Optional[float]) -> ForecastCheck:
+def b1_trend_persistence(
+    *,
+    close: Optional[float],
+    ema20: Optional[float],
+    sma50: Optional[float],
+    slope_close_10: Optional[float],
+) -> ForecastCheck:
     meaning = "Is the trend likely to persist into H (structure intact and improving)?"
     if close is None or ema20 is None or sma50 is None or slope_close_10 is None:
-        return neutral_check("Trend Persistence", meaning, "Insufficient history; neutral.")
+        return neutral_check(
+            "Trend Persistence", meaning, "Insufficient history; neutral."
+        )
     up_stack = close > ema20 > sma50
     if up_stack and slope_close_10 > 0.0005:
         sc = 2
-    elif (close > ema20 and slope_close_10 > 0.0) or (up_stack and slope_close_10 >= 0.0):
+    elif (close > ema20 and slope_close_10 > 0.0) or (
+        up_stack and slope_close_10 >= 0.0
+    ):
         sc = 1
     else:
         sc = 0
-    return ForecastCheck("Trend Persistence", meaning, sc, {"close": close, "ema20": ema20, "sma50": sma50, "slope_close_10": slope_close_10, "up_stack": up_stack})
+    return ForecastCheck(
+        "Trend Persistence",
+        meaning,
+        sc,
+        {
+            "close": close,
+            "ema20": ema20,
+            "sma50": sma50,
+            "slope_close_10": slope_close_10,
+            "up_stack": up_stack,
+        },
+    )
 
 
-def b2_follow_through_setup(*, close: Optional[float], hi20: Optional[float], clv: Optional[float]) -> ForecastCheck:
+def b2_follow_through_setup(
+    *, close: Optional[float], hi20: Optional[float], clv: Optional[float]
+) -> ForecastCheck:
     meaning = "If a move just occurred, is it likely to follow through rather than fail quickly?"
     if close is None or hi20 is None:
-        return neutral_check("Follow-Through Setup", meaning, "Insufficient history; neutral.")
+        return neutral_check(
+            "Follow-Through Setup", meaning, "Insufficient history; neutral."
+        )
     breakout = close >= hi20
     clv_val = clv if clv is not None else 0.0
     if breakout and clv_val > 0.3:
@@ -69,13 +100,22 @@ def b2_follow_through_setup(*, close: Optional[float], hi20: Optional[float], cl
         sc = 1
     else:
         sc = 0
-    return ForecastCheck("Follow-Through Setup", meaning, sc, {"close": close, "hi20": hi20, "breakout": breakout, "clv": clv})
+    return ForecastCheck(
+        "Follow-Through Setup",
+        meaning,
+        sc,
+        {"close": close, "hi20": hi20, "breakout": breakout, "clv": clv},
+    )
 
 
-def b3_rs_momentum(*, rs_slope_10: Optional[float], rs_z_20: Optional[float]) -> ForecastCheck:
+def b3_rs_momentum(
+    *, rs_slope_10: Optional[float], rs_z_20: Optional[float]
+) -> ForecastCheck:
     meaning = "Is relative strength improving (momentum), not just currently high?"
     if rs_slope_10 is None:
-        return neutral_check("RS Momentum vs SPY", meaning, "Insufficient RS history; neutral.")
+        return neutral_check(
+            "RS Momentum vs SPY", meaning, "Insufficient RS history; neutral."
+        )
     z = rs_z_20 if rs_z_20 is not None else 0.0
     if rs_slope_10 > 0.0005 and z < 2.5:
         sc = 2
@@ -83,13 +123,22 @@ def b3_rs_momentum(*, rs_slope_10: Optional[float], rs_z_20: Optional[float]) ->
         sc = 1
     else:
         sc = 0
-    return ForecastCheck("RS Momentum vs SPY", meaning, sc, {"rs_slope_10": rs_slope_10, "rs_z_20": rs_z_20})
+    return ForecastCheck(
+        "RS Momentum vs SPY",
+        meaning,
+        sc,
+        {"rs_slope_10": rs_slope_10, "rs_z_20": rs_z_20},
+    )
 
 
-def b4_support_cushion(*, close: Optional[float], ema20: Optional[float], atrp14: Optional[float]) -> ForecastCheck:
+def b4_support_cushion(
+    *, close: Optional[float], ema20: Optional[float], atrp14: Optional[float]
+) -> ForecastCheck:
     meaning = "How much room exists before key support breaks (buffer against normal pullbacks)?"
     if close is None or ema20 is None:
-        return neutral_check("Support Cushion", meaning, "Insufficient history; neutral.")
+        return neutral_check(
+            "Support Cushion", meaning, "Insufficient history; neutral."
+        )
     dist_pct = ((close - ema20) / close) * 100.0 if close else 0.0
     denom = atrp14 if (atrp14 is not None and atrp14 > 0) else 1.0
     cushion_proxy = dist_pct / denom
@@ -99,26 +148,57 @@ def b4_support_cushion(*, close: Optional[float], ema20: Optional[float], atrp14
         sc = 1
     else:
         sc = 0
-    return ForecastCheck("Support Cushion", meaning, sc, {"dist_pct_to_ema20": dist_pct, "atrp14": atrp14, "cushion_proxy": cushion_proxy})
+    return ForecastCheck(
+        "Support Cushion",
+        meaning,
+        sc,
+        {
+            "dist_pct_to_ema20": dist_pct,
+            "atrp14": atrp14,
+            "cushion_proxy": cushion_proxy,
+        },
+    )
 
 
-def b5_participation_trend(*, up_down_vol_ratio_20: Optional[float], rs_slope_10: Optional[float]) -> ForecastCheck:
-    meaning = "Is participation improving (more supportive flow/volume behavior), not fading?"
+def b5_participation_trend(
+    *, up_down_vol_ratio_20: Optional[float], rs_slope_10: Optional[float]
+) -> ForecastCheck:
+    meaning = (
+        "Is participation improving (more supportive flow/volume behavior), not fading?"
+    )
     if up_down_vol_ratio_20 is None or rs_slope_10 is None:
-        return neutral_check("Participation Trend", meaning, "No volume feed or insufficient history; neutral.")
+        return neutral_check(
+            "Participation Trend",
+            meaning,
+            "No volume feed or insufficient history; neutral.",
+        )
     if up_down_vol_ratio_20 >= 1.2 and rs_slope_10 > 0.0:
         sc = 2
     elif up_down_vol_ratio_20 >= 1.0:
         sc = 1
     else:
         sc = 0
-    return ForecastCheck("Participation Trend", meaning, sc, {"up_down_vol_ratio_20": up_down_vol_ratio_20, "rs_slope_10": rs_slope_10})
+    return ForecastCheck(
+        "Participation Trend",
+        meaning,
+        sc,
+        {"up_down_vol_ratio_20": up_down_vol_ratio_20, "rs_slope_10": rs_slope_10},
+    )
 
 
-def b6_acceleration_vs_exhaustion(*, ext_z_20: Optional[float], slope_close_10: Optional[float], vol_rank_20: Optional[float]) -> ForecastCheck:
-    meaning = "Is momentum accelerating cleanly, or showing exhaustion (late-stage, fragile)?"
+def b6_acceleration_vs_exhaustion(
+    *,
+    ext_z_20: Optional[float],
+    slope_close_10: Optional[float],
+    vol_rank_20: Optional[float],
+) -> ForecastCheck:
+    meaning = (
+        "Is momentum accelerating cleanly, or showing exhaustion (late-stage, fragile)?"
+    )
     if ext_z_20 is None or slope_close_10 is None:
-        return neutral_check("Acceleration vs Exhaustion", meaning, "Insufficient history; neutral.")
+        return neutral_check(
+            "Acceleration vs Exhaustion", meaning, "Insufficient history; neutral."
+        )
     v = vol_rank_20 if vol_rank_20 is not None else 0.5
     if slope_close_10 > 0.0 and ext_z_20 < 1.8 and v < 0.85:
         sc = 2
@@ -126,4 +206,13 @@ def b6_acceleration_vs_exhaustion(*, ext_z_20: Optional[float], slope_close_10: 
         sc = 1
     else:
         sc = 0
-    return ForecastCheck("Acceleration vs Exhaustion", meaning, sc, {"slope_close_10": slope_close_10, "ext_z_20": ext_z_20, "vol_rank_20": vol_rank_20})
+    return ForecastCheck(
+        "Acceleration vs Exhaustion",
+        meaning,
+        sc,
+        {
+            "slope_close_10": slope_close_10,
+            "ext_z_20": ext_z_20,
+            "vol_rank_20": vol_rank_20,
+        },
+    )

--- a/market_health/forecast_checks_c_crowding.py
+++ b/market_health/forecast_checks_c_crowding.py
@@ -42,7 +42,9 @@ def compute_c_checks(
 def c1_extension_risk(*, ext_z_20: Optional[float]) -> ForecastCheck:
     meaning = "Is the move too far too fast, increasing mean reversion risk into H?"
     if ext_z_20 is None:
-        return neutral_check("Extension Risk", meaning, "Insufficient history; neutral.")
+        return neutral_check(
+            "Extension Risk", meaning, "Insufficient history; neutral."
+        )
     if ext_z_20 >= 2.5:
         sc = 0
     elif ext_z_20 >= 1.5:
@@ -52,10 +54,16 @@ def c1_extension_risk(*, ext_z_20: Optional[float]) -> ForecastCheck:
     return ForecastCheck("Extension Risk", meaning, sc, {"ext_z_20": ext_z_20})
 
 
-def c2_volume_climax_risk(*, vol_rank_20: Optional[float], last_ret: Optional[float], clv: Optional[float]) -> ForecastCheck:
+def c2_volume_climax_risk(
+    *, vol_rank_20: Optional[float], last_ret: Optional[float], clv: Optional[float]
+) -> ForecastCheck:
     meaning = "Did a volume climax likely mark distribution or instability into H?"
     if vol_rank_20 is None or last_ret is None:
-        return neutral_check("Volume Climax Risk", meaning, "No volume feed or insufficient history; neutral.")
+        return neutral_check(
+            "Volume Climax Risk",
+            meaning,
+            "No volume feed or insufficient history; neutral.",
+        )
     clv_val = clv if clv is not None else 0.0
     if vol_rank_20 >= 0.95 and (last_ret < 0.0 or clv_val < -0.2):
         sc = 0
@@ -63,16 +71,27 @@ def c2_volume_climax_risk(*, vol_rank_20: Optional[float], last_ret: Optional[fl
         sc = 1
     else:
         sc = 2
-    return ForecastCheck("Volume Climax Risk", meaning, sc, {"vol_rank_20": vol_rank_20, "last_ret": last_ret, "clv": clv})
+    return ForecastCheck(
+        "Volume Climax Risk",
+        meaning,
+        sc,
+        {"vol_rank_20": vol_rank_20, "last_ret": last_ret, "clv": clv},
+    )
 
 
-def c3_breadth_thinning(*, returns: Optional[Sequence[Optional[float]]]) -> ForecastCheck:
+def c3_breadth_thinning(
+    *, returns: Optional[Sequence[Optional[float]]]
+) -> ForecastCheck:
     meaning = "Is participation narrowing (few big days dominate), increasing fragility into H?"
     if returns is None or len(returns) < 25:
-        return neutral_check("Breadth Thinning", meaning, "Insufficient returns history; neutral.")
+        return neutral_check(
+            "Breadth Thinning", meaning, "Insufficient returns history; neutral."
+        )
     w = [abs(r) for r in returns[-20:] if r is not None]
     if len(w) < 10:
-        return neutral_check("Breadth Thinning", meaning, "Insufficient usable returns window; neutral.")
+        return neutral_check(
+            "Breadth Thinning", meaning, "Insufficient usable returns window; neutral."
+        )
     total = sum(w)
     top3 = sum(sorted(w, reverse=True)[:3])
     ratio = (top3 / total) if total > 0 else 0.0
@@ -82,10 +101,14 @@ def c3_breadth_thinning(*, returns: Optional[Sequence[Optional[float]]]) -> Fore
         sc = 1
     else:
         sc = 2
-    return ForecastCheck("Breadth Thinning", meaning, sc, {"top3_absret_share_20": ratio})
+    return ForecastCheck(
+        "Breadth Thinning", meaning, sc, {"top3_absret_share_20": ratio}
+    )
 
 
-def c4_flow_pressure(*, up_down_vol_ratio_20: Optional[float], clv: Optional[float]) -> ForecastCheck:
+def c4_flow_pressure(
+    *, up_down_vol_ratio_20: Optional[float], clv: Optional[float]
+) -> ForecastCheck:
     meaning = "Are flows likely to force continuation or reversal (accumulation vs distribution proxy)?"
     if up_down_vol_ratio_20 is None:
         return neutral_check("Flow Pressure", meaning, "No volume feed; neutral.")
@@ -96,19 +119,32 @@ def c4_flow_pressure(*, up_down_vol_ratio_20: Optional[float], clv: Optional[flo
         sc = 1
     else:
         sc = 0
-    return ForecastCheck("Flow Pressure", meaning, sc, {"up_down_vol_ratio_20": up_down_vol_ratio_20, "clv": clv})
+    return ForecastCheck(
+        "Flow Pressure",
+        meaning,
+        sc,
+        {"up_down_vol_ratio_20": up_down_vol_ratio_20, "clv": clv},
+    )
 
 
-def c5_positioning_asymmetry(*, returns: Optional[Sequence[Optional[float]]]) -> ForecastCheck:
+def c5_positioning_asymmetry(
+    *, returns: Optional[Sequence[Optional[float]]]
+) -> ForecastCheck:
     meaning = "Is behavior one-sided (downside tail skew), so small shocks can cause outsized moves?"
     if returns is None or len(returns) < 30:
-        return neutral_check("Positioning Asymmetry", meaning, "Insufficient returns history; neutral.")
+        return neutral_check(
+            "Positioning Asymmetry", meaning, "Insufficient returns history; neutral."
+        )
     w = [r for r in returns[-20:] if r is not None]
     if len(w) < 10:
-        return neutral_check("Positioning Asymmetry", meaning, "Insufficient usable returns window; neutral.")
+        return neutral_check(
+            "Positioning Asymmetry",
+            meaning,
+            "Insufficient usable returns window; neutral.",
+        )
     m = sum(w) / len(w)
     var = sum((r - m) ** 2 for r in w) / max(1, (len(w) - 1))
-    sd = var ** 0.5
+    sd = var**0.5
     tail = sum(1 for r in w if sd > 0 and r < -2.0 * sd)
     freq = tail / len(w)
     if freq >= 0.10:
@@ -117,17 +153,31 @@ def c5_positioning_asymmetry(*, returns: Optional[Sequence[Optional[float]]]) ->
         sc = 1
     else:
         sc = 2
-    return ForecastCheck("Positioning Asymmetry", meaning, sc, {"downside_tail_freq_20": freq, "sd_20": sd})
+    return ForecastCheck(
+        "Positioning Asymmetry",
+        meaning,
+        sc,
+        {"downside_tail_freq_20": freq, "sd_20": sd},
+    )
 
 
-def c6_correlation_crowding(*, corr20: Optional[float], dispersion: Optional[float]) -> ForecastCheck:
+def c6_correlation_crowding(
+    *, corr20: Optional[float], dispersion: Optional[float]
+) -> ForecastCheck:
     meaning = "Is diversification collapsing (high correlation / low dispersion), reducing rotation edge?"
     if corr20 is None or dispersion is None:
-        return neutral_check("Correlation Crowding", meaning, "Insufficient universe context; neutral.")
+        return neutral_check(
+            "Correlation Crowding", meaning, "Insufficient universe context; neutral."
+        )
     if corr20 >= 0.85 and dispersion < 0.006:
         sc = 0
     elif corr20 >= 0.75 or dispersion < 0.008:
         sc = 1
     else:
         sc = 2
-    return ForecastCheck("Correlation Crowding", meaning, sc, {"corr20": corr20, "dispersion": dispersion})
+    return ForecastCheck(
+        "Correlation Crowding",
+        meaning,
+        sc,
+        {"corr20": corr20, "dispersion": dispersion},
+    )

--- a/market_health/forecast_checks_d_danger.py
+++ b/market_health/forecast_checks_d_danger.py
@@ -36,19 +36,30 @@ def compute_d_checks(
     support_cushion_proxy: Optional[float] = None,
 ) -> List[ForecastCheck]:
     return [
-        d1_volatility_trend(atrp14=atrp14, atrp_slope_10=atrp_slope_10, bb_width=bb_width),
+        d1_volatility_trend(
+            atrp14=atrp14, atrp_slope_10=atrp_slope_10, bb_width=bb_width
+        ),
         d2_tail_gap_risk(H=H, returns=returns, calendar=calendar, atrp14=atrp14),
         d3_market_coupling_trend(corr5=corr5, corr20=corr20),
         d4_liquidity_stress(returns=returns, volume=volume),
         d5_drawdown_vulnerability(close=close, lo20=lo20, atrp14=atrp14),
-        d6_risk_reward_feasibility(atrp14=atrp14, support_cushion_proxy=support_cushion_proxy, corr20=corr20),
+        d6_risk_reward_feasibility(
+            atrp14=atrp14, support_cushion_proxy=support_cushion_proxy, corr20=corr20
+        ),
     ]
 
 
-def d1_volatility_trend(*, atrp14: Optional[float], atrp_slope_10: Optional[float], bb_width: Optional[float]) -> ForecastCheck:
+def d1_volatility_trend(
+    *,
+    atrp14: Optional[float],
+    atrp_slope_10: Optional[float],
+    bb_width: Optional[float],
+) -> ForecastCheck:
     meaning = "Is risk rising or falling (volatility expanding/contracting) into H?"
     if atrp14 is None or atrp_slope_10 is None:
-        return neutral_check("Volatility Trend", meaning, "No H/L feed or insufficient history; neutral.")
+        return neutral_check(
+            "Volatility Trend", meaning, "No H/L feed or insufficient history; neutral."
+        )
     width = bb_width if bb_width is not None else 0.0
     elevated = (atrp14 >= 2.5) or (width >= 8.0)
     rising = atrp_slope_10 > 0.0
@@ -58,19 +69,40 @@ def d1_volatility_trend(*, atrp14: Optional[float], atrp_slope_10: Optional[floa
         sc = 1
     else:
         sc = 2
-    return ForecastCheck("Volatility Trend", meaning, sc, {"atrp14": atrp14, "atrp_slope_10": atrp_slope_10, "bb_width": bb_width, "elevated": elevated, "rising": rising})
+    return ForecastCheck(
+        "Volatility Trend",
+        meaning,
+        sc,
+        {
+            "atrp14": atrp14,
+            "atrp_slope_10": atrp_slope_10,
+            "bb_width": bb_width,
+            "elevated": elevated,
+            "rising": rising,
+        },
+    )
 
 
-def d2_tail_gap_risk(*, H: int, returns: Optional[Sequence[Optional[float]]], calendar: Optional[Dict[str, Any]], atrp14: Optional[float]) -> ForecastCheck:
+def d2_tail_gap_risk(
+    *,
+    H: int,
+    returns: Optional[Sequence[Optional[float]]],
+    calendar: Optional[Dict[str, Any]],
+    atrp14: Optional[float],
+) -> ForecastCheck:
     meaning = "Is gap/tail risk elevated into H (rare large moves more likely)?"
     if returns is None or len(returns) < 30:
-        return neutral_check("Tail / Gap Risk", meaning, "Insufficient returns history; neutral.")
+        return neutral_check(
+            "Tail / Gap Risk", meaning, "Insufficient returns history; neutral."
+        )
     w = [r for r in returns[-20:] if r is not None]
     if len(w) < 10:
-        return neutral_check("Tail / Gap Risk", meaning, "Insufficient usable returns window; neutral.")
+        return neutral_check(
+            "Tail / Gap Risk", meaning, "Insufficient usable returns window; neutral."
+        )
     m = sum(w) / len(w)
     var = sum((r - m) ** 2 for r in w) / max(1, (len(w) - 1))
-    sd = var ** 0.5
+    sd = var**0.5
     big = sum(1 for r in w if sd > 0 and abs(r) > 2.0 * sd)
     freq = big / len(w)
     catalyst = bool(calendar.get("catalysts_in_window", False)) if calendar else False
@@ -81,13 +113,30 @@ def d2_tail_gap_risk(*, H: int, returns: Optional[Sequence[Optional[float]]], ca
         sc = 1
     else:
         sc = 2
-    return ForecastCheck("Tail / Gap Risk", meaning, sc, {"H": H, "big_move_freq_20": freq, "sd_20": sd, "catalyst_in_window": catalyst, "atrp14": atrp14})
+    return ForecastCheck(
+        "Tail / Gap Risk",
+        meaning,
+        sc,
+        {
+            "H": H,
+            "big_move_freq_20": freq,
+            "sd_20": sd,
+            "catalyst_in_window": catalyst,
+            "atrp14": atrp14,
+        },
+    )
 
 
-def d3_market_coupling_trend(*, corr5: Optional[float], corr20: Optional[float]) -> ForecastCheck:
+def d3_market_coupling_trend(
+    *, corr5: Optional[float], corr20: Optional[float]
+) -> ForecastCheck:
     meaning = "Is market coupling increasing (less diversification, more systemic drawdown risk) into H?"
     if corr5 is None or corr20 is None:
-        return neutral_check("Market Coupling Trend", meaning, "Insufficient correlation history; neutral.")
+        return neutral_check(
+            "Market Coupling Trend",
+            meaning,
+            "Insufficient correlation history; neutral.",
+        )
     rising = corr5 > corr20 + 0.05
     high = corr5 >= 0.85
     if high and rising:
@@ -96,17 +145,30 @@ def d3_market_coupling_trend(*, corr5: Optional[float], corr20: Optional[float])
         sc = 1
     else:
         sc = 2
-    return ForecastCheck("Market Coupling Trend", meaning, sc, {"corr5": corr5, "corr20": corr20, "high": high, "rising": rising})
+    return ForecastCheck(
+        "Market Coupling Trend",
+        meaning,
+        sc,
+        {"corr5": corr5, "corr20": corr20, "high": high, "rising": rising},
+    )
 
 
-def d4_liquidity_stress(*, returns: Optional[Sequence[Optional[float]]], volume: Optional[Sequence[Number]]) -> ForecastCheck:
+def d4_liquidity_stress(
+    *, returns: Optional[Sequence[Optional[float]]], volume: Optional[Sequence[Number]]
+) -> ForecastCheck:
     meaning = "Are there signs of stressed trading conditions (higher friction, erratic moves) into H?"
     if returns is None or volume is None or len(returns) < 25 or len(volume) < 25:
-        return neutral_check("Liquidity Stress", meaning, "No volume feed or insufficient history; neutral.")
+        return neutral_check(
+            "Liquidity Stress",
+            meaning,
+            "No volume feed or insufficient history; neutral.",
+        )
     rets = [r for r in returns[-20:] if r is not None]
     vols = [float(v) for v in volume][-20:]
     if len(rets) < 10 or len(vols) < 10:
-        return neutral_check("Liquidity Stress", meaning, "Insufficient usable window; neutral.")
+        return neutral_check(
+            "Liquidity Stress", meaning, "Insufficient usable window; neutral."
+        )
     n = min(len(rets), len(vols))
     impacts = [abs(rets[i]) / max(1.0, vols[i]) for i in range(n)]
     imp_now = impacts[-1]
@@ -118,13 +180,24 @@ def d4_liquidity_stress(*, returns: Optional[Sequence[Optional[float]]], volume:
         sc = 1
     else:
         sc = 2
-    return ForecastCheck("Liquidity Stress", meaning, sc, {"impact_now": imp_now, "impact_median": imp_med, "impact_ratio": ratio})
+    return ForecastCheck(
+        "Liquidity Stress",
+        meaning,
+        sc,
+        {"impact_now": imp_now, "impact_median": imp_med, "impact_ratio": ratio},
+    )
 
 
-def d5_drawdown_vulnerability(*, close: Optional[float], lo20: Optional[float], atrp14: Optional[float]) -> ForecastCheck:
-    meaning = "Is the sector close to damage levels where a small drop breaks structure?"
+def d5_drawdown_vulnerability(
+    *, close: Optional[float], lo20: Optional[float], atrp14: Optional[float]
+) -> ForecastCheck:
+    meaning = (
+        "Is the sector close to damage levels where a small drop breaks structure?"
+    )
     if close is None or lo20 is None:
-        return neutral_check("Drawdown Vulnerability", meaning, "Insufficient history; neutral.")
+        return neutral_check(
+            "Drawdown Vulnerability", meaning, "Insufficient history; neutral."
+        )
     dist_pct = ((close - lo20) / close) * 100.0 if close else 0.0
     denom = atrp14 if (atrp14 is not None and atrp14 > 0) else 1.0
     vuln_proxy = dist_pct / denom
@@ -134,13 +207,25 @@ def d5_drawdown_vulnerability(*, close: Optional[float], lo20: Optional[float], 
         sc = 1
     else:
         sc = 2
-    return ForecastCheck("Drawdown Vulnerability", meaning, sc, {"dist_pct_to_20d_low": dist_pct, "atrp14": atrp14, "vuln_proxy": vuln_proxy})
+    return ForecastCheck(
+        "Drawdown Vulnerability",
+        meaning,
+        sc,
+        {"dist_pct_to_20d_low": dist_pct, "atrp14": atrp14, "vuln_proxy": vuln_proxy},
+    )
 
 
-def d6_risk_reward_feasibility(*, atrp14: Optional[float], support_cushion_proxy: Optional[float], corr20: Optional[float]) -> ForecastCheck:
+def d6_risk_reward_feasibility(
+    *,
+    atrp14: Optional[float],
+    support_cushion_proxy: Optional[float],
+    corr20: Optional[float],
+) -> ForecastCheck:
     meaning = "Given forecast risk, can you size it and still have acceptable risk/reward feasibility?"
     if atrp14 is None or support_cushion_proxy is None:
-        return neutral_check("Risk/Reward Feasibility", meaning, "Insufficient risk inputs; neutral.")
+        return neutral_check(
+            "Risk/Reward Feasibility", meaning, "Insufficient risk inputs; neutral."
+        )
     c = corr20 if corr20 is not None else 0.5
     if atrp14 >= 3.0 and support_cushion_proxy < 0.5 and c >= 0.85:
         sc = 0
@@ -148,4 +233,13 @@ def d6_risk_reward_feasibility(*, atrp14: Optional[float], support_cushion_proxy
         sc = 1
     else:
         sc = 2
-    return ForecastCheck("Risk/Reward Feasibility", meaning, sc, {"atrp14": atrp14, "support_cushion_proxy": support_cushion_proxy, "corr20": corr20})
+    return ForecastCheck(
+        "Risk/Reward Feasibility",
+        meaning,
+        sc,
+        {
+            "atrp14": atrp14,
+            "support_cushion_proxy": support_cushion_proxy,
+            "corr20": corr20,
+        },
+    )

--- a/market_health/forecast_checks_e_environment.py
+++ b/market_health/forecast_checks_e_environment.py
@@ -40,14 +40,20 @@ def compute_e_checks(
         e3_leadership_persistence(symbol=symbol_u, returns_by_symbol=returns_by_symbol),
         e4_breadth_regime(dispersion=dispersion),
         e5_cross_regime_pressure(symbol=symbol_u, returns_by_symbol=returns_by_symbol),
-        e6_driver_alignment(rs_slope_10=rs_slope_10, spy_outlook_score=spy_check.score, vix_outlook_score=vix_check.score),
+        e6_driver_alignment(
+            rs_slope_10=rs_slope_10,
+            spy_outlook_score=spy_check.score,
+            vix_outlook_score=vix_check.score,
+        ),
     ]
 
 
 def e1_spy_outlook(*, spy_slope_10: Optional[float]) -> ForecastCheck:
     meaning = "Is the broad market setup improving or deteriorating into H?"
     if spy_slope_10 is None:
-        return neutral_check("SPY Outlook", meaning, "Insufficient SPY history; neutral.")
+        return neutral_check(
+            "SPY Outlook", meaning, "Insufficient SPY history; neutral."
+        )
     if spy_slope_10 > 0.0004:
         sc = 2
     elif spy_slope_10 > -0.0002:
@@ -65,42 +71,63 @@ def e2_vix_outlook(*, vix_features: Dict[str, Any]) -> ForecastCheck:
     vix_rank = vix_features.get("vix_rank_60", [])
     slope_now = vix_slope[-1] if isinstance(vix_slope, list) and vix_slope else None
     rank_now = vix_rank[-1] if isinstance(vix_rank, list) and vix_rank else None
-    elevated = (rank_now is not None and rank_now >= 0.75)
-    rising = (slope_now is not None and slope_now > 0.0)
+    elevated = rank_now is not None and rank_now >= 0.75
+    rising = slope_now is not None and slope_now > 0.0
     if elevated and rising:
         sc = 0
     elif elevated or rising:
         sc = 1
     else:
         sc = 2
-    return ForecastCheck("VIX Outlook", meaning, sc, {"vix_rank_60": rank_now, "vix_slope_10": slope_now})
+    return ForecastCheck(
+        "VIX Outlook", meaning, sc, {"vix_rank_60": rank_now, "vix_slope_10": slope_now}
+    )
 
 
-def e3_leadership_persistence(*, symbol: str, returns_by_symbol: Optional[Dict[str, Sequence[Optional[float]]]], window: int = 5) -> ForecastCheck:
+def e3_leadership_persistence(
+    *,
+    symbol: str,
+    returns_by_symbol: Optional[Dict[str, Sequence[Optional[float]]]],
+    window: int = 5,
+) -> ForecastCheck:
     meaning = "Are sector ranks stable (leaders staying leaders) or rotating rapidly?"
     if not returns_by_symbol:
-        return neutral_check("Leadership Persistence", meaning, "No universe returns; neutral.")
+        return neutral_check(
+            "Leadership Persistence", meaning, "No universe returns; neutral."
+        )
     syms = sorted(returns_by_symbol.keys())
     if symbol not in returns_by_symbol:
-        return neutral_check("Leadership Persistence", meaning, "Symbol missing from universe; neutral.")
+        return neutral_check(
+            "Leadership Persistence", meaning, "Symbol missing from universe; neutral."
+        )
     try:
         min_len = min(len(returns_by_symbol[s]) for s in syms)
     except Exception:
-        return neutral_check("Leadership Persistence", meaning, "Invalid universe returns; neutral.")
+        return neutral_check(
+            "Leadership Persistence", meaning, "Invalid universe returns; neutral."
+        )
     if min_len < window + 1:
-        return neutral_check("Leadership Persistence", meaning, "Insufficient history; neutral.")
+        return neutral_check(
+            "Leadership Persistence", meaning, "Insufficient history; neutral."
+        )
     ranks: List[int] = []
     for t in range(min_len - window, min_len):
         snapshot: List[tuple[str, float]] = []
         for s in syms:
             r = returns_by_symbol[s][t]
             if r is None:
-                return neutral_check("Leadership Persistence", meaning, "Missing returns in window; neutral.")
+                return neutral_check(
+                    "Leadership Persistence",
+                    meaning,
+                    "Missing returns in window; neutral.",
+                )
             snapshot.append((s, float(r)))
         snapshot.sort(key=lambda x: x[1], reverse=True)
         rank = next((i for i, (s, _) in enumerate(snapshot) if s == symbol), None)
         if rank is None:
-            return neutral_check("Leadership Persistence", meaning, "Rank lookup failed; neutral.")
+            return neutral_check(
+                "Leadership Persistence", meaning, "Rank lookup failed; neutral."
+            )
         ranks.append(rank)
     span = max(ranks) - min(ranks)
     avg_rank = sum(ranks) / len(ranks)
@@ -110,11 +137,18 @@ def e3_leadership_persistence(*, symbol: str, returns_by_symbol: Optional[Dict[s
         sc = 1
     else:
         sc = 0
-    return ForecastCheck("Leadership Persistence", meaning, sc, {"ranks_window": ranks, "span": span, "avg_rank": avg_rank, "window": window})
+    return ForecastCheck(
+        "Leadership Persistence",
+        meaning,
+        sc,
+        {"ranks_window": ranks, "span": span, "avg_rank": avg_rank, "window": window},
+    )
 
 
 def e4_breadth_regime(*, dispersion: Optional[float]) -> ForecastCheck:
-    meaning = "Is market participation broad or narrow (proxy via cross-sector dispersion)?"
+    meaning = (
+        "Is market participation broad or narrow (proxy via cross-sector dispersion)?"
+    )
     if dispersion is None:
         return neutral_check("Breadth Regime", meaning, "No dispersion input; neutral.")
     if dispersion >= 0.010:
@@ -126,13 +160,26 @@ def e4_breadth_regime(*, dispersion: Optional[float]) -> ForecastCheck:
     return ForecastCheck("Breadth Regime", meaning, sc, {"dispersion": dispersion})
 
 
-def e5_cross_regime_pressure(*, symbol: str, returns_by_symbol: Optional[Dict[str, Sequence[Optional[float]]]], window: int = 5) -> ForecastCheck:
-    meaning = "Are conditions favoring offense or defense (risk-on vs risk-off tilt into H)?"
+def e5_cross_regime_pressure(
+    *,
+    symbol: str,
+    returns_by_symbol: Optional[Dict[str, Sequence[Optional[float]]]],
+    window: int = 5,
+) -> ForecastCheck:
+    meaning = (
+        "Are conditions favoring offense or defense (risk-on vs risk-off tilt into H)?"
+    )
     if not returns_by_symbol:
-        return neutral_check("Cross-Regime Pressure", meaning, "No universe returns; neutral.")
+        return neutral_check(
+            "Cross-Regime Pressure", meaning, "No universe returns; neutral."
+        )
     syms = set(returns_by_symbol.keys())
     if not (DEFENSIVE.issubset(syms) and (CYCLICAL & syms)):
-        return neutral_check("Cross-Regime Pressure", meaning, "Universe missing defensive/cyclical sets; neutral.")
+        return neutral_check(
+            "Cross-Regime Pressure",
+            meaning,
+            "Universe missing defensive/cyclical sets; neutral.",
+        )
 
     def _avg_cumret(symset: Set[str]) -> Optional[float]:
         vals: List[float] = []
@@ -149,7 +196,11 @@ def e5_cross_regime_pressure(*, symbol: str, returns_by_symbol: Optional[Dict[st
     def_ret = _avg_cumret(DEFENSIVE)
     cyc_ret = _avg_cumret(set(s for s in CYCLICAL if s in syms))
     if def_ret is None or cyc_ret is None:
-        return neutral_check("Cross-Regime Pressure", meaning, "Insufficient returns for regime proxy; neutral.")
+        return neutral_check(
+            "Cross-Regime Pressure",
+            meaning,
+            "Insufficient returns for regime proxy; neutral.",
+        )
     defensive_winning = def_ret > cyc_ret
     is_def = symbol in DEFENSIVE
     if abs(def_ret - cyc_ret) < 0.01:
@@ -160,13 +211,28 @@ def e5_cross_regime_pressure(*, symbol: str, returns_by_symbol: Optional[Dict[st
         sc = 2
     else:
         sc = 0
-    return ForecastCheck("Cross-Regime Pressure", meaning, sc, {"def_ret_window": def_ret, "cyc_ret_window": cyc_ret, "defensive_winning": defensive_winning, "is_defensive": is_def, "window": window})
+    return ForecastCheck(
+        "Cross-Regime Pressure",
+        meaning,
+        sc,
+        {
+            "def_ret_window": def_ret,
+            "cyc_ret_window": cyc_ret,
+            "defensive_winning": defensive_winning,
+            "is_defensive": is_def,
+            "window": window,
+        },
+    )
 
 
-def e6_driver_alignment(*, rs_slope_10: Optional[float], spy_outlook_score: int, vix_outlook_score: int) -> ForecastCheck:
+def e6_driver_alignment(
+    *, rs_slope_10: Optional[float], spy_outlook_score: int, vix_outlook_score: int
+) -> ForecastCheck:
     meaning = "Are dominant drivers likely to support this sector into H (proxy: RS improving under environment)?"
     if rs_slope_10 is None:
-        return neutral_check("Driver Alignment", meaning, "Insufficient RS history; neutral.")
+        return neutral_check(
+            "Driver Alignment", meaning, "Insufficient RS history; neutral."
+        )
     env_support = (spy_outlook_score + vix_outlook_score) / 4.0
     if env_support >= 0.75 and rs_slope_10 > 0.0:
         sc = 2
@@ -174,4 +240,14 @@ def e6_driver_alignment(*, rs_slope_10: Optional[float], spy_outlook_score: int,
         sc = 1
     else:
         sc = 0
-    return ForecastCheck("Driver Alignment", meaning, sc, {"rs_slope_10": rs_slope_10, "spy_outlook_score": spy_outlook_score, "vix_outlook_score": vix_outlook_score, "env_support": env_support})
+    return ForecastCheck(
+        "Driver Alignment",
+        meaning,
+        sc,
+        {
+            "rs_slope_10": rs_slope_10,
+            "spy_outlook_score": spy_outlook_score,
+            "vix_outlook_score": vix_outlook_score,
+            "env_support": env_support,
+        },
+    )

--- a/market_health/forecast_features.py
+++ b/market_health/forecast_features.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from math import sqrt
-from typing import Dict, List, Optional, Sequence, Union
+from typing import Any, Dict, List, Optional, Sequence, Union
 
 Number = Union[int, float]
 
@@ -109,7 +109,9 @@ def rolling_max(values: Sequence[Number], window: int) -> List[Optional[float]]:
     return out
 
 
-def rolling_std(returns: Sequence[Optional[Number]], window: int) -> List[Optional[float]]:
+def rolling_std(
+    returns: Sequence[Optional[Number]], window: int
+) -> List[Optional[float]]:
     if window <= 1:
         raise ValueError("window must be >= 2")
     r = [None if v is None else float(v) for v in returns]
@@ -144,7 +146,9 @@ def zscore(values: Sequence[Number], window: int) -> List[Optional[float]]:
     return out
 
 
-def rolling_percentile_rank(values: Sequence[Number], window: int) -> List[Optional[float]]:
+def rolling_percentile_rank(
+    values: Sequence[Number], window: int
+) -> List[Optional[float]]:
     if window <= 1:
         raise ValueError("window must be >= 2")
     v = _as_float_list(values)
@@ -161,7 +165,9 @@ def rolling_percentile_rank(values: Sequence[Number], window: int) -> List[Optio
     return out
 
 
-def linear_regression_slope(values: Sequence[Number], window: int) -> List[Optional[float]]:
+def linear_regression_slope(
+    values: Sequence[Number], window: int
+) -> List[Optional[float]]:
     if window <= 1:
         raise ValueError("window must be >= 2")
     v = _as_float_list(values)
@@ -181,7 +187,9 @@ def linear_regression_slope(values: Sequence[Number], window: int) -> List[Optio
     return out
 
 
-def normalized_slope(values: Sequence[Number], window: int, eps: float = 1e-12) -> List[Optional[float]]:
+def normalized_slope(
+    values: Sequence[Number], window: int, eps: float = 1e-12
+) -> List[Optional[float]]:
     v = _as_float_list(values)
     sl = linear_regression_slope(v, window)
     denom = sma([abs(x) for x in v], window)
@@ -194,19 +202,23 @@ def normalized_slope(values: Sequence[Number], window: int, eps: float = 1e-12) 
     return out
 
 
-def true_range(high: Sequence[Number], low: Sequence[Number], close: Sequence[Number]) -> List[Optional[float]]:
+def true_range(
+    high: Sequence[Number], low: Sequence[Number], close: Sequence[Number]
+) -> List[Optional[float]]:
     _require_same_length(high, low, close)
     h = _as_float_list(high)
-    l = _as_float_list(low)
+    lo = _as_float_list(low)
     c = _as_float_list(close)
     n = len(c)
     out = _none_list(n)
     for i in range(1, n):
-        out[i] = max(h[i] - l[i], abs(h[i] - c[i - 1]), abs(l[i] - c[i - 1]))
+        out[i] = max(h[i] - lo[i], abs(h[i] - c[i - 1]), abs(lo[i] - c[i - 1]))
     return out
 
 
-def atr(high: Sequence[Number], low: Sequence[Number], close: Sequence[Number], window: int) -> List[Optional[float]]:
+def atr(
+    high: Sequence[Number], low: Sequence[Number], close: Sequence[Number], window: int
+) -> List[Optional[float]]:
     if window <= 0:
         raise ValueError("window must be positive")
     tr = true_range(high, low, close)
@@ -222,7 +234,9 @@ def atr(high: Sequence[Number], low: Sequence[Number], close: Sequence[Number], 
     return out
 
 
-def atr_percent(high: Sequence[Number], low: Sequence[Number], close: Sequence[Number], window: int) -> List[Optional[float]]:
+def atr_percent(
+    high: Sequence[Number], low: Sequence[Number], close: Sequence[Number], window: int
+) -> List[Optional[float]]:
     a = atr(high, low, close, window)
     c = _as_float_list(close)
     out = _none_list(len(c))
@@ -233,7 +247,9 @@ def atr_percent(high: Sequence[Number], low: Sequence[Number], close: Sequence[N
     return out
 
 
-def bollinger_bands(close: Sequence[Number], window: int = 20, k: float = 2.0) -> Dict[str, List[Optional[float]]]:
+def bollinger_bands(
+    close: Sequence[Number], window: int = 20, k: float = 2.0
+) -> Dict[str, List[Optional[float]]]:
     c = _as_float_list(close)
     mid = sma(c, window)
     std = _none_list(len(c))
@@ -257,7 +273,9 @@ def bollinger_bands(close: Sequence[Number], window: int = 20, k: float = 2.0) -
     return {"mid": mid, "upper": upper, "lower": lower, "width_pct": width_pct}
 
 
-def up_down_volume_ratio(close: Sequence[Number], volume: Sequence[Number], window: int = 20) -> List[Optional[float]]:
+def up_down_volume_ratio(
+    close: Sequence[Number], volume: Sequence[Number], window: int = 20
+) -> List[Optional[float]]:
     if window <= 0:
         raise ValueError("window must be positive")
     _require_same_length(close, volume)
@@ -281,20 +299,24 @@ def up_down_volume_ratio(close: Sequence[Number], volume: Sequence[Number], wind
     return out
 
 
-def close_location_value(high: Sequence[Number], low: Sequence[Number], close: Sequence[Number]) -> List[Optional[float]]:
+def close_location_value(
+    high: Sequence[Number], low: Sequence[Number], close: Sequence[Number]
+) -> List[Optional[float]]:
     _require_same_length(high, low, close)
     h = _as_float_list(high)
-    l = _as_float_list(low)
+    lo = _as_float_list(low)
     c = _as_float_list(close)
     n = len(c)
     out = _none_list(n)
     for i in range(n):
-        rng = h[i] - l[i]
-        out[i] = None if rng == 0 else (((c[i] - l[i]) - (h[i] - c[i])) / rng)
+        rng = h[i] - lo[i]
+        out[i] = None if rng == 0 else (((c[i] - lo[i]) - (h[i] - c[i])) / rng)
     return out
 
 
-def rs_ratio(asset_close: Sequence[Number], benchmark_close: Sequence[Number]) -> List[Optional[float]]:
+def rs_ratio(
+    asset_close: Sequence[Number], benchmark_close: Sequence[Number]
+) -> List[Optional[float]]:
     _require_same_length(asset_close, benchmark_close)
     a = _as_float_list(asset_close)
     b = _as_float_list(benchmark_close)
@@ -304,7 +326,9 @@ def rs_ratio(asset_close: Sequence[Number], benchmark_close: Sequence[Number]) -
     return out
 
 
-def rolling_correlation(x: Sequence[Optional[Number]], y: Sequence[Optional[Number]], window: int) -> List[Optional[float]]:
+def rolling_correlation(
+    x: Sequence[Optional[Number]], y: Sequence[Optional[Number]], window: int
+) -> List[Optional[float]]:
     if window <= 1:
         raise ValueError("window must be >= 2")
     _require_same_length(x, y)
@@ -331,7 +355,9 @@ def rolling_correlation(x: Sequence[Optional[Number]], y: Sequence[Optional[Numb
     return out
 
 
-def cross_sectional_dispersion(returns_by_symbol: Dict[str, Sequence[Optional[Number]]], index: int) -> Optional[float]:
+def cross_sectional_dispersion(
+    returns_by_symbol: Dict[str, Sequence[Optional[Number]]], index: int
+) -> Optional[float]:
     vals: List[float] = []
     for series in returns_by_symbol.values():
         if index >= len(series):
@@ -357,6 +383,7 @@ class OHLCV:
 
 class FeatureCache:
     """Compute-once cache (optional). Here kept minimal for future expansion."""
+
     def __init__(self) -> None:
         self._cache: Dict[str, Dict[str, Any]] = {}
 

--- a/market_health/forecast_score_provider.py
+++ b/market_health/forecast_score_provider.py
@@ -58,7 +58,9 @@ def compute_forecast_universe(
     _ = policy  # reserved for future use
 
     # Precompute returns for dispersion/correlation
-    returns_by_symbol: Dict[str, list[Optional[float]]] = {s.upper(): pct_change(ohlcv.close) for s, ohlcv in universe.items()}
+    returns_by_symbol: Dict[str, list[Optional[float]]] = {
+        s.upper(): pct_change(ohlcv.close) for s, ohlcv in universe.items()
+    }
     spy_returns = pct_change(spy.close)
 
     # Optional VIX features
@@ -81,7 +83,16 @@ def compute_forecast_universe(
         idx = n - 1
 
         if n == 0:
-            results[sym_u] = {h: {"forecast_score": 0.0, "points": 0, "max_points": 0, "categories": {}, "diagnostics": {"note": "empty_series"}} for h in horizons}
+            results[sym_u] = {
+                h: {
+                    "forecast_score": 0.0,
+                    "points": 0,
+                    "max_points": 0,
+                    "categories": {},
+                    "diagnostics": {"note": "empty_series"},
+                }
+                for h in horizons
+            }
             continue
 
         # Shared features at "now"
@@ -104,7 +115,9 @@ def compute_forecast_universe(
 
         dispersion_now = cross_sectional_dispersion(returns_by_symbol, idx)
 
-        ema20 = ema(close, 20)  # SMA is fine as proxy for the orchestrator; check modules don't care
+        ema20 = ema(
+            close, 20
+        )  # SMA is fine as proxy for the orchestrator; check modules don't care
         sma50 = sma(close, 50)
         ema20_now = ema20[idx] if idx < len(ema20) else None
         sma50_now = sma50[idx] if idx < len(sma50) else None
@@ -125,7 +138,9 @@ def compute_forecast_universe(
         if ohlcv.high is not None and ohlcv.low is not None:
             atrp = atr_percent(ohlcv.high, ohlcv.low, close, 14)
             atrp14_now = atrp[idx] if idx < len(atrp) else None
-            atrp_slope_10 = normalized_slope([x if x is not None else 0.0 for x in atrp], 10)
+            atrp_slope_10 = normalized_slope(
+                [x if x is not None else 0.0 for x in atrp], 10
+            )
             atrp_slope_10_now = atrp_slope_10[idx] if idx < len(atrp_slope_10) else None
             clv = close_location_value(ohlcv.high, ohlcv.low, close)
             clv_now = clv[idx] if idx < len(clv) else None
@@ -139,7 +154,11 @@ def compute_forecast_universe(
             vol_rank = rolling_percentile_rank([float(v) for v in ohlcv.volume], 20)
             vol_rank_now = vol_rank[idx] if idx < len(vol_rank) else None
 
-        last_ret = returns_by_symbol.get(sym_u, [None])[idx] if sym_u in returns_by_symbol and idx < len(returns_by_symbol[sym_u]) else None
+        last_ret = (
+            returns_by_symbol.get(sym_u, [None])[idx]
+            if sym_u in returns_by_symbol and idx < len(returns_by_symbol[sym_u])
+            else None
+        )
 
         results[sym_u] = {}
 
@@ -171,7 +190,9 @@ def compute_forecast_universe(
                 vol_rank_20=vol_rank_now,
             )
 
-            support_cushion_proxy = b_checks[3].metrics.get("cushion_proxy") if len(b_checks) >= 4 else None
+            support_cushion_proxy = (
+                b_checks[3].metrics.get("cushion_proxy") if len(b_checks) >= 4 else None
+            )
 
             c_checks = compute_c_checks(
                 ext_z_20=ext_z_now,

--- a/market_health/forecast_types.py
+++ b/market_health/forecast_types.py
@@ -19,6 +19,7 @@ class ForecastCheck:
     score: 0/1/2
     metrics: debug payload to explain how the score was produced
     """
+
     label: str
     meaning: str
     score: int
@@ -47,7 +48,12 @@ def category_dict(checks: List[ForecastCheck]) -> Dict[str, Any]:
     pts, mx = sum_points(checks)
     return {
         "checks": [
-            {"label": c.label, "meaning": c.meaning, "score": int(c.score), "metrics": c.metrics}
+            {
+                "label": c.label,
+                "meaning": c.meaning,
+                "score": int(c.score),
+                "metrics": c.metrics,
+            }
             for c in checks
         ],
         "points": pts,


### PR DESCRIPTION
Implements #107.\n\n- Adds forecast_features/types and A–E forecast check modules (6 checks each)\n- Refactors forecast_score_provider into a thin orchestrator that delegates scoring to the dimension modules\n- No IO / deterministic\n