### PR TITLE
Issue #116: Forecast checks unit tests (contract + fail-soft + boundary)

### DIFF
--- a/tests/test_forecast_checks_v1.py
+++ b/tests/test_forecast_checks_v1.py
@@ -1,15 +1,12 @@
 import unittest
-from typing import Dict, Any
+from typing import Any, Dict
 
 from market_health.forecast_features import OHLCV
 from market_health.forecast_score_provider import compute_forecast_universe
 
 
 def _ohlcv_trend(n: int = 80, direction: int = 1) -> OHLCV:
-    """
-    direction=+1 => gentle uptrend
-    direction=-1 => gentle downtrend
-    """
+    """direction=+1 => gentle uptrend, direction=-1 => gentle downtrend."""
     base = 100.0
     close = [base + direction * (i * 0.25) for i in range(n)]
     high = [c + 1.0 for c in close]
@@ -38,10 +35,12 @@ def _assert_payload_contract(tc: unittest.TestCase, payload: Dict[str, Any]) -> 
     cats = payload.get("categories")
     tc.assertIsInstance(cats, dict)
 
+    # A–E × 6 checks each (30 total)
     for k in ("A", "B", "C", "D", "E"):
         tc.assertIn(k, cats)
         cat = cats[k]
         tc.assertIsInstance(cat, dict)
+
         checks = cat.get("checks")
         tc.assertIsInstance(checks, list)
         tc.assertEqual(
@@ -49,6 +48,7 @@ def _assert_payload_contract(tc: unittest.TestCase, payload: Dict[str, Any]) -> 
             6,
             msg=f"Category {k} must have exactly 6 checks (got {len(checks)})",
         )
+
         for chk in checks:
             tc.assertIsInstance(chk, dict)
             tc.assertIsInstance(chk.get("label"), str)
@@ -58,67 +58,80 @@ def _assert_payload_contract(tc: unittest.TestCase, payload: Dict[str, Any]) -> 
 
 
 class TestForecastChecksV1(unittest.TestCase):
-    def test_contract_shape_h1_h5(self):
+    def test_contract_shape_h1_h5(self) -> None:
         universe = {
             "SPY": _ohlcv_trend(),
             "XLK": _ohlcv_trend(),
             "XLF": _ohlcv_trend(),
         }
-        doc = compute_forecast_universe(universe, horizons_trading_days=(1, 5))
-        self.assertIsInstance(doc, dict)
-        self.assertEqual(doc.get("schema"), "forecast_scores.v1")
 
-        scores = doc.get("scores")
+        scores = compute_forecast_universe(
+            universe=universe,
+            spy=universe["SPY"],
+            horizons_trading_days=(1, 5),
+        )
         self.assertIsInstance(scores, dict)
         self.assertIn("SPY", scores)
 
         by_h = scores["SPY"]
         self.assertIsInstance(by_h, dict)
-        self.assertIn(1, by_h)  # may be int keys
+        self.assertIn(1, by_h)
         self.assertIn(5, by_h)
 
         _assert_payload_contract(self, by_h[1])
         _assert_payload_contract(self, by_h[5])
 
-    def test_missing_data_close_only_does_not_crash(self):
-        # close-only should be valid input and should yield a valid payload contract
+    def test_missing_data_close_only_does_not_crash(self) -> None:
         universe = {
             "SPY": _ohlcv_close_only(),
             "XLK": _ohlcv_close_only(),
             "XLF": _ohlcv_close_only(),
         }
-        doc = compute_forecast_universe(universe, horizons_trading_days=(1, 5))
-        self.assertEqual(doc.get("schema"), "forecast_scores.v1")
-        scores = doc["scores"]
+        scores = compute_forecast_universe(
+            universe=universe,
+            spy=universe["SPY"],
+            horizons_trading_days=(1, 5),
+        )
+        self.assertIn("SPY", scores)
         _assert_payload_contract(self, scores["SPY"][1])
         _assert_payload_contract(self, scores["SPY"][5])
 
-    def test_too_short_series_is_fail_soft(self):
-        # Short series should not raise; it should still return a contract-valid payload
-        short = _ohlcv_trend(n=10, direction=1)
-        doc = compute_forecast_universe(
-            {"SPY": short, "XLK": short, "XLF": short}, horizons_trading_days=(1, 5)
+    def test_too_short_series_is_fail_soft(self) -> None:
+        short = OHLCV(close=[100.0, 101.0, 102.0], high=None, low=None, volume=None)
+        universe = {"SPY": short, "XLK": short, "XLF": short}
+        scores = compute_forecast_universe(
+            universe=universe,
+            spy=universe["SPY"],
+            horizons_trading_days=(1, 5),
         )
-        self.assertEqual(doc.get("schema"), "forecast_scores.v1")
-        scores = doc["scores"]
+        self.assertIn("SPY", scores)
         _assert_payload_contract(self, scores["SPY"][1])
+        _assert_payload_contract(self, scores["SPY"][5])
 
-    def test_boundary_uptrend_vs_downtrend_changes_score(self):
-        up = {"SPY": _ohlcv_trend(direction=1), "XLK": _ohlcv_trend(direction=1)}
-        dn = {"SPY": _ohlcv_trend(direction=-1), "XLK": _ohlcv_trend(direction=-1)}
+    def test_boundary_uptrend_vs_downtrend_changes_score(self) -> None:
+        up = {
+            "SPY": _ohlcv_trend(direction=1),
+            "XLK": _ohlcv_trend(direction=1),
+            "XLF": _ohlcv_trend(direction=1),
+        }
+        dn = {
+            "SPY": _ohlcv_trend(direction=-1),
+            "XLK": _ohlcv_trend(direction=-1),
+            "XLF": _ohlcv_trend(direction=-1),
+        }
 
-        doc_up = compute_forecast_universe(up, horizons_trading_days=(5,))
-        doc_dn = compute_forecast_universe(dn, horizons_trading_days=(5,))
-
-        s_up = float(doc_up["scores"]["SPY"][5]["forecast_score"])
-        s_dn = float(doc_dn["scores"]["SPY"][5]["forecast_score"])
-
-        # Not asserting which direction is "better"—just that the model responds to a strong regime change.
-        self.assertNotEqual(
-            s_up,
-            s_dn,
-            msg="Uptrend vs downtrend should change forecast_score in at least one horizon.",
+        scores_up = compute_forecast_universe(
+            universe=up, spy=up["SPY"], horizons_trading_days=(5,)
         )
+        scores_dn = compute_forecast_universe(
+            universe=dn, spy=dn["SPY"], horizons_trading_days=(5,)
+        )
+
+        s_up = float(scores_up["SPY"][5]["forecast_score"])
+        s_dn = float(scores_dn["SPY"][5]["forecast_score"])
+
+        # We don't pin exact values (too brittle), but direction should matter.
+        self.assertNotAlmostEqual(s_up, s_dn, places=6)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Implements #116.

- Adds unit tests validating forecast_scores.v1 shape (A–E × 6 checks)
- Ensures fail-soft behavior for close-only and short OHLCV
- Adds simple regime boundary sanity (uptrend vs downtrend changes score)
