### PR TITLE
Add PM12 calibration document ingestion

### DIFF
--- a/market_health/forecast_recommendations.py
+++ b/market_health/forecast_recommendations.py
@@ -80,18 +80,29 @@ def recommend_forecast_mode(
 ) -> Recommendation:
     horizon = int(constraints.get("horizon_trading_days", 5) or 5)
 
+    calibration_doc = constraints.get("calibration") or {}
+    if not isinstance(calibration_doc, dict):
+        calibration_doc = {}
+
+    calibration_doc_thresholds = calibration_doc.get("thresholds") or {}
+    if not isinstance(calibration_doc_thresholds, dict):
+        calibration_doc_thresholds = {}
+
     calibration_thresholds = constraints.get("calibration_thresholds") or {}
     if not isinstance(calibration_thresholds, dict):
         calibration_thresholds = {}
 
+    effective_thresholds = dict(calibration_doc_thresholds)
+    effective_thresholds.update(calibration_thresholds)
+
     thr = float(
-        calibration_thresholds.get(
+        effective_thresholds.get(
             "min_improvement_threshold",
             constraints.get("min_improvement_threshold", 0.12),
         )
     )
     veto_edge = float(
-        calibration_thresholds.get(
+        effective_thresholds.get(
             "disagreement_veto_edge",
             constraints.get("disagreement_veto_edge", 0.0),
         )

--- a/tests/test_forecast_recommendations_pm12.py
+++ b/tests/test_forecast_recommendations_pm12.py
@@ -1,0 +1,58 @@
+from datetime import date
+
+from market_health.calibration_v1 import build_calibration_v1
+from market_health.forecast_recommendations import recommend_forecast_mode
+
+
+def _forecast_constraints(scores, **overrides):
+    base = {
+        "forecast_scores": scores,
+        "forecast_horizons": (1, 5),
+        "horizon_trading_days": 5,
+        "min_improvement_threshold": 0.05,
+        "disagreement_veto_edge": 0.0,
+        "max_swaps_per_day": 1,
+        "swaps_today": 0,
+        "cooldown_trading_days": 0,
+        "cooldown_history": [],
+        "max_weight_per_symbol": 1.0,
+        "min_distinct_symbols": 1,
+        "hhi_cap": 1.0,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_pm12_can_read_thresholds_from_calibration_v1_doc():
+    scores = {
+        "AAA": {
+            1: {"forecast_score": 0.50},
+            5: {"forecast_score": 0.50},
+        },
+        "BBB": {
+            1: {"forecast_score": 0.54},
+            5: {"forecast_score": 0.57},
+        },
+    }
+
+    calibration_doc = build_calibration_v1(
+        asof_date=date(2026, 1, 1),
+        thresholds={
+            "min_improvement_threshold": 0.03,
+            "disagreement_veto_edge": 0.0,
+        },
+    )
+
+    rec = recommend_forecast_mode(
+        positions={"positions": [{"symbol": "AAA", "market_value": 1000.0}]},
+        constraints=_forecast_constraints(
+            scores,
+            min_improvement_threshold=0.05,
+            calibration=calibration_doc,
+        ),
+    )
+
+    assert rec.action == "SWAP"
+    assert rec.from_symbol == "AAA"
+    assert rec.to_symbol == "BBB"
+    assert rec.diagnostics["threshold"] == 0.03


### PR DESCRIPTION
Adds PM12 calibration.v1 threshold ingestion for forecast recommendations and test coverage.