### PR TITLE
Issue #112: Cooldown / anti-ping-pong enforcement

### DIFF
--- a/market_health/cooldown_policy.py
+++ b/market_health/cooldown_policy.py
@@ -17,6 +17,7 @@ from typing import Iterable, Optional, Sequence, Tuple
 @dataclass(frozen=True)
 class SwapEvent:
     """A historical swap action."""
+
     ts: datetime
     from_symbol: str
     to_symbol: str

--- a/tests/test_cooldown_policy.py
+++ b/tests/test_cooldown_policy.py
@@ -22,7 +22,9 @@ class TestCooldownPolicy(unittest.TestCase):
 
     def test_no_veto_after_window(self):
         now = datetime(2026, 2, 26, 12, 0, 0)
-        hist = [SwapEvent(ts=now - timedelta(days=10), from_symbol="XLK", to_symbol="XLF")]
+        hist = [
+            SwapEvent(ts=now - timedelta(days=10), from_symbol="XLK", to_symbol="XLF")
+        ]
         res = check_cooldown(
             proposed_from="XLK",
             proposed_to="XLF",
@@ -34,8 +36,15 @@ class TestCooldownPolicy(unittest.TestCase):
 
     def test_disable_when_zero(self):
         now = datetime(2026, 2, 26, 12, 0, 0)
-        hist = [SwapEvent(ts=now - timedelta(days=1), from_symbol="XLK", to_symbol="XLF")]
-        res = check_cooldown(proposed_from="XLK", proposed_to="XLF", history=hist, cooldown_trading_days=0)
+        hist = [
+            SwapEvent(ts=now - timedelta(days=1), from_symbol="XLK", to_symbol="XLF")
+        ]
+        res = check_cooldown(
+            proposed_from="XLK",
+            proposed_to="XLF",
+            history=hist,
+            cooldown_trading_days=0,
+        )
         self.assertFalse(res.vetoed)
 
 


### PR DESCRIPTION
Implements #112.\n\n- Adds market_health/cooldown_policy.py (pure veto logic)\n- Vetoes repeated swap pairs (either direction) within cooldown window\n- Adds stdlib unittest coverage