### PR TITLE
Issue #120: Holiday-aware trading days (calendar.v1 when available)

### DIFF
--- a/market_health/trading_days.py
+++ b/market_health/trading_days.py
@@ -1,48 +1,139 @@
+"""market_health.trading_days
+
+Weekend-only trading days (v0), with optional holiday-aware behavior.
+
+Behavior:
+- Always treats Sat/Sun as non-trading.
+- If a local calendar file exists, also treats listed holidays as non-trading.
+- If no calendar is available, behavior remains weekends-only (backwards compatible).
+
+Calendar discovery:
+- $JERBOA_CALENDAR_V1_PATH (preferred if set and exists)
+- ~/.cache/jerboa/calendar.v1.json (fallback)
+"""
+
 from __future__ import annotations
 
 import datetime as dt
-from typing import Union
+import json
+import os
+from pathlib import Path
+from typing import Any, Optional, Set, Union
 
-DateLike = Union[dt.date, dt.datetime]
+DateLike = Union[dt.date, dt.datetime, str]
 
-
-def _to_date(x: DateLike) -> dt.date:
-    return x.date() if isinstance(x, dt.datetime) else x
-
-
-def is_trading_day(d: dt.date) -> bool:
-    """v0: weekends-only (Mon-Fri are trading days)."""
-    return d.weekday() < 5
+_DEFAULT_CAL_PATH = os.path.expanduser("~/.cache/jerboa/calendar.v1.json")
+_ENV_CAL_PATH = "JERBOA_CALENDAR_V1_PATH"
 
 
-def next_trading_day(d: dt.date) -> dt.date:
-    """Roll forward to the next trading day (including today if already trading)."""
-    while not is_trading_day(d):
-        d += dt.timedelta(days=1)
-    return d
+def _as_date(x: DateLike) -> dt.date:
+    if isinstance(x, dt.datetime):
+        return x.date()
+    if isinstance(x, dt.date):
+        return x
+    if isinstance(x, str):
+        return dt.date.fromisoformat(x.strip())
+    raise TypeError(f"Unsupported DateLike: {type(x)}")
+
+
+def _read_json(path: str) -> Optional[Any]:
+    try:
+        p = Path(path)
+        if not p.exists():
+            return None
+        return json.loads(p.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+
+
+def _parse_date_str(s: Any) -> Optional[dt.date]:
+    if not isinstance(s, str):
+        return None
+    s = s.strip()
+    if not s:
+        return None
+    try:
+        return dt.date.fromisoformat(s)
+    except Exception:
+        return None
+
+
+def _extract_holidays(obj: Any) -> Set[dt.date]:
+    """
+    Tolerant extraction:
+    - {"holidays": ["YYYY-MM-DD", ...]}
+    - {"market_holidays": [...]}
+    - {"trading_holidays": [...]}
+    - {"calendar": {"holidays": [...]}}
+    - {"data": {"holidays": [...]}}
+    """
+    if not isinstance(obj, dict):
+        return set()
+
+    candidates = []
+    for key in ("holidays", "market_holidays", "trading_holidays"):
+        candidates.append(obj.get(key))
+
+    cal = obj.get("calendar")
+    if isinstance(cal, dict):
+        candidates.append(cal.get("holidays"))
+
+    data = obj.get("data")
+    if isinstance(data, dict):
+        candidates.append(data.get("holidays"))
+
+    out: Set[dt.date] = set()
+    for c in candidates:
+        if isinstance(c, list):
+            for item in c:
+                d = _parse_date_str(item)
+                if d:
+                    out.add(d)
+    return out
+
+
+def _default_holidays() -> Set[dt.date]:
+    path = os.environ.get(_ENV_CAL_PATH) or _DEFAULT_CAL_PATH
+    obj = _read_json(path)
+    return _extract_holidays(obj)
+
+
+def is_trading_day(d: DateLike, *, holidays: Optional[Set[dt.date]] = None) -> bool:
+    dd = _as_date(d)
+    if dd.weekday() >= 5:
+        return False
+    if holidays and dd in holidays:
+        return False
+    return True
+
+
+def next_trading_day(
+    d: DateLike, *, holidays: Optional[Set[dt.date]] = None
+) -> dt.date:
+    """
+    Roll forward to the next trading day (including today if already trading).
+    """
+    dd = _as_date(d)
+    while not is_trading_day(dd, holidays=holidays):
+        dd = dd + dt.timedelta(days=1)
+    return dd
 
 
 def add_trading_days(start: DateLike, trading_days: int) -> dt.date:
     """Add N trading days to start.
 
-    Semantics (v0):
-    - Weekends are non-trading.
     - Start is rolled forward to a trading day.
     - N=0 returns the rolled-forward trading day.
     - N>0 returns the Nth trading day after that.
-
-    This ensures outputs are always trading days.
     """
     if trading_days < 0:
         raise ValueError("trading_days must be >= 0")
 
-    d = next_trading_day(_to_date(start))
-    if trading_days == 0:
-        return d
+    holidays = _default_holidays()
+    d0 = next_trading_day(start, holidays=holidays)
 
-    added = 0
-    while added < trading_days:
-        d += dt.timedelta(days=1)
-        if is_trading_day(d):
-            added += 1
+    d = d0
+    for _ in range(trading_days):
+        d = d + dt.timedelta(days=1)
+        d = next_trading_day(d, holidays=holidays)
     return d

--- a/tests/test_trading_days_calendar.py
+++ b/tests/test_trading_days_calendar.py
@@ -1,0 +1,23 @@
+import json
+from datetime import date
+
+from market_health.trading_days import add_trading_days
+
+
+def test_add_trading_days_skips_holiday(tmp_path, monkeypatch):
+    cal = {
+        "schema": "calendar.v1",
+        "holidays": ["2026-01-01"],  # New Year's Day
+    }
+    cal_p = tmp_path / "calendar.v1.json"
+    cal_p.write_text(json.dumps(cal), encoding="utf-8")
+    monkeypatch.setenv("JERBOA_CALENDAR_V1_PATH", str(cal_p))
+
+    # 2025-12-31 is Wed. +1 trading day would normally be 2026-01-01,
+    # but that is a holiday, so it should roll to 2026-01-02.
+    got = add_trading_days(date(2025, 12, 31), 1)
+    assert got.isoformat() == "2026-01-02"
+
+    # Start on a holiday should roll forward even for N=0
+    got0 = add_trading_days("2026-01-01", 0)
+    assert got0.isoformat() == "2026-01-02"


### PR DESCRIPTION
Implements #120.

- trading_days.add_trading_days remains backwards compatible
- If a local calendar file is present, skips listed holidays
- Adds hermetic unit test via JERBOA_CALENDAR_V1_PATH
