### PR TITLE
Issue #117: Golden fixtures (forecast + recommendation)

### DIFF
--- a/market_health/golden_fixtures_v1.py
+++ b/market_health/golden_fixtures_v1.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, Mapping, Tuple
+
+from market_health.forecast_features import OHLCV
+from market_health.forecast_score_provider import compute_forecast_universe
+from market_health.recommendations_engine import Recommendation, recommend
+
+
+def _ohlcv_trend(n: int = 90, *, direction: int = 1, step: float = 0.25) -> OHLCV:
+    """Deterministic synthetic OHLCV. direction=+1 up, -1 down."""
+    base = 100.0
+    close = [base + direction * (i * step) for i in range(n)]
+    high = [c + 1.0 for c in close]
+    low = [c - 1.0 for c in close]
+    volume = [1_000_000.0 for _ in close]
+    return OHLCV(close=close, high=high, low=low, volume=volume)
+
+
+def _round_f(x: Any, nd: int = 6) -> Any:
+    if isinstance(x, float):
+        return round(x, nd)
+    return x
+
+
+def _sanitize_forecast(
+    scores: Mapping[str, Any], symbols: Iterable[str]
+) -> Dict[str, Any]:
+    """
+    Make fixture stable:
+    - keep forecast_score/points/max_points
+    - keep A–E checks with only label + score
+    - drop metrics/meaning to avoid churn
+    """
+    out: Dict[str, Any] = {}
+    for sym in [s.upper() for s in symbols]:
+        by_h = scores.get(sym)
+        if not isinstance(by_h, dict):
+            continue
+
+        sym_out: Dict[str, Any] = {}
+        for hk, payload in by_h.items():
+            try:
+                h = int(hk)
+            except Exception:
+                continue
+            if not isinstance(payload, dict):
+                continue
+
+            cats = payload.get("categories")
+            cats = cats if isinstance(cats, dict) else {}
+
+            slim_cats: Dict[str, Any] = {}
+            for k in ("A", "B", "C", "D", "E"):
+                cat = cats.get(k)
+                if not isinstance(cat, dict):
+                    slim_cats[k] = {"checks": []}
+                    continue
+                checks = cat.get("checks")
+                checks = checks if isinstance(checks, list) else []
+                slim_cats[k] = {
+                    "checks": [
+                        {
+                            "label": str(chk.get("label", "")),
+                            "score": int(chk.get("score", 0) or 0),
+                        }
+                        for chk in checks
+                        if isinstance(chk, dict)
+                    ]
+                }
+
+            sym_out[str(h)] = {
+                "forecast_score": _round_f(float(payload.get("forecast_score", 0.0))),
+                "points": int(payload.get("points", 0) or 0),
+                "max_points": int(payload.get("max_points", 0) or 0),
+                "categories": slim_cats,
+            }
+
+        if sym_out:
+            out[sym] = sym_out
+    return out
+
+
+def _sanitize_rec(rec: Recommendation) -> Dict[str, Any]:
+    diag = rec.diagnostics or {}
+    edges_by_h = diag.get("edges_by_h")
+    if not isinstance(edges_by_h, dict):
+        edges_by_h = {}
+
+    return {
+        "action": rec.action,
+        "from_symbol": rec.from_symbol,
+        "to_symbol": rec.to_symbol,
+        "reason": rec.reason,
+        "constraints_applied": list(rec.constraints_applied),
+        "constraints_triggered": list(rec.constraints_triggered),
+        "diagnostics": {
+            "mode": diag.get("mode"),
+            "decision_metric": diag.get("decision_metric"),
+            "edge": _round_f(diag.get("edge")),
+            "robust_edge": _round_f(diag.get("robust_edge")),
+            "edges_by_h": {str(k): _round_f(v) for k, v in edges_by_h.items()},
+        },
+    }
+
+
+def build_universe() -> Tuple[Dict[str, OHLCV], list[str]]:
+    # 11 sector ETFs + SPY
+    syms = [
+        "SPY",
+        "XLB",
+        "XLC",
+        "XLE",
+        "XLF",
+        "XLI",
+        "XLK",
+        "XLP",
+        "XLRE",
+        "XLU",
+        "XLV",
+        "XLY",
+    ]
+
+    # Make one clear winner (XLE) and make two held symbols weaker (XLK, XLF)
+    universe: Dict[str, OHLCV] = {}
+    for s in syms:
+        if s == "SPY":
+            universe[s] = _ohlcv_trend(direction=1, step=0.20)
+        elif s == "XLE":
+            universe[s] = _ohlcv_trend(direction=1, step=0.40)
+        elif s in {"XLK", "XLF"}:
+            universe[s] = _ohlcv_trend(direction=-1, step=0.25)
+        else:
+            universe[s] = _ohlcv_trend(direction=-1, step=0.10)
+
+    return universe, syms
+
+
+def generate_golden_fixtures_v1() -> Dict[str, Any]:
+    universe, syms = build_universe()
+
+    # compute_forecast_universe returns: {SYM: {H: payload}}
+    scores = compute_forecast_universe(
+        universe=universe,
+        spy=universe["SPY"],
+        horizons_trading_days=(1, 5),
+    )
+
+    forecast_fixture = {
+        "schema": "golden.forecast_scores.v1",
+        "horizons_trading_days": [1, 5],
+        "symbols": syms,
+        "scores": _sanitize_forecast(scores, syms),
+    }
+
+    # Forecast-mode recommend() path (pass scores=[], it won’t be used in forecast mode)
+    positions = {
+        "schema": "positions.v1",
+        "positions": [
+            {"symbol": "XLK", "market_value": 1000.0},
+            {"symbol": "XLF", "market_value": 1000.0},
+        ],
+    }
+
+    rec = recommend(
+        positions=positions,
+        scores=[],
+        constraints={
+            "forecast_scores": scores,
+            "forecast_horizons": (1, 5),
+            "min_improvement_threshold": 0.12,
+            "disagreement_veto_edge": 0.0,
+            "cooldown_trading_days": 0,
+            "cooldown_history": [],
+            # Relax diversity so we actually exercise the SWAP path deterministically
+            "max_weight_per_symbol": 1.0,
+            "min_distinct_symbols": 1,
+            "hhi_cap": 1.0,
+            "max_swaps_per_day": 1,
+            "swaps_today": 0,
+        },
+    )
+
+    rec_fixture = {
+        "schema": "golden.recommendation.forecast.v1",
+        "positions": positions,
+        "recommendation": _sanitize_rec(rec),
+    }
+
+    return {"forecast": forecast_fixture, "recommendation": rec_fixture}

--- a/scripts/dev/update_golden_fixtures_v1.py
+++ b/scripts/dev/update_golden_fixtures_v1.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from market_health.golden_fixtures_v1 import generate_golden_fixtures_v1
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Write golden fixtures for Issue #117")
+    ap.add_argument("--out-dir", default="tests/fixtures")
+    args = ap.parse_args()
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    fx = generate_golden_fixtures_v1()
+
+    (out_dir / "golden.forecast_scores.v1.json").write_text(
+        json.dumps(fx["forecast"], indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    (out_dir / "golden.recommendation.forecast.v1.json").write_text(
+        json.dumps(fx["recommendation"], indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    print(f"OK: wrote fixtures into {out_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/golden.forecast_scores.v1.json
+++ b/tests/fixtures/golden.forecast_scores.v1.json
@@ -1,0 +1,3575 @@
+{
+  "horizons_trading_days": [
+    1,
+    5
+  ],
+  "schema": "golden.forecast_scores.v1",
+  "scores": {
+    "SPY": {
+      "1": {
+        "categories": {
+          "A": {
+            "checks": [
+              {
+                "label": "Catalyst Window",
+                "score": 1
+              },
+              {
+                "label": "Macro Calendar Pressure",
+                "score": 1
+              },
+              {
+                "label": "Earnings Cluster",
+                "score": 1
+              },
+              {
+                "label": "Policy / Regulation Risk",
+                "score": 1
+              },
+              {
+                "label": "Headline Shock Proxy",
+                "score": 1
+              },
+              {
+                "label": "Narrative Momentum",
+                "score": 1
+              }
+            ]
+          },
+          "B": {
+            "checks": [
+              {
+                "label": "Trend Persistence",
+                "score": 2
+              },
+              {
+                "label": "Follow-Through Setup",
+                "score": 1
+              },
+              {
+                "label": "RS Momentum vs SPY",
+                "score": 0
+              },
+              {
+                "label": "Support Cushion",
+                "score": 1
+              },
+              {
+                "label": "Participation Trend",
+                "score": 1
+              },
+              {
+                "label": "Acceleration vs Exhaustion",
+                "score": 2
+              }
+            ]
+          },
+          "C": {
+            "checks": [
+              {
+                "label": "Extension Risk",
+                "score": 1
+              },
+              {
+                "label": "Volume Climax Risk",
+                "score": 2
+              },
+              {
+                "label": "Breadth Thinning",
+                "score": 2
+              },
+              {
+                "label": "Flow Pressure",
+                "score": 1
+              },
+              {
+                "label": "Positioning Asymmetry",
+                "score": 2
+              },
+              {
+                "label": "Correlation Crowding",
+                "score": 0
+              }
+            ]
+          },
+          "D": {
+            "checks": [
+              {
+                "label": "Volatility Trend",
+                "score": 2
+              },
+              {
+                "label": "Tail / Gap Risk",
+                "score": 0
+              },
+              {
+                "label": "Market Coupling Trend",
+                "score": 1
+              },
+              {
+                "label": "Liquidity Stress",
+                "score": 2
+              },
+              {
+                "label": "Drawdown Vulnerability",
+                "score": 2
+              },
+              {
+                "label": "Risk/Reward Feasibility",
+                "score": 2
+              }
+            ]
+          },
+          "E": {
+            "checks": [
+              {
+                "label": "SPY Outlook",
+                "score": 2
+              },
+              {
+                "label": "VIX Outlook",
+                "score": 1
+              },
+              {
+                "label": "Leadership Persistence",
+                "score": 2
+              },
+              {
+                "label": "Breadth Regime",
+                "score": 0
+              },
+              {
+                "label": "Cross-Regime Pressure",
+                "score": 1
+              },
+              {
+                "label": "Driver Alignment",
+                "score": 1
+              }
+            ]
+          }
+        },
+        "forecast_score": 0.616667,
+        "max_points": 60,
+        "points": 37
+      },
+      "5": {
+        "categories": {
+          "A": {
+            "checks": [
+              {
+                "label": "Catalyst Window",
+                "score": 1
+              },
+              {
+                "label": "Macro Calendar Pressure",
+                "score": 1
+              },
+              {
+                "label": "Earnings Cluster",
+                "score": 1
+              },
+              {
+                "label": "Policy / Regulation Risk",
+                "score": 1
+              },
+              {
+                "label": "Headline Shock Proxy",
+                "score": 1
+              },
+              {
+                "label": "Narrative Momentum",
+                "score": 1
+              }
+            ]
+          },
+          "B": {
+            "checks": [
+              {
+                "label": "Trend Persistence",
+                "score": 2
+              },
+              {
+                "label": "Follow-Through Setup",
+                "score": 1
+              },
+              {
+                "label": "RS Momentum vs SPY",
+                "score": 0
+              },
+              {
+                "label": "Support Cushion",
+                "score": 1
+              },
+              {
+                "label": "Participation Trend",
+                "score": 1
+              },
+              {
+                "label": "Acceleration vs Exhaustion",
+                "score": 2
+              }
+            ]
+          },
+          "C": {
+            "checks": [
+              {
+                "label": "Extension Risk",
+                "score": 1
+              },
+              {
+                "label": "Volume Climax Risk",
+                "score": 2
+              },
+              {
+                "label": "Breadth Thinning",
+                "score": 2
+              },
+              {
+                "label": "Flow Pressure",
+                "score": 1
+              },
+              {
+                "label": "Positioning Asymmetry",
+                "score": 2
+              },
+              {
+                "label": "Correlation Crowding",
+                "score": 0
+              }
+            ]
+          },
+          "D": {
+            "checks": [
+              {
+                "label": "Volatility Trend",
+                "score": 2
+              },
+              {
+                "label": "Tail / Gap Risk",
+                "score": 0
+              },
+              {
+                "label": "Market Coupling Trend",
+                "score": 1
+              },
+              {
+                "label": "Liquidity Stress",
+                "score": 2
+              },
+              {
+                "label": "Drawdown Vulnerability",
+                "score": 2
+              },
+              {
+                "label": "Risk/Reward Feasibility",
+                "score": 2
+              }
+            ]
+          },
+          "E": {
+            "checks": [
+              {
+                "label": "SPY Outlook",
+                "score": 2
+              },
+              {
+                "label": "VIX Outlook",
+                "score": 1
+              },
+              {
+                "label": "Leadership Persistence",
+                "score": 2
+              },
+              {
+                "label": "Breadth Regime",
+                "score": 0
+              },
+              {
+                "label": "Cross-Regime Pressure",
+                "score": 1
+              },
+              {
+                "label": "Driver Alignment",
+                "score": 1
+              }
+            ]
+          }
+        },
+        "forecast_score": 0.616667,
+        "max_points": 60,
+        "points": 37
+      }
+    },
+    "XLB": {
+      "1": {
+        "categories": {
+          "A": {
+            "checks": [
+              {
+                "label": "Catalyst Window",
+                "score": 1
+              },
+              {
+                "label": "Macro Calendar Pressure",
+                "score": 1
+              },
+              {
+                "label": "Earnings Cluster",
+                "score": 1
+              },
+              {
+                "label": "Policy / Regulation Risk",
+                "score": 1
+              },
+              {
+                "label": "Headline Shock Proxy",
+                "score": 1
+              },
+              {
+                "label": "Narrative Momentum",
+                "score": 0
+              }
+            ]
+          },
+          "B": {
+            "checks": [
+              {
+                "label": "Trend Persistence",
+                "score": 0
+              },
+              {
+                "label": "Follow-Through Setup",
+                "score": 0
+              },
+              {
+                "label": "RS Momentum vs SPY",
+                "score": 0
+              },
+              {
+                "label": "Support Cushion",
+                "score": 0
+              },
+              {
+                "label": "Participation Trend",
+                "score": 0
+              },
+              {
+                "label": "Acceleration vs Exhaustion",
+                "score": 1
+              }
+            ]
+          },
+          "C": {
+            "checks": [
+              {
+                "label": "Extension Risk",
+                "score": 2
+              },
+              {
+                "label": "Volume Climax Risk",
+                "score": 2
+              },
+              {
+                "label": "Breadth Thinning",
+                "score": 2
+              },
+              {
+                "label": "Flow Pressure",
+                "score": 0
+              },
+              {
+                "label": "Positioning Asymmetry",
+                "score": 0
+              },
+              {
+                "label": "Correlation Crowding",
+                "score": 0
+              }
+            ]
+          },
+          "D": {
+            "checks": [
+              {
+                "label": "Volatility Trend",
+                "score": 1
+              },
+              {
+                "label": "Tail / Gap Risk",
+                "score": 0
+              },
+              {
+                "label": "Market Coupling Trend",
+                "score": 1
+              },
+              {
+                "label": "Liquidity Stress",
+                "score": 2
+              },
+              {
+                "label": "Drawdown Vulnerability",
+                "score": 0
+              },
+              {
+                "label": "Risk/Reward Feasibility",
+                "score": 2
+              }
+            ]
+          },
+          "E": {
+            "checks": [
+              {
+                "label": "SPY Outlook",
+                "score": 2
+              },
+              {
+                "label": "VIX Outlook",
+                "score": 1
+              },
+              {
+                "label": "Leadership Persistence",
+                "score": 2
+              },
+              {
+                "label": "Breadth Regime",
+                "score": 0
+              },
+              {
+                "label": "Cross-Regime Pressure",
+                "score": 1
+              },
+              {
+                "label": "Driver Alignment",
+                "score": 0
+              }
+            ]
+          }
+        },
+        "forecast_score": 0.4,
+        "max_points": 60,
+        "points": 24
+      },
+      "5": {
+        "categories": {
+          "A": {
+            "checks": [
+              {
+                "label": "Catalyst Window",
+                "score": 1
+              },
+              {
+                "label": "Macro Calendar Pressure",
+                "score": 1
+              },
+              {
+                "label": "Earnings Cluster",
+                "score": 1
+              },
+              {
+                "label": "Policy / Regulation Risk",
+                "score": 1
+              },
+              {
+                "label": "Headline Shock Proxy",
+                "score": 1
+              },
+              {
+                "label": "Narrative Momentum",
+                "score": 0
+              }
+            ]
+          },
+          "B": {
+            "checks": [
+              {
+                "label": "Trend Persistence",
+                "score": 0
+              },
+              {
+                "label": "Follow-Through Setup",
+                "score": 0
+              },
+              {
+                "label": "RS Momentum vs SPY",
+                "score": 0
+              },
+              {
+                "label": "Support Cushion",
+                "score": 0
+              },
+              {
+                "label": "Participation Trend",
+                "score": 0
+              },
+              {
+                "label": "Acceleration vs Exhaustion",
+                "score": 1
+              }
+            ]
+          },
+          "C": {
+            "checks": [
+              {
+                "label": "Extension Risk",
+                "score": 2
+              },
+              {
+                "label": "Volume Climax Risk",
+                "score": 2
+              },
+              {
+                "label": "Breadth Thinning",
+                "score": 2
+              },
+              {
+                "label": "Flow Pressure",
+                "score": 0
+              },
+              {
+                "label": "Positioning Asymmetry",
+                "score": 0
+              },
+              {
+                "label": "Correlation Crowding",
+                "score": 0
+              }
+            ]
+          },
+          "D": {
+            "checks": [
+              {
+                "label": "Volatility Trend",
+                "score": 1
+              },
+              {
+                "label": "Tail / Gap Risk",
+                "score": 0
+              },
+              {
+                "label": "Market Coupling Trend",
+                "score": 1
+              },
+              {
+                "label": "Liquidity Stress",
+                "score": 2
+              },
+              {
+                "label": "Drawdown Vulnerability",
+                "score": 0
+              },
+              {
+                "label": "Risk/Reward Feasibility",
+                "score": 2
+              }
+            ]
+          },
+          "E": {
+            "checks": [
+              {
+                "label": "SPY Outlook",
+                "score": 2
+              },
+              {
+                "label": "VIX Outlook",
+                "score": 1
+              },
+              {
+                "label": "Leadership Persistence",
+                "score": 2
+              },
+              {
+                "label": "Breadth Regime",
+                "score": 0
+              },
+              {
+                "label": "Cross-Regime Pressure",
+                "score": 1
+              },
+              {
+                "label": "Driver Alignment",
+                "score": 0
+              }
+            ]
+          }
+        },
+        "forecast_score": 0.4,
+        "max_points": 60,
+        "points": 24
+      }
+    },
+    "XLC": {
+      "1": {
+        "categories": {
+          "A": {
+            "checks": [
+              {
+                "label": "Catalyst Window",
+                "score": 1
+              },
+              {
+                "label": "Macro Calendar Pressure",
+                "score": 1
+              },
+              {
+                "label": "Earnings Cluster",
+                "score": 1
+              },
+              {
+                "label": "Policy / Regulation Risk",
+                "score": 1
+              },
+              {
+                "label": "Headline Shock Proxy",
+                "score": 1
+              },
+              {
+                "label": "Narrative Momentum",
+                "score": 0
+              }
+            ]
+          },
+          "B": {
+            "checks": [
+              {
+                "label": "Trend Persistence",
+                "score": 0
+              },
+              {
+                "label": "Follow-Through Setup",
+                "score": 0
+              },
+              {
+                "label": "RS Momentum vs SPY",
+                "score": 0
+              },
+              {
+                "label": "Support Cushion",
+                "score": 0
+              },
+              {
+                "label": "Participation Trend",
+                "score": 0
+              },
+              {
+                "label": "Acceleration vs Exhaustion",
+                "score": 1
+              }
+            ]
+          },
+          "C": {
+            "checks": [
+              {
+                "label": "Extension Risk",
+                "score": 2
+              },
+              {
+                "label": "Volume Climax Risk",
+                "score": 2
+              },
+              {
+                "label": "Breadth Thinning",
+                "score": 2
+              },
+              {
+                "label": "Flow Pressure",
+                "score": 0
+              },
+              {
+                "label": "Positioning Asymmetry",
+                "score": 0
+              },
+              {
+                "label": "Correlation Crowding",
+                "score": 0
+              }
+            ]
+          },
+          "D": {
+            "checks": [
+              {
+                "label": "Volatility Trend",
+                "score": 1
+              },
+              {
+                "label": "Tail / Gap Risk",
+                "score": 0
+              },
+              {
+                "label": "Market Coupling Trend",
+                "score": 1
+              },
+              {
+                "label": "Liquidity Stress",
+                "score": 2
+              },
+              {
+                "label": "Drawdown Vulnerability",
+                "score": 0
+              },
+              {
+                "label": "Risk/Reward Feasibility",
+                "score": 2
+              }
+            ]
+          },
+          "E": {
+            "checks": [
+              {
+                "label": "SPY Outlook",
+                "score": 2
+              },
+              {
+                "label": "VIX Outlook",
+                "score": 1
+              },
+              {
+                "label": "Leadership Persistence",
+                "score": 2
+              },
+              {
+                "label": "Breadth Regime",
+                "score": 0
+              },
+              {
+                "label": "Cross-Regime Pressure",
+                "score": 1
+              },
+              {
+                "label": "Driver Alignment",
+                "score": 0
+              }
+            ]
+          }
+        },
+        "forecast_score": 0.4,
+        "max_points": 60,
+        "points": 24
+      },
+      "5": {
+        "categories": {
+          "A": {
+            "checks": [
+              {
+                "label": "Catalyst Window",
+                "score": 1
+              },
+              {
+                "label": "Macro Calendar Pressure",
+                "score": 1
+              },
+              {
+                "label": "Earnings Cluster",
+                "score": 1
+              },
+              {
+                "label": "Policy / Regulation Risk",
+                "score": 1
+              },
+              {
+                "label": "Headline Shock Proxy",
+                "score": 1
+              },
+              {
+                "label": "Narrative Momentum",
+                "score": 0
+              }
+            ]
+          },
+          "B": {
+            "checks": [
+              {
+                "label": "Trend Persistence",
+                "score": 0
+              },
+              {
+                "label": "Follow-Through Setup",
+                "score": 0
+              },
+              {
+                "label": "RS Momentum vs SPY",
+                "score": 0
+              },
+              {
+                "label": "Support Cushion",
+                "score": 0
+              },
+              {
+                "label": "Participation Trend",
+                "score": 0
+              },
+              {
+                "label": "Acceleration vs Exhaustion",
+                "score": 1
+              }
+            ]
+          },
+          "C": {
+            "checks": [
+              {
+                "label": "Extension Risk",
+                "score": 2
+              },
+              {
+                "label": "Volume Climax Risk",
+                "score": 2
+              },
+              {
+                "label": "Breadth Thinning",
+                "score": 2
+              },
+              {
+                "label": "Flow Pressure",
+                "score": 0
+              },
+              {
+                "label": "Positioning Asymmetry",
+                "score": 0
+              },
+              {
+                "label": "Correlation Crowding",
+                "score": 0
+              }
+            ]
+          },
+          "D": {
+            "checks": [
+              {
+                "label": "Volatility Trend",
+                "score": 1
+              },
+              {
+                "label": "Tail / Gap Risk",
+                "score": 0
+              },
+              {
+                "label": "Market Coupling Trend",
+                "score": 1
+              },
+              {
+                "label": "Liquidity Stress",
+                "score": 2
+              },
+              {
+                "label": "Drawdown Vulnerability",
+                "score": 0
+              },
+              {
+                "label": "Risk/Reward Feasibility",
+                "score": 2
+              }
+            ]
+          },
+          "E": {
+            "checks": [
+              {
+                "label": "SPY Outlook",
+                "score": 2
+              },
+              {
+                "label": "VIX Outlook",
+                "score": 1
+              },
+              {
+                "label": "Leadership Persistence",
+                "score": 2
+              },
+              {
+                "label": "Breadth Regime",
+                "score": 0
+              },
+              {
+                "label": "Cross-Regime Pressure",
+                "score": 1
+              },
+              {
+                "label": "Driver Alignment",
+                "score": 0
+              }
+            ]
+          }
+        },
+        "forecast_score": 0.4,
+        "max_points": 60,
+        "points": 24
+      }
+    },
+    "XLE": {
+      "1": {
+        "categories": {
+          "A": {
+            "checks": [
+              {
+                "label": "Catalyst Window",
+                "score": 1
+              },
+              {
+                "label": "Macro Calendar Pressure",
+                "score": 1
+              },
+              {
+                "label": "Earnings Cluster",
+                "score": 1
+              },
+              {
+                "label": "Policy / Regulation Risk",
+                "score": 1
+              },
+              {
+                "label": "Headline Shock Proxy",
+                "score": 1
+              },
+              {
+                "label": "Narrative Momentum",
+                "score": 2
+              }
+            ]
+          },
+          "B": {
+            "checks": [
+              {
+                "label": "Trend Persistence",
+                "score": 2
+              },
+              {
+                "label": "Follow-Through Setup",
+                "score": 1
+              },
+              {
+                "label": "RS Momentum vs SPY",
+                "score": 2
+              },
+              {
+                "label": "Support Cushion",
+                "score": 2
+              },
+              {
+                "label": "Participation Trend",
+                "score": 1
+              },
+              {
+                "label": "Acceleration vs Exhaustion",
+                "score": 2
+              }
+            ]
+          },
+          "C": {
+            "checks": [
+              {
+                "label": "Extension Risk",
+                "score": 1
+              },
+              {
+                "label": "Volume Climax Risk",
+                "score": 2
+              },
+              {
+                "label": "Breadth Thinning",
+                "score": 2
+              },
+              {
+                "label": "Flow Pressure",
+                "score": 1
+              },
+              {
+                "label": "Positioning Asymmetry",
+                "score": 2
+              },
+              {
+                "label": "Correlation Crowding",
+                "score": 0
+              }
+            ]
+          },
+          "D": {
+            "checks": [
+              {
+                "label": "Volatility Trend",
+                "score": 2
+              },
+              {
+                "label": "Tail / Gap Risk",
+                "score": 0
+              },
+              {
+                "label": "Market Coupling Trend",
+                "score": 1
+              },
+              {
+                "label": "Liquidity Stress",
+                "score": 2
+              },
+              {
+                "label": "Drawdown Vulnerability",
+                "score": 2
+              },
+              {
+                "label": "Risk/Reward Feasibility",
+                "score": 2
+              }
+            ]
+          },
+          "E": {
+            "checks": [
+              {
+                "label": "SPY Outlook",
+                "score": 2
+              },
+              {
+                "label": "VIX Outlook",
+                "score": 1
+              },
+              {
+                "label": "Leadership Persistence",
+                "score": 2
+              },
+              {
+                "label": "Breadth Regime",
+                "score": 0
+              },
+              {
+                "label": "Cross-Regime Pressure",
+                "score": 1
+              },
+              {
+                "label": "Driver Alignment",
+                "score": 2
+              }
+            ]
+          }
+        },
+        "forecast_score": 0.7,
+        "max_points": 60,
+        "points": 42
+      },
+      "5": {
+        "categories": {
+          "A": {
+            "checks": [
+              {
+                "label": "Catalyst Window",
+                "score": 1
+              },
+              {
+                "label": "Macro Calendar Pressure",
+                "score": 1
+              },
+              {
+                "label": "Earnings Cluster",
+                "score": 1
+              },
+              {
+                "label": "Policy / Regulation Risk",
+                "score": 1
+              },
+              {
+                "label": "Headline Shock Proxy",
+                "score": 1
+              },
+              {
+                "label": "Narrative Momentum",
+                "score": 2
+              }
+            ]
+          },
+          "B": {
+            "checks": [
+              {
+                "label": "Trend Persistence",
+                "score": 2
+              },
+              {
+                "label": "Follow-Through Setup",
+                "score": 1
+              },
+              {
+                "label": "RS Momentum vs SPY",
+                "score": 2
+              },
+              {
+                "label": "Support Cushion",
+                "score": 2
+              },
+              {
+                "label": "Participation Trend",
+                "score": 1
+              },
+              {
+                "label": "Acceleration vs Exhaustion",
+                "score": 2
+              }
+            ]
+          },
+          "C": {
+            "checks": [
+              {
+                "label": "Extension Risk",
+                "score": 1
+              },
+              {
+                "label": "Volume Climax Risk",
+                "score": 2
+              },
+              {
+                "label": "Breadth Thinning",
+                "score": 2
+              },
+              {
+                "label": "Flow Pressure",
+                "score": 1
+              },
+              {
+                "label": "Positioning Asymmetry",
+                "score": 2
+              },
+              {
+                "label": "Correlation Crowding",
+                "score": 0
+              }
+            ]
+          },
+          "D": {
+            "checks": [
+              {
+                "label": "Volatility Trend",
+                "score": 2
+              },
+              {
+                "label": "Tail / Gap Risk",
+                "score": 0
+              },
+              {
+                "label": "Market Coupling Trend",
+                "score": 1
+              },
+              {
+                "label": "Liquidity Stress",
+                "score": 2
+              },
+              {
+                "label": "Drawdown Vulnerability",
+                "score": 2
+              },
+              {
+                "label": "Risk/Reward Feasibility",
+                "score": 2
+              }
+            ]
+          },
+          "E": {
+            "checks": [
+              {
+                "label": "SPY Outlook",
+                "score": 2
+              },
+              {
+                "label": "VIX Outlook",
+                "score": 1
+              },
+              {
+                "label": "Leadership Persistence",
+                "score": 2
+              },
+              {
+                "label": "Breadth Regime",
+                "score": 0
+              },
+              {
+                "label": "Cross-Regime Pressure",
+                "score": 1
+              },
+              {
+                "label": "Driver Alignment",
+                "score": 2
+              }
+            ]
+          }
+        },
+        "forecast_score": 0.7,
+        "max_points": 60,
+        "points": 42
+      }
+    },
+    "XLF": {
+      "1": {
+        "categories": {
+          "A": {
+            "checks": [
+              {
+                "label": "Catalyst Window",
+                "score": 1
+              },
+              {
+                "label": "Macro Calendar Pressure",
+                "score": 1
+              },
+              {
+                "label": "Earnings Cluster",
+                "score": 1
+              },
+              {
+                "label": "Policy / Regulation Risk",
+                "score": 1
+              },
+              {
+                "label": "Headline Shock Proxy",
+                "score": 1
+              },
+              {
+                "label": "Narrative Momentum",
+                "score": 0
+              }
+            ]
+          },
+          "B": {
+            "checks": [
+              {
+                "label": "Trend Persistence",
+                "score": 0
+              },
+              {
+                "label": "Follow-Through Setup",
+                "score": 0
+              },
+              {
+                "label": "RS Momentum vs SPY",
+                "score": 0
+              },
+              {
+                "label": "Support Cushion",
+                "score": 0
+              },
+              {
+                "label": "Participation Trend",
+                "score": 0
+              },
+              {
+                "label": "Acceleration vs Exhaustion",
+                "score": 1
+              }
+            ]
+          },
+          "C": {
+            "checks": [
+              {
+                "label": "Extension Risk",
+                "score": 2
+              },
+              {
+                "label": "Volume Climax Risk",
+                "score": 2
+              },
+              {
+                "label": "Breadth Thinning",
+                "score": 2
+              },
+              {
+                "label": "Flow Pressure",
+                "score": 0
+              },
+              {
+                "label": "Positioning Asymmetry",
+                "score": 0
+              },
+              {
+                "label": "Correlation Crowding",
+                "score": 0
+              }
+            ]
+          },
+          "D": {
+            "checks": [
+              {
+                "label": "Volatility Trend",
+                "score": 0
+              },
+              {
+                "label": "Tail / Gap Risk",
+                "score": 0
+              },
+              {
+                "label": "Market Coupling Trend",
+                "score": 1
+              },
+              {
+                "label": "Liquidity Stress",
+                "score": 2
+              },
+              {
+                "label": "Drawdown Vulnerability",
+                "score": 0
+              },
+              {
+                "label": "Risk/Reward Feasibility",
+                "score": 1
+              }
+            ]
+          },
+          "E": {
+            "checks": [
+              {
+                "label": "SPY Outlook",
+                "score": 2
+              },
+              {
+                "label": "VIX Outlook",
+                "score": 1
+              },
+              {
+                "label": "Leadership Persistence",
+                "score": 1
+              },
+              {
+                "label": "Breadth Regime",
+                "score": 0
+              },
+              {
+                "label": "Cross-Regime Pressure",
+                "score": 1
+              },
+              {
+                "label": "Driver Alignment",
+                "score": 0
+              }
+            ]
+          }
+        },
+        "forecast_score": 0.35,
+        "max_points": 60,
+        "points": 21
+      },
+      "5": {
+        "categories": {
+          "A": {
+            "checks": [
+              {
+                "label": "Catalyst Window",
+                "score": 1
+              },
+              {
+                "label": "Macro Calendar Pressure",
+                "score": 1
+              },
+              {
+                "label": "Earnings Cluster",
+                "score": 1
+              },
+              {
+                "label": "Policy / Regulation Risk",
+                "score": 1
+              },
+              {
+                "label": "Headline Shock Proxy",
+                "score": 1
+              },
+              {
+                "label": "Narrative Momentum",
+                "score": 0
+              }
+            ]
+          },
+          "B": {
+            "checks": [
+              {
+                "label": "Trend Persistence",
+                "score": 0
+              },
+              {
+                "label": "Follow-Through Setup",
+                "score": 0
+              },
+              {
+                "label": "RS Momentum vs SPY",
+                "score": 0
+              },
+              {
+                "label": "Support Cushion",
+                "score": 0
+              },
+              {
+                "label": "Participation Trend",
+                "score": 0
+              },
+              {
+                "label": "Acceleration vs Exhaustion",
+                "score": 1
+              }
+            ]
+          },
+          "C": {
+            "checks": [
+              {
+                "label": "Extension Risk",
+                "score": 2
+              },
+              {
+                "label": "Volume Climax Risk",
+                "score": 2
+              },
+              {
+                "label": "Breadth Thinning",
+                "score": 2
+              },
+              {
+                "label": "Flow Pressure",
+                "score": 0
+              },
+              {
+                "label": "Positioning Asymmetry",
+                "score": 0
+              },
+              {
+                "label": "Correlation Crowding",
+                "score": 0
+              }
+            ]
+          },
+          "D": {
+            "checks": [
+              {
+                "label": "Volatility Trend",
+                "score": 0
+              },
+              {
+                "label": "Tail / Gap Risk",
+                "score": 0
+              },
+              {
+                "label": "Market Coupling Trend",
+                "score": 1
+              },
+              {
+                "label": "Liquidity Stress",
+                "score": 2
+              },
+              {
+                "label": "Drawdown Vulnerability",
+                "score": 0
+              },
+              {
+                "label": "Risk/Reward Feasibility",
+                "score": 1
+              }
+            ]
+          },
+          "E": {
+            "checks": [
+              {
+                "label": "SPY Outlook",
+                "score": 2
+              },
+              {
+                "label": "VIX Outlook",
+                "score": 1
+              },
+              {
+                "label": "Leadership Persistence",
+                "score": 1
+              },
+              {
+                "label": "Breadth Regime",
+                "score": 0
+              },
+              {
+                "label": "Cross-Regime Pressure",
+                "score": 1
+              },
+              {
+                "label": "Driver Alignment",
+                "score": 0
+              }
+            ]
+          }
+        },
+        "forecast_score": 0.35,
+        "max_points": 60,
+        "points": 21
+      }
+    },
+    "XLI": {
+      "1": {
+        "categories": {
+          "A": {
+            "checks": [
+              {
+                "label": "Catalyst Window",
+                "score": 1
+              },
+              {
+                "label": "Macro Calendar Pressure",
+                "score": 1
+              },
+              {
+                "label": "Earnings Cluster",
+                "score": 1
+              },
+              {
+                "label": "Policy / Regulation Risk",
+                "score": 1
+              },
+              {
+                "label": "Headline Shock Proxy",
+                "score": 1
+              },
+              {
+                "label": "Narrative Momentum",
+                "score": 0
+              }
+            ]
+          },
+          "B": {
+            "checks": [
+              {
+                "label": "Trend Persistence",
+                "score": 0
+              },
+              {
+                "label": "Follow-Through Setup",
+                "score": 0
+              },
+              {
+                "label": "RS Momentum vs SPY",
+                "score": 0
+              },
+              {
+                "label": "Support Cushion",
+                "score": 0
+              },
+              {
+                "label": "Participation Trend",
+                "score": 0
+              },
+              {
+                "label": "Acceleration vs Exhaustion",
+                "score": 1
+              }
+            ]
+          },
+          "C": {
+            "checks": [
+              {
+                "label": "Extension Risk",
+                "score": 2
+              },
+              {
+                "label": "Volume Climax Risk",
+                "score": 2
+              },
+              {
+                "label": "Breadth Thinning",
+                "score": 2
+              },
+              {
+                "label": "Flow Pressure",
+                "score": 0
+              },
+              {
+                "label": "Positioning Asymmetry",
+                "score": 0
+              },
+              {
+                "label": "Correlation Crowding",
+                "score": 0
+              }
+            ]
+          },
+          "D": {
+            "checks": [
+              {
+                "label": "Volatility Trend",
+                "score": 1
+              },
+              {
+                "label": "Tail / Gap Risk",
+                "score": 0
+              },
+              {
+                "label": "Market Coupling Trend",
+                "score": 1
+              },
+              {
+                "label": "Liquidity Stress",
+                "score": 2
+              },
+              {
+                "label": "Drawdown Vulnerability",
+                "score": 0
+              },
+              {
+                "label": "Risk/Reward Feasibility",
+                "score": 2
+              }
+            ]
+          },
+          "E": {
+            "checks": [
+              {
+                "label": "SPY Outlook",
+                "score": 2
+              },
+              {
+                "label": "VIX Outlook",
+                "score": 1
+              },
+              {
+                "label": "Leadership Persistence",
+                "score": 2
+              },
+              {
+                "label": "Breadth Regime",
+                "score": 0
+              },
+              {
+                "label": "Cross-Regime Pressure",
+                "score": 1
+              },
+              {
+                "label": "Driver Alignment",
+                "score": 0
+              }
+            ]
+          }
+        },
+        "forecast_score": 0.4,
+        "max_points": 60,
+        "points": 24
+      },
+      "5": {
+        "categories": {
+          "A": {
+            "checks": [
+              {
+                "label": "Catalyst Window",
+                "score": 1
+              },
+              {
+                "label": "Macro Calendar Pressure",
+                "score": 1
+              },
+              {
+                "label": "Earnings Cluster",
+                "score": 1
+              },
+              {
+                "label": "Policy / Regulation Risk",
+                "score": 1
+              },
+              {
+                "label": "Headline Shock Proxy",
+                "score": 1
+              },
+              {
+                "label": "Narrative Momentum",
+                "score": 0
+              }
+            ]
+          },
+          "B": {
+            "checks": [
+              {
+                "label": "Trend Persistence",
+                "score": 0
+              },
+              {
+                "label": "Follow-Through Setup",
+                "score": 0
+              },
+              {
+                "label": "RS Momentum vs SPY",
+                "score": 0
+              },
+              {
+                "label": "Support Cushion",
+                "score": 0
+              },
+              {
+                "label": "Participation Trend",
+                "score": 0
+              },
+              {
+                "label": "Acceleration vs Exhaustion",
+                "score": 1
+              }
+            ]
+          },
+          "C": {
+            "checks": [
+              {
+                "label": "Extension Risk",
+                "score": 2
+              },
+              {
+                "label": "Volume Climax Risk",
+                "score": 2
+              },
+              {
+                "label": "Breadth Thinning",
+                "score": 2
+              },
+              {
+                "label": "Flow Pressure",
+                "score": 0
+              },
+              {
+                "label": "Positioning Asymmetry",
+                "score": 0
+              },
+              {
+                "label": "Correlation Crowding",
+                "score": 0
+              }
+            ]
+          },
+          "D": {
+            "checks": [
+              {
+                "label": "Volatility Trend",
+                "score": 1
+              },
+              {
+                "label": "Tail / Gap Risk",
+                "score": 0
+              },
+              {
+                "label": "Market Coupling Trend",
+                "score": 1
+              },
+              {
+                "label": "Liquidity Stress",
+                "score": 2
+              },
+              {
+                "label": "Drawdown Vulnerability",
+                "score": 0
+              },
+              {
+                "label": "Risk/Reward Feasibility",
+                "score": 2
+              }
+            ]
+          },
+          "E": {
+            "checks": [
+              {
+                "label": "SPY Outlook",
+                "score": 2
+              },
+              {
+                "label": "VIX Outlook",
+                "score": 1
+              },
+              {
+                "label": "Leadership Persistence",
+                "score": 2
+              },
+              {
+                "label": "Breadth Regime",
+                "score": 0
+              },
+              {
+                "label": "Cross-Regime Pressure",
+                "score": 1
+              },
+              {
+                "label": "Driver Alignment",
+                "score": 0
+              }
+            ]
+          }
+        },
+        "forecast_score": 0.4,
+        "max_points": 60,
+        "points": 24
+      }
+    },
+    "XLK": {
+      "1": {
+        "categories": {
+          "A": {
+            "checks": [
+              {
+                "label": "Catalyst Window",
+                "score": 1
+              },
+              {
+                "label": "Macro Calendar Pressure",
+                "score": 1
+              },
+              {
+                "label": "Earnings Cluster",
+                "score": 1
+              },
+              {
+                "label": "Policy / Regulation Risk",
+                "score": 1
+              },
+              {
+                "label": "Headline Shock Proxy",
+                "score": 1
+              },
+              {
+                "label": "Narrative Momentum",
+                "score": 0
+              }
+            ]
+          },
+          "B": {
+            "checks": [
+              {
+                "label": "Trend Persistence",
+                "score": 0
+              },
+              {
+                "label": "Follow-Through Setup",
+                "score": 0
+              },
+              {
+                "label": "RS Momentum vs SPY",
+                "score": 0
+              },
+              {
+                "label": "Support Cushion",
+                "score": 0
+              },
+              {
+                "label": "Participation Trend",
+                "score": 0
+              },
+              {
+                "label": "Acceleration vs Exhaustion",
+                "score": 1
+              }
+            ]
+          },
+          "C": {
+            "checks": [
+              {
+                "label": "Extension Risk",
+                "score": 2
+              },
+              {
+                "label": "Volume Climax Risk",
+                "score": 2
+              },
+              {
+                "label": "Breadth Thinning",
+                "score": 2
+              },
+              {
+                "label": "Flow Pressure",
+                "score": 0
+              },
+              {
+                "label": "Positioning Asymmetry",
+                "score": 0
+              },
+              {
+                "label": "Correlation Crowding",
+                "score": 0
+              }
+            ]
+          },
+          "D": {
+            "checks": [
+              {
+                "label": "Volatility Trend",
+                "score": 0
+              },
+              {
+                "label": "Tail / Gap Risk",
+                "score": 0
+              },
+              {
+                "label": "Market Coupling Trend",
+                "score": 1
+              },
+              {
+                "label": "Liquidity Stress",
+                "score": 2
+              },
+              {
+                "label": "Drawdown Vulnerability",
+                "score": 0
+              },
+              {
+                "label": "Risk/Reward Feasibility",
+                "score": 1
+              }
+            ]
+          },
+          "E": {
+            "checks": [
+              {
+                "label": "SPY Outlook",
+                "score": 2
+              },
+              {
+                "label": "VIX Outlook",
+                "score": 1
+              },
+              {
+                "label": "Leadership Persistence",
+                "score": 1
+              },
+              {
+                "label": "Breadth Regime",
+                "score": 0
+              },
+              {
+                "label": "Cross-Regime Pressure",
+                "score": 1
+              },
+              {
+                "label": "Driver Alignment",
+                "score": 0
+              }
+            ]
+          }
+        },
+        "forecast_score": 0.35,
+        "max_points": 60,
+        "points": 21
+      },
+      "5": {
+        "categories": {
+          "A": {
+            "checks": [
+              {
+                "label": "Catalyst Window",
+                "score": 1
+              },
+              {
+                "label": "Macro Calendar Pressure",
+                "score": 1
+              },
+              {
+                "label": "Earnings Cluster",
+                "score": 1
+              },
+              {
+                "label": "Policy / Regulation Risk",
+                "score": 1
+              },
+              {
+                "label": "Headline Shock Proxy",
+                "score": 1
+              },
+              {
+                "label": "Narrative Momentum",
+                "score": 0
+              }
+            ]
+          },
+          "B": {
+            "checks": [
+              {
+                "label": "Trend Persistence",
+                "score": 0
+              },
+              {
+                "label": "Follow-Through Setup",
+                "score": 0
+              },
+              {
+                "label": "RS Momentum vs SPY",
+                "score": 0
+              },
+              {
+                "label": "Support Cushion",
+                "score": 0
+              },
+              {
+                "label": "Participation Trend",
+                "score": 0
+              },
+              {
+                "label": "Acceleration vs Exhaustion",
+                "score": 1
+              }
+            ]
+          },
+          "C": {
+            "checks": [
+              {
+                "label": "Extension Risk",
+                "score": 2
+              },
+              {
+                "label": "Volume Climax Risk",
+                "score": 2
+              },
+              {
+                "label": "Breadth Thinning",
+                "score": 2
+              },
+              {
+                "label": "Flow Pressure",
+                "score": 0
+              },
+              {
+                "label": "Positioning Asymmetry",
+                "score": 0
+              },
+              {
+                "label": "Correlation Crowding",
+                "score": 0
+              }
+            ]
+          },
+          "D": {
+            "checks": [
+              {
+                "label": "Volatility Trend",
+                "score": 0
+              },
+              {
+                "label": "Tail / Gap Risk",
+                "score": 0
+              },
+              {
+                "label": "Market Coupling Trend",
+                "score": 1
+              },
+              {
+                "label": "Liquidity Stress",
+                "score": 2
+              },
+              {
+                "label": "Drawdown Vulnerability",
+                "score": 0
+              },
+              {
+                "label": "Risk/Reward Feasibility",
+                "score": 1
+              }
+            ]
+          },
+          "E": {
+            "checks": [
+              {
+                "label": "SPY Outlook",
+                "score": 2
+              },
+              {
+                "label": "VIX Outlook",
+                "score": 1
+              },
+              {
+                "label": "Leadership Persistence",
+                "score": 1
+              },
+              {
+                "label": "Breadth Regime",
+                "score": 0
+              },
+              {
+                "label": "Cross-Regime Pressure",
+                "score": 1
+              },
+              {
+                "label": "Driver Alignment",
+                "score": 0
+              }
+            ]
+          }
+        },
+        "forecast_score": 0.35,
+        "max_points": 60,
+        "points": 21
+      }
+    },
+    "XLP": {
+      "1": {
+        "categories": {
+          "A": {
+            "checks": [
+              {
+                "label": "Catalyst Window",
+                "score": 1
+              },
+              {
+                "label": "Macro Calendar Pressure",
+                "score": 1
+              },
+              {
+                "label": "Earnings Cluster",
+                "score": 1
+              },
+              {
+                "label": "Policy / Regulation Risk",
+                "score": 1
+              },
+              {
+                "label": "Headline Shock Proxy",
+                "score": 1
+              },
+              {
+                "label": "Narrative Momentum",
+                "score": 0
+              }
+            ]
+          },
+          "B": {
+            "checks": [
+              {
+                "label": "Trend Persistence",
+                "score": 0
+              },
+              {
+                "label": "Follow-Through Setup",
+                "score": 0
+              },
+              {
+                "label": "RS Momentum vs SPY",
+                "score": 0
+              },
+              {
+                "label": "Support Cushion",
+                "score": 0
+              },
+              {
+                "label": "Participation Trend",
+                "score": 0
+              },
+              {
+                "label": "Acceleration vs Exhaustion",
+                "score": 1
+              }
+            ]
+          },
+          "C": {
+            "checks": [
+              {
+                "label": "Extension Risk",
+                "score": 2
+              },
+              {
+                "label": "Volume Climax Risk",
+                "score": 2
+              },
+              {
+                "label": "Breadth Thinning",
+                "score": 2
+              },
+              {
+                "label": "Flow Pressure",
+                "score": 0
+              },
+              {
+                "label": "Positioning Asymmetry",
+                "score": 0
+              },
+              {
+                "label": "Correlation Crowding",
+                "score": 0
+              }
+            ]
+          },
+          "D": {
+            "checks": [
+              {
+                "label": "Volatility Trend",
+                "score": 1
+              },
+              {
+                "label": "Tail / Gap Risk",
+                "score": 0
+              },
+              {
+                "label": "Market Coupling Trend",
+                "score": 1
+              },
+              {
+                "label": "Liquidity Stress",
+                "score": 2
+              },
+              {
+                "label": "Drawdown Vulnerability",
+                "score": 0
+              },
+              {
+                "label": "Risk/Reward Feasibility",
+                "score": 2
+              }
+            ]
+          },
+          "E": {
+            "checks": [
+              {
+                "label": "SPY Outlook",
+                "score": 2
+              },
+              {
+                "label": "VIX Outlook",
+                "score": 1
+              },
+              {
+                "label": "Leadership Persistence",
+                "score": 1
+              },
+              {
+                "label": "Breadth Regime",
+                "score": 0
+              },
+              {
+                "label": "Cross-Regime Pressure",
+                "score": 1
+              },
+              {
+                "label": "Driver Alignment",
+                "score": 0
+              }
+            ]
+          }
+        },
+        "forecast_score": 0.383333,
+        "max_points": 60,
+        "points": 23
+      },
+      "5": {
+        "categories": {
+          "A": {
+            "checks": [
+              {
+                "label": "Catalyst Window",
+                "score": 1
+              },
+              {
+                "label": "Macro Calendar Pressure",
+                "score": 1
+              },
+              {
+                "label": "Earnings Cluster",
+                "score": 1
+              },
+              {
+                "label": "Policy / Regulation Risk",
+                "score": 1
+              },
+              {
+                "label": "Headline Shock Proxy",
+                "score": 1
+              },
+              {
+                "label": "Narrative Momentum",
+                "score": 0
+              }
+            ]
+          },
+          "B": {
+            "checks": [
+              {
+                "label": "Trend Persistence",
+                "score": 0
+              },
+              {
+                "label": "Follow-Through Setup",
+                "score": 0
+              },
+              {
+                "label": "RS Momentum vs SPY",
+                "score": 0
+              },
+              {
+                "label": "Support Cushion",
+                "score": 0
+              },
+              {
+                "label": "Participation Trend",
+                "score": 0
+              },
+              {
+                "label": "Acceleration vs Exhaustion",
+                "score": 1
+              }
+            ]
+          },
+          "C": {
+            "checks": [
+              {
+                "label": "Extension Risk",
+                "score": 2
+              },
+              {
+                "label": "Volume Climax Risk",
+                "score": 2
+              },
+              {
+                "label": "Breadth Thinning",
+                "score": 2
+              },
+              {
+                "label": "Flow Pressure",
+                "score": 0
+              },
+              {
+                "label": "Positioning Asymmetry",
+                "score": 0
+              },
+              {
+                "label": "Correlation Crowding",
+                "score": 0
+              }
+            ]
+          },
+          "D": {
+            "checks": [
+              {
+                "label": "Volatility Trend",
+                "score": 1
+              },
+              {
+                "label": "Tail / Gap Risk",
+                "score": 0
+              },
+              {
+                "label": "Market Coupling Trend",
+                "score": 1
+              },
+              {
+                "label": "Liquidity Stress",
+                "score": 2
+              },
+              {
+                "label": "Drawdown Vulnerability",
+                "score": 0
+              },
+              {
+                "label": "Risk/Reward Feasibility",
+                "score": 2
+              }
+            ]
+          },
+          "E": {
+            "checks": [
+              {
+                "label": "SPY Outlook",
+                "score": 2
+              },
+              {
+                "label": "VIX Outlook",
+                "score": 1
+              },
+              {
+                "label": "Leadership Persistence",
+                "score": 1
+              },
+              {
+                "label": "Breadth Regime",
+                "score": 0
+              },
+              {
+                "label": "Cross-Regime Pressure",
+                "score": 1
+              },
+              {
+                "label": "Driver Alignment",
+                "score": 0
+              }
+            ]
+          }
+        },
+        "forecast_score": 0.383333,
+        "max_points": 60,
+        "points": 23
+      }
+    },
+    "XLRE": {
+      "1": {
+        "categories": {
+          "A": {
+            "checks": [
+              {
+                "label": "Catalyst Window",
+                "score": 1
+              },
+              {
+                "label": "Macro Calendar Pressure",
+                "score": 1
+              },
+              {
+                "label": "Earnings Cluster",
+                "score": 1
+              },
+              {
+                "label": "Policy / Regulation Risk",
+                "score": 1
+              },
+              {
+                "label": "Headline Shock Proxy",
+                "score": 1
+              },
+              {
+                "label": "Narrative Momentum",
+                "score": 0
+              }
+            ]
+          },
+          "B": {
+            "checks": [
+              {
+                "label": "Trend Persistence",
+                "score": 0
+              },
+              {
+                "label": "Follow-Through Setup",
+                "score": 0
+              },
+              {
+                "label": "RS Momentum vs SPY",
+                "score": 0
+              },
+              {
+                "label": "Support Cushion",
+                "score": 0
+              },
+              {
+                "label": "Participation Trend",
+                "score": 0
+              },
+              {
+                "label": "Acceleration vs Exhaustion",
+                "score": 1
+              }
+            ]
+          },
+          "C": {
+            "checks": [
+              {
+                "label": "Extension Risk",
+                "score": 2
+              },
+              {
+                "label": "Volume Climax Risk",
+                "score": 2
+              },
+              {
+                "label": "Breadth Thinning",
+                "score": 2
+              },
+              {
+                "label": "Flow Pressure",
+                "score": 0
+              },
+              {
+                "label": "Positioning Asymmetry",
+                "score": 0
+              },
+              {
+                "label": "Correlation Crowding",
+                "score": 0
+              }
+            ]
+          },
+          "D": {
+            "checks": [
+              {
+                "label": "Volatility Trend",
+                "score": 1
+              },
+              {
+                "label": "Tail / Gap Risk",
+                "score": 0
+              },
+              {
+                "label": "Market Coupling Trend",
+                "score": 1
+              },
+              {
+                "label": "Liquidity Stress",
+                "score": 2
+              },
+              {
+                "label": "Drawdown Vulnerability",
+                "score": 0
+              },
+              {
+                "label": "Risk/Reward Feasibility",
+                "score": 2
+              }
+            ]
+          },
+          "E": {
+            "checks": [
+              {
+                "label": "SPY Outlook",
+                "score": 2
+              },
+              {
+                "label": "VIX Outlook",
+                "score": 1
+              },
+              {
+                "label": "Leadership Persistence",
+                "score": 1
+              },
+              {
+                "label": "Breadth Regime",
+                "score": 0
+              },
+              {
+                "label": "Cross-Regime Pressure",
+                "score": 1
+              },
+              {
+                "label": "Driver Alignment",
+                "score": 0
+              }
+            ]
+          }
+        },
+        "forecast_score": 0.383333,
+        "max_points": 60,
+        "points": 23
+      },
+      "5": {
+        "categories": {
+          "A": {
+            "checks": [
+              {
+                "label": "Catalyst Window",
+                "score": 1
+              },
+              {
+                "label": "Macro Calendar Pressure",
+                "score": 1
+              },
+              {
+                "label": "Earnings Cluster",
+                "score": 1
+              },
+              {
+                "label": "Policy / Regulation Risk",
+                "score": 1
+              },
+              {
+                "label": "Headline Shock Proxy",
+                "score": 1
+              },
+              {
+                "label": "Narrative Momentum",
+                "score": 0
+              }
+            ]
+          },
+          "B": {
+            "checks": [
+              {
+                "label": "Trend Persistence",
+                "score": 0
+              },
+              {
+                "label": "Follow-Through Setup",
+                "score": 0
+              },
+              {
+                "label": "RS Momentum vs SPY",
+                "score": 0
+              },
+              {
+                "label": "Support Cushion",
+                "score": 0
+              },
+              {
+                "label": "Participation Trend",
+                "score": 0
+              },
+              {
+                "label": "Acceleration vs Exhaustion",
+                "score": 1
+              }
+            ]
+          },
+          "C": {
+            "checks": [
+              {
+                "label": "Extension Risk",
+                "score": 2
+              },
+              {
+                "label": "Volume Climax Risk",
+                "score": 2
+              },
+              {
+                "label": "Breadth Thinning",
+                "score": 2
+              },
+              {
+                "label": "Flow Pressure",
+                "score": 0
+              },
+              {
+                "label": "Positioning Asymmetry",
+                "score": 0
+              },
+              {
+                "label": "Correlation Crowding",
+                "score": 0
+              }
+            ]
+          },
+          "D": {
+            "checks": [
+              {
+                "label": "Volatility Trend",
+                "score": 1
+              },
+              {
+                "label": "Tail / Gap Risk",
+                "score": 0
+              },
+              {
+                "label": "Market Coupling Trend",
+                "score": 1
+              },
+              {
+                "label": "Liquidity Stress",
+                "score": 2
+              },
+              {
+                "label": "Drawdown Vulnerability",
+                "score": 0
+              },
+              {
+                "label": "Risk/Reward Feasibility",
+                "score": 2
+              }
+            ]
+          },
+          "E": {
+            "checks": [
+              {
+                "label": "SPY Outlook",
+                "score": 2
+              },
+              {
+                "label": "VIX Outlook",
+                "score": 1
+              },
+              {
+                "label": "Leadership Persistence",
+                "score": 1
+              },
+              {
+                "label": "Breadth Regime",
+                "score": 0
+              },
+              {
+                "label": "Cross-Regime Pressure",
+                "score": 1
+              },
+              {
+                "label": "Driver Alignment",
+                "score": 0
+              }
+            ]
+          }
+        },
+        "forecast_score": 0.383333,
+        "max_points": 60,
+        "points": 23
+      }
+    },
+    "XLU": {
+      "1": {
+        "categories": {
+          "A": {
+            "checks": [
+              {
+                "label": "Catalyst Window",
+                "score": 1
+              },
+              {
+                "label": "Macro Calendar Pressure",
+                "score": 1
+              },
+              {
+                "label": "Earnings Cluster",
+                "score": 1
+              },
+              {
+                "label": "Policy / Regulation Risk",
+                "score": 1
+              },
+              {
+                "label": "Headline Shock Proxy",
+                "score": 1
+              },
+              {
+                "label": "Narrative Momentum",
+                "score": 0
+              }
+            ]
+          },
+          "B": {
+            "checks": [
+              {
+                "label": "Trend Persistence",
+                "score": 0
+              },
+              {
+                "label": "Follow-Through Setup",
+                "score": 0
+              },
+              {
+                "label": "RS Momentum vs SPY",
+                "score": 0
+              },
+              {
+                "label": "Support Cushion",
+                "score": 0
+              },
+              {
+                "label": "Participation Trend",
+                "score": 0
+              },
+              {
+                "label": "Acceleration vs Exhaustion",
+                "score": 1
+              }
+            ]
+          },
+          "C": {
+            "checks": [
+              {
+                "label": "Extension Risk",
+                "score": 2
+              },
+              {
+                "label": "Volume Climax Risk",
+                "score": 2
+              },
+              {
+                "label": "Breadth Thinning",
+                "score": 2
+              },
+              {
+                "label": "Flow Pressure",
+                "score": 0
+              },
+              {
+                "label": "Positioning Asymmetry",
+                "score": 0
+              },
+              {
+                "label": "Correlation Crowding",
+                "score": 0
+              }
+            ]
+          },
+          "D": {
+            "checks": [
+              {
+                "label": "Volatility Trend",
+                "score": 1
+              },
+              {
+                "label": "Tail / Gap Risk",
+                "score": 0
+              },
+              {
+                "label": "Market Coupling Trend",
+                "score": 1
+              },
+              {
+                "label": "Liquidity Stress",
+                "score": 2
+              },
+              {
+                "label": "Drawdown Vulnerability",
+                "score": 0
+              },
+              {
+                "label": "Risk/Reward Feasibility",
+                "score": 2
+              }
+            ]
+          },
+          "E": {
+            "checks": [
+              {
+                "label": "SPY Outlook",
+                "score": 2
+              },
+              {
+                "label": "VIX Outlook",
+                "score": 1
+              },
+              {
+                "label": "Leadership Persistence",
+                "score": 1
+              },
+              {
+                "label": "Breadth Regime",
+                "score": 0
+              },
+              {
+                "label": "Cross-Regime Pressure",
+                "score": 1
+              },
+              {
+                "label": "Driver Alignment",
+                "score": 0
+              }
+            ]
+          }
+        },
+        "forecast_score": 0.383333,
+        "max_points": 60,
+        "points": 23
+      },
+      "5": {
+        "categories": {
+          "A": {
+            "checks": [
+              {
+                "label": "Catalyst Window",
+                "score": 1
+              },
+              {
+                "label": "Macro Calendar Pressure",
+                "score": 1
+              },
+              {
+                "label": "Earnings Cluster",
+                "score": 1
+              },
+              {
+                "label": "Policy / Regulation Risk",
+                "score": 1
+              },
+              {
+                "label": "Headline Shock Proxy",
+                "score": 1
+              },
+              {
+                "label": "Narrative Momentum",
+                "score": 0
+              }
+            ]
+          },
+          "B": {
+            "checks": [
+              {
+                "label": "Trend Persistence",
+                "score": 0
+              },
+              {
+                "label": "Follow-Through Setup",
+                "score": 0
+              },
+              {
+                "label": "RS Momentum vs SPY",
+                "score": 0
+              },
+              {
+                "label": "Support Cushion",
+                "score": 0
+              },
+              {
+                "label": "Participation Trend",
+                "score": 0
+              },
+              {
+                "label": "Acceleration vs Exhaustion",
+                "score": 1
+              }
+            ]
+          },
+          "C": {
+            "checks": [
+              {
+                "label": "Extension Risk",
+                "score": 2
+              },
+              {
+                "label": "Volume Climax Risk",
+                "score": 2
+              },
+              {
+                "label": "Breadth Thinning",
+                "score": 2
+              },
+              {
+                "label": "Flow Pressure",
+                "score": 0
+              },
+              {
+                "label": "Positioning Asymmetry",
+                "score": 0
+              },
+              {
+                "label": "Correlation Crowding",
+                "score": 0
+              }
+            ]
+          },
+          "D": {
+            "checks": [
+              {
+                "label": "Volatility Trend",
+                "score": 1
+              },
+              {
+                "label": "Tail / Gap Risk",
+                "score": 0
+              },
+              {
+                "label": "Market Coupling Trend",
+                "score": 1
+              },
+              {
+                "label": "Liquidity Stress",
+                "score": 2
+              },
+              {
+                "label": "Drawdown Vulnerability",
+                "score": 0
+              },
+              {
+                "label": "Risk/Reward Feasibility",
+                "score": 2
+              }
+            ]
+          },
+          "E": {
+            "checks": [
+              {
+                "label": "SPY Outlook",
+                "score": 2
+              },
+              {
+                "label": "VIX Outlook",
+                "score": 1
+              },
+              {
+                "label": "Leadership Persistence",
+                "score": 1
+              },
+              {
+                "label": "Breadth Regime",
+                "score": 0
+              },
+              {
+                "label": "Cross-Regime Pressure",
+                "score": 1
+              },
+              {
+                "label": "Driver Alignment",
+                "score": 0
+              }
+            ]
+          }
+        },
+        "forecast_score": 0.383333,
+        "max_points": 60,
+        "points": 23
+      }
+    },
+    "XLV": {
+      "1": {
+        "categories": {
+          "A": {
+            "checks": [
+              {
+                "label": "Catalyst Window",
+                "score": 1
+              },
+              {
+                "label": "Macro Calendar Pressure",
+                "score": 1
+              },
+              {
+                "label": "Earnings Cluster",
+                "score": 1
+              },
+              {
+                "label": "Policy / Regulation Risk",
+                "score": 1
+              },
+              {
+                "label": "Headline Shock Proxy",
+                "score": 1
+              },
+              {
+                "label": "Narrative Momentum",
+                "score": 0
+              }
+            ]
+          },
+          "B": {
+            "checks": [
+              {
+                "label": "Trend Persistence",
+                "score": 0
+              },
+              {
+                "label": "Follow-Through Setup",
+                "score": 0
+              },
+              {
+                "label": "RS Momentum vs SPY",
+                "score": 0
+              },
+              {
+                "label": "Support Cushion",
+                "score": 0
+              },
+              {
+                "label": "Participation Trend",
+                "score": 0
+              },
+              {
+                "label": "Acceleration vs Exhaustion",
+                "score": 1
+              }
+            ]
+          },
+          "C": {
+            "checks": [
+              {
+                "label": "Extension Risk",
+                "score": 2
+              },
+              {
+                "label": "Volume Climax Risk",
+                "score": 2
+              },
+              {
+                "label": "Breadth Thinning",
+                "score": 2
+              },
+              {
+                "label": "Flow Pressure",
+                "score": 0
+              },
+              {
+                "label": "Positioning Asymmetry",
+                "score": 0
+              },
+              {
+                "label": "Correlation Crowding",
+                "score": 0
+              }
+            ]
+          },
+          "D": {
+            "checks": [
+              {
+                "label": "Volatility Trend",
+                "score": 1
+              },
+              {
+                "label": "Tail / Gap Risk",
+                "score": 0
+              },
+              {
+                "label": "Market Coupling Trend",
+                "score": 1
+              },
+              {
+                "label": "Liquidity Stress",
+                "score": 2
+              },
+              {
+                "label": "Drawdown Vulnerability",
+                "score": 0
+              },
+              {
+                "label": "Risk/Reward Feasibility",
+                "score": 2
+              }
+            ]
+          },
+          "E": {
+            "checks": [
+              {
+                "label": "SPY Outlook",
+                "score": 2
+              },
+              {
+                "label": "VIX Outlook",
+                "score": 1
+              },
+              {
+                "label": "Leadership Persistence",
+                "score": 1
+              },
+              {
+                "label": "Breadth Regime",
+                "score": 0
+              },
+              {
+                "label": "Cross-Regime Pressure",
+                "score": 1
+              },
+              {
+                "label": "Driver Alignment",
+                "score": 0
+              }
+            ]
+          }
+        },
+        "forecast_score": 0.383333,
+        "max_points": 60,
+        "points": 23
+      },
+      "5": {
+        "categories": {
+          "A": {
+            "checks": [
+              {
+                "label": "Catalyst Window",
+                "score": 1
+              },
+              {
+                "label": "Macro Calendar Pressure",
+                "score": 1
+              },
+              {
+                "label": "Earnings Cluster",
+                "score": 1
+              },
+              {
+                "label": "Policy / Regulation Risk",
+                "score": 1
+              },
+              {
+                "label": "Headline Shock Proxy",
+                "score": 1
+              },
+              {
+                "label": "Narrative Momentum",
+                "score": 0
+              }
+            ]
+          },
+          "B": {
+            "checks": [
+              {
+                "label": "Trend Persistence",
+                "score": 0
+              },
+              {
+                "label": "Follow-Through Setup",
+                "score": 0
+              },
+              {
+                "label": "RS Momentum vs SPY",
+                "score": 0
+              },
+              {
+                "label": "Support Cushion",
+                "score": 0
+              },
+              {
+                "label": "Participation Trend",
+                "score": 0
+              },
+              {
+                "label": "Acceleration vs Exhaustion",
+                "score": 1
+              }
+            ]
+          },
+          "C": {
+            "checks": [
+              {
+                "label": "Extension Risk",
+                "score": 2
+              },
+              {
+                "label": "Volume Climax Risk",
+                "score": 2
+              },
+              {
+                "label": "Breadth Thinning",
+                "score": 2
+              },
+              {
+                "label": "Flow Pressure",
+                "score": 0
+              },
+              {
+                "label": "Positioning Asymmetry",
+                "score": 0
+              },
+              {
+                "label": "Correlation Crowding",
+                "score": 0
+              }
+            ]
+          },
+          "D": {
+            "checks": [
+              {
+                "label": "Volatility Trend",
+                "score": 1
+              },
+              {
+                "label": "Tail / Gap Risk",
+                "score": 0
+              },
+              {
+                "label": "Market Coupling Trend",
+                "score": 1
+              },
+              {
+                "label": "Liquidity Stress",
+                "score": 2
+              },
+              {
+                "label": "Drawdown Vulnerability",
+                "score": 0
+              },
+              {
+                "label": "Risk/Reward Feasibility",
+                "score": 2
+              }
+            ]
+          },
+          "E": {
+            "checks": [
+              {
+                "label": "SPY Outlook",
+                "score": 2
+              },
+              {
+                "label": "VIX Outlook",
+                "score": 1
+              },
+              {
+                "label": "Leadership Persistence",
+                "score": 1
+              },
+              {
+                "label": "Breadth Regime",
+                "score": 0
+              },
+              {
+                "label": "Cross-Regime Pressure",
+                "score": 1
+              },
+              {
+                "label": "Driver Alignment",
+                "score": 0
+              }
+            ]
+          }
+        },
+        "forecast_score": 0.383333,
+        "max_points": 60,
+        "points": 23
+      }
+    },
+    "XLY": {
+      "1": {
+        "categories": {
+          "A": {
+            "checks": [
+              {
+                "label": "Catalyst Window",
+                "score": 1
+              },
+              {
+                "label": "Macro Calendar Pressure",
+                "score": 1
+              },
+              {
+                "label": "Earnings Cluster",
+                "score": 1
+              },
+              {
+                "label": "Policy / Regulation Risk",
+                "score": 1
+              },
+              {
+                "label": "Headline Shock Proxy",
+                "score": 1
+              },
+              {
+                "label": "Narrative Momentum",
+                "score": 0
+              }
+            ]
+          },
+          "B": {
+            "checks": [
+              {
+                "label": "Trend Persistence",
+                "score": 0
+              },
+              {
+                "label": "Follow-Through Setup",
+                "score": 0
+              },
+              {
+                "label": "RS Momentum vs SPY",
+                "score": 0
+              },
+              {
+                "label": "Support Cushion",
+                "score": 0
+              },
+              {
+                "label": "Participation Trend",
+                "score": 0
+              },
+              {
+                "label": "Acceleration vs Exhaustion",
+                "score": 1
+              }
+            ]
+          },
+          "C": {
+            "checks": [
+              {
+                "label": "Extension Risk",
+                "score": 2
+              },
+              {
+                "label": "Volume Climax Risk",
+                "score": 2
+              },
+              {
+                "label": "Breadth Thinning",
+                "score": 2
+              },
+              {
+                "label": "Flow Pressure",
+                "score": 0
+              },
+              {
+                "label": "Positioning Asymmetry",
+                "score": 0
+              },
+              {
+                "label": "Correlation Crowding",
+                "score": 0
+              }
+            ]
+          },
+          "D": {
+            "checks": [
+              {
+                "label": "Volatility Trend",
+                "score": 1
+              },
+              {
+                "label": "Tail / Gap Risk",
+                "score": 0
+              },
+              {
+                "label": "Market Coupling Trend",
+                "score": 1
+              },
+              {
+                "label": "Liquidity Stress",
+                "score": 2
+              },
+              {
+                "label": "Drawdown Vulnerability",
+                "score": 0
+              },
+              {
+                "label": "Risk/Reward Feasibility",
+                "score": 2
+              }
+            ]
+          },
+          "E": {
+            "checks": [
+              {
+                "label": "SPY Outlook",
+                "score": 2
+              },
+              {
+                "label": "VIX Outlook",
+                "score": 1
+              },
+              {
+                "label": "Leadership Persistence",
+                "score": 1
+              },
+              {
+                "label": "Breadth Regime",
+                "score": 0
+              },
+              {
+                "label": "Cross-Regime Pressure",
+                "score": 1
+              },
+              {
+                "label": "Driver Alignment",
+                "score": 0
+              }
+            ]
+          }
+        },
+        "forecast_score": 0.383333,
+        "max_points": 60,
+        "points": 23
+      },
+      "5": {
+        "categories": {
+          "A": {
+            "checks": [
+              {
+                "label": "Catalyst Window",
+                "score": 1
+              },
+              {
+                "label": "Macro Calendar Pressure",
+                "score": 1
+              },
+              {
+                "label": "Earnings Cluster",
+                "score": 1
+              },
+              {
+                "label": "Policy / Regulation Risk",
+                "score": 1
+              },
+              {
+                "label": "Headline Shock Proxy",
+                "score": 1
+              },
+              {
+                "label": "Narrative Momentum",
+                "score": 0
+              }
+            ]
+          },
+          "B": {
+            "checks": [
+              {
+                "label": "Trend Persistence",
+                "score": 0
+              },
+              {
+                "label": "Follow-Through Setup",
+                "score": 0
+              },
+              {
+                "label": "RS Momentum vs SPY",
+                "score": 0
+              },
+              {
+                "label": "Support Cushion",
+                "score": 0
+              },
+              {
+                "label": "Participation Trend",
+                "score": 0
+              },
+              {
+                "label": "Acceleration vs Exhaustion",
+                "score": 1
+              }
+            ]
+          },
+          "C": {
+            "checks": [
+              {
+                "label": "Extension Risk",
+                "score": 2
+              },
+              {
+                "label": "Volume Climax Risk",
+                "score": 2
+              },
+              {
+                "label": "Breadth Thinning",
+                "score": 2
+              },
+              {
+                "label": "Flow Pressure",
+                "score": 0
+              },
+              {
+                "label": "Positioning Asymmetry",
+                "score": 0
+              },
+              {
+                "label": "Correlation Crowding",
+                "score": 0
+              }
+            ]
+          },
+          "D": {
+            "checks": [
+              {
+                "label": "Volatility Trend",
+                "score": 1
+              },
+              {
+                "label": "Tail / Gap Risk",
+                "score": 0
+              },
+              {
+                "label": "Market Coupling Trend",
+                "score": 1
+              },
+              {
+                "label": "Liquidity Stress",
+                "score": 2
+              },
+              {
+                "label": "Drawdown Vulnerability",
+                "score": 0
+              },
+              {
+                "label": "Risk/Reward Feasibility",
+                "score": 2
+              }
+            ]
+          },
+          "E": {
+            "checks": [
+              {
+                "label": "SPY Outlook",
+                "score": 2
+              },
+              {
+                "label": "VIX Outlook",
+                "score": 1
+              },
+              {
+                "label": "Leadership Persistence",
+                "score": 1
+              },
+              {
+                "label": "Breadth Regime",
+                "score": 0
+              },
+              {
+                "label": "Cross-Regime Pressure",
+                "score": 1
+              },
+              {
+                "label": "Driver Alignment",
+                "score": 0
+              }
+            ]
+          }
+        },
+        "forecast_score": 0.383333,
+        "max_points": 60,
+        "points": 23
+      }
+    }
+  },
+  "symbols": [
+    "SPY",
+    "XLB",
+    "XLC",
+    "XLE",
+    "XLF",
+    "XLI",
+    "XLK",
+    "XLP",
+    "XLRE",
+    "XLU",
+    "XLV",
+    "XLY"
+  ]
+}

--- a/tests/fixtures/golden.recommendation.forecast.v1.json
+++ b/tests/fixtures/golden.recommendation.forecast.v1.json
@@ -1,0 +1,42 @@
+{
+  "positions": {
+    "positions": [
+      {
+        "market_value": 1000.0,
+        "symbol": "XLK"
+      },
+      {
+        "market_value": 1000.0,
+        "symbol": "XLF"
+      }
+    ],
+    "schema": "positions.v1"
+  },
+  "recommendation": {
+    "action": "SWAP",
+    "constraints_applied": [
+      "forecast_mode",
+      "robust_edge=min(edge(H))",
+      "disagreement_veto_edge",
+      "diversity_constraints",
+      "cooldown",
+      "max_swaps_per_day",
+      "min_improvement_threshold"
+    ],
+    "constraints_triggered": [],
+    "diagnostics": {
+      "decision_metric": "robust_edge",
+      "edge": 0.35,
+      "edges_by_h": {
+        "1": 0.35,
+        "5": 0.35
+      },
+      "mode": "forecast",
+      "robust_edge": 0.35
+    },
+    "from_symbol": "XLF",
+    "reason": "Forecast robust edge 0.350 clears threshold 0.120.",
+    "to_symbol": "XLE"
+  },
+  "schema": "golden.recommendation.forecast.v1"
+}

--- a/tests/test_golden_fixtures_v1.py
+++ b/tests/test_golden_fixtures_v1.py
@@ -1,0 +1,41 @@
+import json
+import unittest
+from pathlib import Path
+
+from market_health.golden_fixtures_v1 import generate_golden_fixtures_v1
+
+
+class TestGoldenFixturesV1(unittest.TestCase):
+    def test_golden_forecast_and_recommendation(self) -> None:
+        fixtures_dir = Path(__file__).resolve().parent / "fixtures"
+        forecast_p = fixtures_dir / "golden.forecast_scores.v1.json"
+        rec_p = fixtures_dir / "golden.recommendation.forecast.v1.json"
+
+        self.assertTrue(
+            forecast_p.exists(),
+            msg="Missing forecast fixture; run scripts/dev/update_golden_fixtures_v1.py",
+        )
+        self.assertTrue(
+            rec_p.exists(),
+            msg="Missing recommendation fixture; run scripts/dev/update_golden_fixtures_v1.py",
+        )
+
+        want_forecast = json.loads(forecast_p.read_text(encoding="utf-8"))
+        want_rec = json.loads(rec_p.read_text(encoding="utf-8"))
+
+        got = generate_golden_fixtures_v1()
+
+        self.assertEqual(
+            want_forecast,
+            got["forecast"],
+            msg="Forecast fixture mismatch. Run scripts/dev/update_golden_fixtures_v1.py to refresh.",
+        )
+        self.assertEqual(
+            want_rec,
+            got["recommendation"],
+            msg="Recommendation fixture mismatch. Run scripts/dev/update_golden_fixtures_v1.py to refresh.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements #117.

- Adds deterministic golden fixtures for forecast_scores + forecast-mode recommendation
- Adds updater: scripts/dev/update_golden_fixtures_v1.py
- Adds test enforcing fixture stability
