### PR TITLE
Add PM11 forecast calibration overrides

### DIFF
--- a/market_health/forecast_recommendations.py
+++ b/market_health/forecast_recommendations.py
@@ -79,8 +79,23 @@ def recommend_forecast_mode(
     *, positions: Any, constraints: Dict[str, Any]
 ) -> Recommendation:
     horizon = int(constraints.get("horizon_trading_days", 5) or 5)
-    thr = float(constraints.get("min_improvement_threshold", 0.12))
-    veto_edge = float(constraints.get("disagreement_veto_edge", 0.0))
+
+    calibration_thresholds = constraints.get("calibration_thresholds") or {}
+    if not isinstance(calibration_thresholds, dict):
+        calibration_thresholds = {}
+
+    thr = float(
+        calibration_thresholds.get(
+            "min_improvement_threshold",
+            constraints.get("min_improvement_threshold", 0.12),
+        )
+    )
+    veto_edge = float(
+        calibration_thresholds.get(
+            "disagreement_veto_edge",
+            constraints.get("disagreement_veto_edge", 0.0),
+        )
+    )
 
     max_swaps = int(constraints.get("max_swaps_per_day", 1) or 1)
     swaps_today = int(constraints.get("swaps_today", 0) or 0)

--- a/tests/test_forecast_recommendations_pm11.py
+++ b/tests/test_forecast_recommendations_pm11.py
@@ -1,0 +1,50 @@
+from market_health.forecast_recommendations import recommend_forecast_mode
+
+
+def _forecast_constraints(scores, **overrides):
+    base = {
+        "forecast_scores": scores,
+        "forecast_horizons": (1, 5),
+        "horizon_trading_days": 5,
+        "min_improvement_threshold": 0.05,
+        "disagreement_veto_edge": 0.0,
+        "max_swaps_per_day": 1,
+        "swaps_today": 0,
+        "cooldown_trading_days": 0,
+        "cooldown_history": [],
+        "max_weight_per_symbol": 1.0,
+        "min_distinct_symbols": 1,
+        "hhi_cap": 1.0,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_pm11_can_override_threshold_from_calibration_profile():
+    scores = {
+        "AAA": {
+            1: {"forecast_score": 0.50},
+            5: {"forecast_score": 0.50},
+        },
+        "BBB": {
+            1: {"forecast_score": 0.54},
+            5: {"forecast_score": 0.57},
+        },
+    }
+
+    rec = recommend_forecast_mode(
+        positions={"positions": [{"symbol": "AAA", "market_value": 1000.0}]},
+        constraints=_forecast_constraints(
+            scores,
+            min_improvement_threshold=0.05,
+            calibration_thresholds={
+                "min_improvement_threshold": 0.03,
+                "disagreement_veto_edge": 0.0,
+            },
+        ),
+    )
+
+    assert rec.action == "SWAP"
+    assert rec.from_symbol == "AAA"
+    assert rec.to_symbol == "BBB"
+    assert rec.diagnostics["threshold"] == 0.03


### PR DESCRIPTION
Adds PM11 calibration-threshold overrides for forecast recommendations and test coverage.