### PR TITLE
Issue #110: Multi-horizon robust edge + disagreement veto

### DIFF
--- a/market_health/forecast_policy.py
+++ b/market_health/forecast_policy.py
@@ -38,7 +38,9 @@ def _get_payload(scores: Mapping[str, Any], symbol: str) -> Optional[Mapping[str
     return v if isinstance(v, dict) else None
 
 
-def _get_forecast_score(scores: Mapping[str, Any], symbol: str, H: int) -> Optional[float]:
+def _get_forecast_score(
+    scores: Mapping[str, Any], symbol: str, H: int
+) -> Optional[float]:
     by_h = _get_payload(scores, symbol)
     if by_h is None:
         return None

--- a/tests/test_forecast_policy.py
+++ b/tests/test_forecast_policy.py
@@ -8,7 +8,12 @@ class TestForecastPolicy(unittest.TestCase):
             "AAA": {1: {"forecast_score": 0.50}, 5: {"forecast_score": 0.55}},
             "BBB": {1: {"forecast_score": 0.60}, 5: {"forecast_score": 0.56}},
         }
-        mh = compute_multi_horizon_edge(from_symbol="AAA", to_symbol="BBB", scores=scores, horizons_trading_days=(1, 5))
+        mh = compute_multi_horizon_edge(
+            from_symbol="AAA",
+            to_symbol="BBB",
+            scores=scores,
+            horizons_trading_days=(1, 5),
+        )
         self.assertAlmostEqual(mh.edges_by_h[1], 0.10, places=6)
         self.assertAlmostEqual(mh.edges_by_h[5], 0.01, places=6)
         self.assertAlmostEqual(mh.robust_edge, 0.01, places=6)
@@ -34,7 +39,12 @@ class TestForecastPolicy(unittest.TestCase):
             "AAA": {1: {"forecast_score": 0.50}},
             "BBB": {1: {"forecast_score": 0.60}, 5: {"forecast_score": 0.61}},
         }
-        mh = compute_multi_horizon_edge(from_symbol="AAA", to_symbol="BBB", scores=scores, horizons_trading_days=(1, 5))
+        mh = compute_multi_horizon_edge(
+            from_symbol="AAA",
+            to_symbol="BBB",
+            scores=scores,
+            horizons_trading_days=(1, 5),
+        )
         self.assertTrue(mh.vetoed)
         self.assertIn("missing_horizons:5", mh.veto_reason)
 


### PR DESCRIPTION
Implements #110.\n\n- Adds market_health/forecast_policy.py (pure policy primitives)\n- robust_edge = min(edge(H)) across horizons\n- disagreement veto if any edge(H) < threshold\n- Adds stdlib unittest coverage