### PR TITLE
Restore canonical Sector Union tri-score UI

### DIFF
--- a/market_health/dashboard_legacy.py
+++ b/market_health/dashboard_legacy.py
@@ -1,5 +1,11 @@
 from __future__ import annotations
+from rich import box
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
 
+import io
 import json
 import os
 import re
@@ -8,6 +14,7 @@ import sys
 from pathlib import Path
 from typing import Any
 import argparse
+from datetime import datetime, timezone
 
 
 def _unpack_scores(res):
@@ -31,6 +38,21 @@ POS_CANDIDATES = [
     CACHE_DIR / "market_health.positions.json",
 ]
 
+MAX_POS_AGE_MINUTES = int(os.environ.get("JERBOA_POSITIONS_MAX_AGE_MINUTES", "15"))
+
+
+def _positions_doc_is_fresh(doc: dict[str, Any]) -> bool:
+    if MAX_POS_AGE_MINUTES <= 0:
+        return True
+    if not isinstance(doc, dict):
+        return False
+    ts = doc.get("__file_mtime_epoch__")
+    if not isinstance(ts, (int, float)):
+        return False
+    now_ts = int(datetime.now(timezone.utc).timestamp())
+    return (now_ts - int(ts)) <= (MAX_POS_AGE_MINUTES * 60)
+
+
 RST = "\033[0m"
 RED = "\033[31m"
 GREEN = "\033[32m"
@@ -50,7 +72,14 @@ def strip_ansi(s: str) -> str:
 def read_json(p: Path) -> dict[str, Any]:
     try:
         if p.exists():
-            return json.loads(p.read_text(encoding="utf-8"))
+            data = json.loads(p.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                try:
+                    data["__file_mtime_epoch__"] = int(p.stat().st_mtime)
+                    data["__file_path__"] = str(p)
+                except Exception:
+                    pass
+                return data
     except Exception:
         pass
     return {}
@@ -80,7 +109,69 @@ def run_core_ui(user_args: list[str]) -> str:
     proc = subprocess.run(
         cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, env=env
     )
-    return proc.stdout if proc.stdout.strip() else proc.stderr
+    output = proc.stdout if proc.stdout.strip() else proc.stderr
+    return _coerce_banner_timestamp_from_cache(output)
+
+
+def _coerce_banner_timestamp_from_cache(core_text: str) -> str:
+    try:
+        rec_doc = read_json(REC_PATH)
+        snap = None
+        if isinstance(rec_doc, dict):
+            snap = (
+                rec_doc.get("snapshot_asof")
+                or rec_doc.get("asof")
+                or rec_doc.get("generated_at")
+            )
+        if not isinstance(snap, str) or not snap:
+            return core_text
+
+        datetime.fromisoformat(snap.replace("Z", "+00:00")).astimezone(timezone.utc)
+        try:
+            from zoneinfo import ZoneInfo as _ZoneInfo
+
+            _banner_tz = _ZoneInfo("America/New_York")
+        except Exception:
+            from datetime import timezone as _tz, timedelta as _td
+
+            _banner_tz = _tz(_td(hours=-5), "ET")
+        from datetime import datetime as _dt
+
+        display = _dt.now(_banner_tz).strftime("%Y-%m-%d %I:%M:%S %p %Z")
+
+        out_lines = []
+        replaced = False
+        for line in core_text.splitlines(True):
+            plain = strip_ansi(line)
+            if (
+                not replaced
+                and "Market Health – Sector Union" in plain
+                and "•" in plain
+            ):
+                try:
+                    from zoneinfo import ZoneInfo as _ZoneInfo
+
+                    _banner_tz = _ZoneInfo("America/New_York")
+                except Exception:
+                    from datetime import timezone as _tz, timedelta as _td
+
+                    _banner_tz = _tz(_td(hours=-5), "ET")
+                from datetime import datetime as _dt
+
+                display = _dt.now(_banner_tz).strftime("%Y-%m-%d %I:%M:%S %p %Z")
+                label = f" Market Health – Sector Union • Rendered {display} "
+                plain_nl = "\n" if plain.endswith("\n") else ""
+                inner_width = max(10, len(plain.rstrip("\n")) - 2)
+                if len(label) > inner_width:
+                    label = label[:inner_width]
+                new_plain = "╭" + label.center(inner_width, "─") + "╮" + plain_nl
+                out_lines.append(new_plain)
+                replaced = True
+                continue
+            out_lines.append(line)
+        return "".join(out_lines)
+    except Exception:
+        return core_text
 
 
 def split_core_output(core_text: str) -> tuple[str, dict[str, str], list[str]]:
@@ -165,6 +256,8 @@ def parse_overview_totals(prefix_text: str) -> tuple[list[str], dict[str, float]
 
 
 def extract_symbols_from_positions(doc: dict[str, Any]) -> list[str]:
+    if not _positions_doc_is_fresh(doc):
+        return []
     syms: list[str] = []
 
     v = doc.get("symbols")
@@ -281,6 +374,34 @@ def _snapshot_order_util(doc: dict) -> tuple[list[str], dict[str, float]]:
 
 
 def render_pi_grid(order: list[str], util: dict[str, float]) -> str:
+    def _forecast_pct_from_cache(sym: str, horizon_days: int):
+        import json
+        from pathlib import Path
+
+        cache_p = Path.home() / ".cache" / "jerboa" / "forecast_scores.v1.json"
+        try:
+            doc = json.loads(cache_p.read_text())
+        except Exception:
+            return None
+
+        scores = doc.get("scores") if isinstance(doc, dict) else None
+        if not isinstance(scores, dict):
+            return None
+
+        sym_doc = scores.get(sym)
+        if not isinstance(sym_doc, dict):
+            return None
+
+        horizon_doc = sym_doc.get(str(horizon_days))
+        if not isinstance(horizon_doc, dict):
+            return None
+
+        v = horizon_doc.get("forecast_score")
+        if not isinstance(v, (int, float)):
+            return None
+
+        return float(v) * 100.0
+
     if not order:
         return ""
     cols = 4
@@ -304,7 +425,15 @@ def render_pi_grid(order: list[str], util: dict[str, float]) -> str:
     )
     row: list[list[str]] = []
     for i, sym in enumerate(order):
-        pct = int(round(util.get(sym, 0.0) * 100))
+        c_pct = float(util.get(sym, 0.0) * 100)
+        h1_pct = _forecast_pct_from_cache(sym, 1)
+        h5_pct = _forecast_pct_from_cache(sym, 5)
+        blend_pct = (
+            c_pct
+            if h1_pct is None or h5_pct is None
+            else ((0.50 * c_pct) + (0.25 * h1_pct) + (0.25 * h5_pct))
+        )
+        pct = int(round(blend_pct))
         row.append(box(sym, pct))
         if (i + 1) % cols == 0:
             for r in range(5):
@@ -322,212 +451,1103 @@ def fmt_u(u: float | None) -> str:
     return f"{u:.3f} / {u * 100:.1f}%"
 
 
-def render_reco(
-    order: list[str],
-    util: dict[str, float],
-    rec_doc: dict[str, Any],
-    held_syms: list[str],
-) -> str:
-    rec = None
-    if isinstance(rec_doc, dict):
-        rec = rec_doc.get("recommendation")
-        if not isinstance(rec, dict):
-            # Accept flat v1 cache schema (keys live at top-level)
-            if any(
-                k in rec_doc
-                for k in (
-                    "action",
-                    "why",
-                    "swap_candidates",
-                    "threshold",
-                    "best",
-                    "weakest",
-                    "held_syms",
-                    "status",
-                )
-            ):
-                rec = rec_doc
+# COMPACT_TRISCORE_OVERVIEW_V1
+def render_overview_triscore(order, held_syms):
+    NL = chr(10)
+    cache = Path.home() / ".cache" / "jerboa"
+    ui_p = cache / "market_health.ui.v1.json"
+    fs_p = cache / "forecast_scores.v1.json"
 
-    if not isinstance(rec, dict):
-        rec_path = os.path.expanduser("~/.cache/jerboa/recommendations.v1.json")
+    def _jload(path):
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            return {}
 
-        return c(f"No recommendations cache found at {rec_path}\n", RED)
-
-    asof = (rec.get("asof") if isinstance(rec, dict) else None) or (
-        rec_doc.get("asof") if isinstance(rec_doc, dict) else None
-    )
-
-    action = rec.get("action")
-    reason = rec.get("why") or rec.get("reason") or rec.get("because") or ""
-
-    from_sym = rec.get("from_symbol")
-    to_sym = rec.get("to_symbol")
-
-    diag = rec.get("diagnostics") if isinstance(rec.get("diagnostics"), dict) else {}
-    best = diag.get("best_candidate")
-    weakest = diag.get("weakest_held")
-    threshold = diag.get("threshold")
-    delta = diag.get("delta_utility")
-
-    weak_u = util.get(weakest) if isinstance(weakest, str) else None
-    thr = float(threshold) if isinstance(threshold, (int, float)) else None
-
-    lines: list[str] = []
-    lines.append(c("=" * 28 + " Recommendation (cached) " + "=" * 28, MAGENTA))
-    lines.append(f"{'asof':<14}: {asof}")
-    lines.append(f"{'action':<14}: {action}")
-    if action == "SWAP":
-        fs = from_sym or weakest or "-"
-        ts = to_sym or best or "-"
-        lines.append(c(f"{'swap':<14}: {fs} -> {ts}", GREEN))
-    lines.append(f"{'why':<14}: {reason}")
-
-    if isinstance(best, str):
-        lines.append(f"{'best':<14}: {best} ({fmt_u(util.get(best))})")
-    if isinstance(weakest, str):
-        lines.append(f"{'weakest':<14}: {weakest} ({fmt_u(weak_u)})")
-    if isinstance(delta, (int, float)):
-        lines.append(f"{'delta':<14}: {float(delta):.3f}")
-    if thr is not None:
-        lines.append(f"{'threshold':<14}: {thr:.3f}")
-        if isinstance(delta, (int, float)):
-            short = thr - float(delta)
-            lines.append(
-                f"{'shortfall':<14}: {short:.3f}"
-                if short > 0
-                else f"{'shortfall':<14}: 0.000"
-            )
-
-    # READY/BLOCKED table (the “denied/ready” concept)
-    lines.append("")
-    lines.append(c("Swap candidates vs weakest held", CYAN))
-    inputs = rec_doc.get("inputs") if isinstance(rec_doc.get("inputs"), dict) else {}
-    use_forecast = (
-        bool(inputs.get("forecast_mode"))
-        or (diag.get("decision_metric") == "robust_edge")
-        or (diag.get("mode") == "forecast")
-    )
-
-    if use_forecast:
-        lines.append(
-            f"{'sym':<6}{'health':>10}  {'edge':>7}  {'thr':>7}  {'status':>8}"
-        )
-        lines.append("-" * 52)
-        fs_doc = read_json(CACHE_DIR / "forecast_scores.v1.json")
-        scores = fs_doc.get("scores") if isinstance(fs_doc, dict) else None
-        horizons = (
-            fs_doc.get("horizons_trading_days") if isinstance(fs_doc, dict) else None
-        )
-        if not isinstance(scores, dict) or not scores or not isinstance(weakest, str):
-            lines.append(
-                c("forecast scores unavailable (cannot compute robust edges)", YELLOW)
-            )
-        else:
-            hs: list[int] = []
-            if isinstance(horizons, list):
-                for h in horizons:
-                    try:
-                        hs.append(int(h))
-                    except Exception:
-                        pass
-            hs = sorted(set(hs)) or [1, 5]
-
-            def iter_checks(node):
-                if isinstance(node, dict):
-                    if isinstance(node.get("label"), str) and "score" in node:
-                        yield node
-                    for v in node.values():
-                        yield from iter_checks(v)
-                elif isinstance(node, list):
-                    for v in node:
-                        yield from iter_checks(v)
-
-            def f_util(sym: str, H: int):
-                by_h = scores.get(sym)
-                if not isinstance(by_h, dict):
-                    return None
-                payload = by_h.get(str(H), by_h.get(H))
-                if payload is None:
-                    return None
-                chks = list(iter_checks(payload))
-                if not chks:
-                    return None
-                s = 0.0
-                for c_ in chks:
-                    try:
-                        s += float(c_.get("score", 0.0))
-                    except Exception:
-                        pass
-                m_ = 2.0 * len(chks)
-                return (s / m_) if m_ else None
-
-            def robust_edge(out_sym: str, to_sym: str):
-                edges = []
-                for H in hs:
-                    uo = f_util(out_sym, H)
-                    ut = f_util(to_sym, H)
-                    if uo is None or ut is None:
-                        return None
-                    edges.append(ut - uo)
-                return min(edges) if edges else None
-
-            held_set = set(held_syms)
-            # Candidate symbols = union of overview sectors and forecast score keys, minus held and outsym
-            cand_syms = sorted(set(order) | set(scores.keys()))
-            cand_syms = [
-                s
-                for s in cand_syms
-                if isinstance(s, str) and s and s not in held_set and s != weakest
-            ]
-
-            rows = []
-            for sym in cand_syms:
-                e = robust_edge(weakest, sym)
-                if e is None:
+    def _sum_cat_pct(row):
+        cats = (row or {}).get("categories", {})
+        if not isinstance(cats, dict):
+            return None
+        pts = 0
+        mx = 0
+        for cat in cats.values():
+            if not isinstance(cat, dict):
+                continue
+            checks = cat.get("checks")
+            if not isinstance(checks, list):
+                continue
+            for chk in checks:
+                if not isinstance(chk, dict):
                     continue
-                rows.append((sym, util.get(sym), e))
-            rows.sort(key=lambda t: (-t[2], t[0]))
-            rows = rows[:6]
+                sc = chk.get("score")
+                if isinstance(sc, (int, float)):
+                    pts += int(sc)
+                    mx += 2
+        return int(round((pts / mx) * 100)) if mx else None
 
-            for sym, hu, e in rows:
-                status = "BLOCKED"
-                col = YELLOW
-                if thr is not None and e >= thr:
-                    status = "READY"
-                    col = GREEN
-                elif thr is None:
-                    status = "?"
-                    col = YELLOW
-                hu_s = f"{hu:>10.3f}" if isinstance(hu, float) else (" " * 10)
-                thr_s = "" if thr is None else f"{thr:>7.3f}"
-                lines.append(f"{sym:<6}{hu_s}  {e:>7.3f}  {thr_s:>7}  {c(status, col)}")
+    def _forecast_pct(scores, sym, horizon):
+        if not isinstance(scores, dict):
+            return None
+        by_h = scores.get(sym)
+        if not isinstance(by_h, dict):
+            return None
+        node = by_h.get(str(horizon), by_h.get(horizon))
+        if not isinstance(node, dict):
+            return None
 
+        fs = node.get("forecast_score")
+        if isinstance(fs, (int, float)):
+            val = float(fs)
+            return int(round(val * 100)) if val <= 1.5 else int(round(val))
+
+        pts = node.get("points")
+        mx = node.get("max_points")
+        if isinstance(pts, (int, float)) and isinstance(mx, (int, float)) and mx:
+            return int(round((float(pts) / float(mx)) * 100))
+        return None
+
+    def _fmt_pct(v):
+        if isinstance(v, (int, float)):
+            return f"{int(v):>3d}%"
+        return "  - "
+
+    def _fmt_delta(v):
+        if isinstance(v, (int, float)):
+            return f"{int(v):+4d}"
+        return "   -"
+
+    ui = _jload(ui_p)
+    fs = _jload(fs_p)
+
+    raw_sectors = (
+        ((ui.get("data") or {}).get("sectors") or {}) if isinstance(ui, dict) else {}
+    )
+    sector_map = {}
+    if isinstance(raw_sectors, dict):
+        for k, v in raw_sectors.items():
+            sym = str(k).strip().upper()
+            if sym and isinstance(v, dict):
+                sector_map[sym] = v
+    elif isinstance(raw_sectors, list):
+        for row in raw_sectors:
+            if not isinstance(row, dict):
+                continue
+            sym = str(row.get("symbol", "")).strip().upper()
+            if sym:
+                sector_map[sym] = row
+
+    raw_scores = (fs.get("scores") or {}) if isinstance(fs, dict) else {}
+    scores = raw_scores if isinstance(raw_scores, dict) else {}
+    held_set = {str(s).strip().upper() for s in (held_syms or []) if str(s).strip()}
+
+    syms = []
+    for s in order or []:
+        sym = str(s).strip().upper()
+        if sym and sym not in syms:
+            syms.append(sym)
+    if not syms and isinstance(sector_map, dict):
+        syms = sorted(sector_map.keys())
+
+    import io
+    from rich import box
+    from rich.console import Console
+    from rich.panel import Panel
+    from rich.table import Table
+
+    def _pct_style(v):
+        if v is None:
+            return "dim"
+        if v >= 60:
+            return "bold green"
+        if v >= 40:
+            return "bold yellow"
+        return "bold red"
+
+    def _delta_style(v):
+        if v is None:
+            return "dim"
+        if v > 0:
+            return "bold green"
+        if v < 0:
+            return "bold red"
+        return "dim"
+
+    console = Console(
+        record=True,
+        force_terminal=True,
+        color_system="truecolor",
+        width=88,
+        file=io.StringIO(),
+    )
+
+    table = Table(
+        box=box.ROUNDED,
+        expand=True,
+        header_style="bold cyan",
+        border_style="bright_blue",
+        pad_edge=False,
+        padding=(0, 1),
+        show_lines=True,
+        row_styles=["none", "on rgb(20,24,28)"],
+    )
+    table.add_column("Sym", style="bold white", no_wrap=True, width=7)
+    table.add_column("Blend", justify="right", no_wrap=True, width=5)
+    table.add_column("C", justify="right", no_wrap=True, width=4)
+    table.add_column("H1", justify="right", no_wrap=True, width=4)
+    table.add_column("H5", justify="right", no_wrap=True, width=4)
+    table.add_column("Δ1", justify="right", no_wrap=True, width=4)
+    table.add_column("Δ5", justify="right", no_wrap=True, width=4)
+
+    rows = []
+    for sym in syms:
+        row = sector_map.get(sym)
+        if not isinstance(row, dict):
+            continue
+
+        c_pct = _sum_cat_pct(row)
+        h1_pct = _forecast_pct(scores, sym, 1)
+        h5_pct = _forecast_pct(scores, sym, 5)
+
+        d1 = None if c_pct is None or h1_pct is None else (h1_pct - c_pct)
+        d5 = None if c_pct is None or h5_pct is None else (h5_pct - c_pct)
+
+        blend_pct = None
+        if c_pct is not None and h1_pct is not None and h5_pct is not None:
+            blend_pct = (0.50 * c_pct) + (0.25 * h1_pct) + (0.25 * h5_pct)
+
+        sym_txt = (
+            f"[bold white]{sym}[/][bold magenta]•[/]"
+            if sym in held_set
+            else f"[bold white]{sym}[/]"
+        )
+
+        blend_txt = f"[{_pct_style(blend_pct)}]{_fmt_pct(blend_pct)}[/]"
+        c_txt = f"[{_pct_style(c_pct)}]{_fmt_pct(c_pct)}[/]"
+        h1_txt = f"[{_pct_style(h1_pct)}]{_fmt_pct(h1_pct)}[/]"
+        h5_txt = f"[{_pct_style(h5_pct)}]{_fmt_pct(h5_pct)}[/]"
+        d1_txt = f"[{_delta_style(d1)}]{_fmt_delta(d1)}[/]"
+        d5_txt = f"[{_delta_style(d5)}]{_fmt_delta(d5)}[/]"
+
+        rows.append(
+            {
+                "sym": sym,
+                "blend": blend_pct,
+                "sym_txt": sym_txt,
+                "blend_txt": blend_txt,
+                "c_txt": c_txt,
+                "h1_txt": h1_txt,
+                "h5_txt": h5_txt,
+                "d1_txt": d1_txt,
+                "d5_txt": d5_txt,
+            }
+        )
+
+    rows.sort(
+        key=lambda r: (
+            r["blend"] is None,
+            -(r["blend"] if r["blend"] is not None else -1.0),
+            r["sym"],
+        )
+    )
+
+    for r in rows:
+        table.add_row(
+            r["sym_txt"],
+            r["blend_txt"],
+            r["c_txt"],
+            r["h1_txt"],
+            r["h5_txt"],
+            r["d1_txt"],
+            r["d5_txt"],
+        )
+
+    console.print()
+    console.print(
+        Panel(
+            table,
+            title="[bold white]Overview (expanded universe, compact tri-score)[/] [bold magenta]• held[/]",
+            border_style="bright_blue",
+            padding=(0, 1),
+        )
+    )
+
+    return console.export_text(styles=True) + NL
+
+
+def _dashboard_intraday_fresh_or_last_completed_session(value, max_age_minutes=15):
+    from datetime import datetime, timezone, timedelta
+
+    if not value or value == "-":
+        return False
+
+    if isinstance(value, datetime):
+        dt = value
+    elif isinstance(value, str):
+        s = value.strip()
+        if s.endswith("Z"):
+            s = s[:-1] + "+00:00"
+        try:
+            dt = datetime.fromisoformat(s)
+        except ValueError:
+            return False
     else:
-        lines.append(f"{'sym':<6}{'utility':>10}  {'Δ':>7}  {'thr':>7}  {'status':>8}")
-        lines.append("-" * 44)
-        held_set = set(held_syms)
-        candidates = [(s, util.get(s)) for s in util.keys() if s not in held_set]
-        candidates = [(s, u) for s, u in candidates if isinstance(u, float)]
-        candidates.sort(key=lambda x: (-x[1], x[0]))
+        return False
 
-        for sym, u in candidates:
-            d = (u - weak_u) if (weak_u is not None) else None
-            status = "BLOCKED"
-            col = YELLOW
-            if d is not None and thr is not None and d >= thr:
-                status = "READY"
-                col = GREEN
-            elif d is None or thr is None:
-                status = "?"
-                col = YELLOW
-            lines.append(
-                f"{sym:<6}{u:>10.3f}  {'' if d is None else f'{d:>7.3f}'}  {'' if thr is None else f'{thr:>7.3f}'}  {c(status, col)}"
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    dt = dt.astimezone(timezone.utc)
+
+    now_utc = datetime.now(timezone.utc)
+    ttl = timedelta(minutes=max_age_minutes)
+
+    try:
+        import pandas_market_calendars as mcal
+    except ModuleNotFoundError:
+        # Dependency-free fallback for CI/offline environments.
+        # Live weekday session -> strict intraday TTL.
+        # Closed market/weekend -> last completed weekday counts as fresh.
+        try:
+            from zoneinfo import ZoneInfo
+
+            et_tz = ZoneInfo("America/New_York")
+        except Exception:
+            et_tz = timezone(timedelta(hours=-5), "ET")
+
+        now_et = now_utc.astimezone(et_tz)
+        dt_et = dt.astimezone(et_tz)
+
+        def _last_weekday(d):
+            while d.weekday() >= 5:
+                d -= timedelta(days=1)
+            return d
+
+        mins_now = now_et.hour * 60 + now_et.minute
+        open_mins = 9 * 60 + 30
+        close_mins = 16 * 60
+
+        if now_et.weekday() < 5 and open_mins <= mins_now <= close_mins:
+            return dt_et.date() == now_et.date() and dt >= (now_utc - ttl)
+
+        ref_date = now_et.date()
+        if now_et.weekday() < 5 and mins_now < open_mins:
+            ref_date -= timedelta(days=1)
+        ref_date = _last_weekday(ref_date)
+        return dt_et.date() == ref_date
+
+    cal = mcal.get_calendar("NYSE")
+    sched = cal.schedule(
+        start_date=(now_utc - timedelta(days=10)).date().isoformat(),
+        end_date=(now_utc + timedelta(days=2)).date().isoformat(),
+    )
+    if sched.empty:
+        return False
+
+    rows = []
+    for idx, row in sched.iterrows():
+        open_ts = row["market_open"].to_pydatetime().astimezone(timezone.utc)
+        close_ts = row["market_close"].to_pydatetime().astimezone(timezone.utc)
+        session_label = str(idx.date() if hasattr(idx, "date") else idx)
+        rows.append((session_label, open_ts, close_ts))
+
+    dt_session = dt.date().isoformat()
+
+    for session_label, open_ts, close_ts in rows:
+        if open_ts <= now_utc <= close_ts:
+            if dt_session != session_label:
+                return False
+            return dt >= (now_utc - ttl)
+
+    prior_rows = [r for r in rows if r[2] <= now_utc]
+    if not prior_rows:
+        return False
+
+    last_completed_session = prior_rows[-1][0]
+    return dt_session == last_completed_session
+
+
+def render_reco(order, util, rec_doc, held_syms):
+    NL = chr(10)
+    console = Console(
+        record=True,
+        force_terminal=True,
+        color_system="truecolor",
+        width=118,
+        file=io.StringIO(),
+    )
+
+    def _num(v):
+        return float(v) if isinstance(v, (int, float)) else None
+
+    def _fmt(v):
+        n = _num(v)
+        return "-" if n is None else f"{n:.2f}"
+
+    def _fmt_pct_weights(w):
+        if not isinstance(w, dict):
+            return "-"
+        c_w = float(w.get("c", 0.0) or 0.0)
+        h1_w = float(w.get("h1", 0.0) or 0.0)
+        h5_w = float(w.get("h5", 0.0) or 0.0)
+        return f"C {c_w:.0%}  H1 {h1_w:.0%}  H5 {h5_w:.0%}"
+
+    def _score_style(v):
+        n = _num(v)
+        if n is None:
+            return "dim"
+        if n >= 0.60:
+            return "bold green"
+        if n >= 0.40:
+            return "bold yellow"
+        return "bold red"
+
+    def _delta_style(v, thr=None):
+        n = _num(v)
+        t = _num(thr)
+        if n is None:
+            return "dim"
+        if t is not None and n >= t:
+            return "bold green"
+        if n > 0:
+            return "yellow"
+        if n < 0:
+            return "red"
+        return "dim"
+
+    def _status_style(s):
+        s = str(s or "").upper()
+        if s == "READY":
+            return "bold green"
+        if s == "BLOCKED":
+            return "bold red"
+        return "bold yellow"
+
+    fs_doc = {}
+    try:
+        fs_doc = json.loads(
+            (Path.home() / ".cache" / "jerboa" / "forecast_scores.v1.json").read_text(
+                encoding="utf-8"
+            )
+        )
+    except Exception:
+        fs_doc = {}
+
+    def _forecast_horizons():
+        hs = fs_doc.get("horizons_trading_days")
+        out = []
+        if isinstance(hs, list):
+            for h in hs:
+                try:
+                    out.append(int(h))
+                except Exception:
+                    pass
+        if len(out) >= 2:
+            return out[0], out[1]
+        return 1, 5
+
+    H1, H5 = _forecast_horizons()
+
+    def _forecast_util(sym, horizon_days):
+        if not isinstance(sym, str) or not sym:
+            return None
+        scores = fs_doc.get("scores")
+        if not isinstance(scores, dict):
+            return None
+        by_h = scores.get(sym)
+        if not isinstance(by_h, dict):
+            return None
+        payload = by_h.get(str(horizon_days), by_h.get(horizon_days))
+        if not isinstance(payload, dict):
+            return None
+
+        fs = payload.get("forecast_score")
+        if isinstance(fs, (int, float)):
+            v = float(fs)
+            return v / 100.0 if v > 1.5 else v
+
+        pts = payload.get("points")
+        mx = payload.get("max_points")
+        if isinstance(pts, (int, float)) and isinstance(mx, (int, float)) and mx:
+            return float(pts) / float(mx)
+
+        return None
+
+    def _blend_components(sym):
+        if not isinstance(sym, str) or not sym:
+            return None
+
+        c_val = util.get(sym)
+        c_util = float(c_val) if isinstance(c_val, (int, float)) else None
+        h1_util = _forecast_util(sym, H1)
+        h5_util = _forecast_util(sym, H5)
+
+        weights = {"c": 0.50, "h1": 0.25, "h5": 0.25}
+        present = {"c": c_util, "h1": h1_util, "h5": h5_util}
+        present = {k: v for k, v in present.items() if isinstance(v, (int, float))}
+        denom = sum(weights[k] for k in present.keys())
+
+        blended = (
+            sum(weights[k] * float(v) for k, v in present.items()) / denom
+            if denom > 0
+            else None
+        )
+
+        return {
+            "blended": blended,
+            "c": c_util,
+            "h1": h1_util,
+            "h5": h5_util,
+        }
+
+    def _merge_comp(sym, comp):
+        base = _blend_components(sym) or {}
+        if isinstance(comp, dict):
+            for k in ("blended", "c", "h1", "h5"):
+                if comp.get(k) is not None:
+                    base[k] = comp.get(k)
+        return base if base else None
+
+    def _comp_line(sym, comp):
+        if not isinstance(sym, str) or not sym:
+            return "-"
+        if not isinstance(comp, dict):
+            return sym
+        return (
+            f"{sym}  "
+            f"(blend {_fmt(comp.get('blended'))} | "
+            f"C {_fmt(comp.get('c'))} | "
+            f"H1 {_fmt(comp.get('h1'))} | "
+            f"H5 {_fmt(comp.get('h5'))})"
+        )
+
+    def _edge_by_h(row, horizon_days):
+        edges = row.get("edges_by_h")
+        if not isinstance(edges, dict):
+            return None
+        return _num(edges.get(str(horizon_days), edges.get(horizon_days)))
+
+    def _short_reason(reason):
+        s = str(reason or "").strip()
+        if not s or s == "-":
+            return "-"
+        if s.startswith("disagreement_veto:edge(") and s.endswith(")<0"):
+            hs = s[len("disagreement_veto:edge(") : -len(")<0")]
+            hs = hs.replace(",", "")
+            return f"e{hs}<0"
+        mapping = {
+            "below_floor": "flr",
+            "below_delta": "dlt",
+            "fallback_only": "fbk",
+            "policy:max_precious_holdings": "pmx",
+            "policy:block_gltr_component_overlap": "gco",
+        }
+        return mapping.get(s, s[:6])
+
+    if not isinstance(rec_doc, dict):
+        console.print(
+            Panel(
+                Text("recommendation cache unavailable", style="yellow"),
+                title="Recommendation",
+                border_style="yellow",
+                box=box.ROUNDED,
+            )
+        )
+        return console.export_text(styles=True) + NL
+
+    rec = rec_doc.get("recommendation")
+    if not isinstance(rec, dict):
+        rec = rec_doc if isinstance(rec_doc, dict) else {}
+
+    d = rec.get("diagnostics") if isinstance(rec.get("diagnostics"), dict) else {}
+    if not isinstance(d, dict):
+        d = {}
+
+    asof = (
+        rec_doc.get("snapshot_asof")
+        or rec_doc.get("asof")
+        or rec_doc.get("generated_at")
+        or "?"
+    )
+    action = str(rec.get("action") or "?").upper()
+    reason = rec.get("reason") or "-"
+    metric = d.get("decision_metric") or "-"
+    weights = _fmt_pct_weights(d.get("utility_weights"))
+    fp = rec_doc.get("snapshot_id") or rec_doc.get("computation_fingerprint") or "-"
+    if isinstance(fp, str) and len(fp) > 12:
+        fp = fp[:12]
+
+    computed_at = rec_doc.get("computed_at") or rec_doc.get("generated_at") or "-"
+
+    from datetime import datetime as _dt, timezone as _tz, timedelta as _td
+
+    try:
+        from zoneinfo import ZoneInfo as _ZoneInfo
+
+        _ET = _ZoneInfo("America/New_York")
+    except Exception:
+        _ET = _tz(_td(hours=-5), "ET")
+
+    cached_freshness = (
+        rec_doc.get("freshness") if isinstance(rec_doc.get("freshness"), dict) else {}
+    )
+    if not isinstance(cached_freshness, dict):
+        cached_freshness = {}
+
+    source_ts = (
+        rec_doc.get("source_timestamps")
+        if isinstance(rec_doc.get("source_timestamps"), dict)
+        else {}
+    )
+    if not isinstance(source_ts, dict):
+        source_ts = {}
+
+    def _parse_iso_any(value):
+        if not value or value == "-":
+            return None
+        if isinstance(value, _dt):
+            dt = value
+        elif isinstance(value, str):
+            s = value.strip()
+            if s.endswith("Z"):
+                s = s[:-1] + "+00:00"
+            try:
+                dt = _dt.fromisoformat(s)
+            except ValueError:
+                return None
+        else:
+            return None
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=_tz.utc)
+        return dt.astimezone(_tz.utc)
+
+    def _fmt_et(value):
+        dt = _parse_iso_any(value)
+        if dt is None:
+            return str(value or "-")
+        return dt.astimezone(_ET).strftime("%Y-%m-%d %I:%M:%S %p %Z")
+
+    def _age_seconds_now(value):
+        dt = _parse_iso_any(value)
+        if dt is None:
+            return None
+        return max(0, int((_dt.now(_tz.utc) - dt).total_seconds()))
+
+    def _fmt_age(seconds):
+        if seconds is None:
+            return "-"
+        seconds = int(seconds)
+        if seconds < 60:
+            return f"{seconds}s"
+        minutes, sec = divmod(seconds, 60)
+        if minutes < 60:
+            return f"{minutes}m {sec:02d}s"
+        hours, minutes = divmod(minutes, 60)
+        return f"{hours}h {minutes:02d}m"
+
+    def _is_same_or_last_completed_session_now(value):
+        dt = _parse_iso_any(value)
+        if dt is None:
+            return False
+        try:
+            import pandas_market_calendars as _mcal
+        except Exception:
+            return False
+
+        now_utc = _dt.now(_tz.utc)
+        cal = _mcal.get_calendar("NYSE")
+        sched = cal.schedule(
+            start_date=(now_utc - _td(days=10)).date().isoformat(),
+            end_date=(now_utc + _td(days=2)).date().isoformat(),
+        )
+        if sched.empty:
+            return False
+
+        rows = []
+        for idx, row in sched.iterrows():
+            open_ts = row["market_open"].to_pydatetime().astimezone(_tz.utc)
+            close_ts = row["market_close"].to_pydatetime().astimezone(_tz.utc)
+            session_label = str(idx.date() if hasattr(idx, "date") else idx)
+            rows.append((session_label, open_ts, close_ts))
+
+        dt_session = dt.astimezone(_ET).date().isoformat()
+
+        for session_label, open_ts, close_ts in rows:
+            if open_ts <= now_utc <= close_ts:
+                return dt_session == session_label
+
+        prior_rows = [r for r in rows if r[2] <= now_utc]
+        if not prior_rows:
+            return False
+
+        last_completed_session = prior_rows[-1][0]
+        return dt_session == last_completed_session
+
+    asof = (
+        source_ts.get("snapshot_asof")
+        or rec_doc.get("snapshot_asof")
+        or rec_doc.get("asof")
+        or computed_at
+    )
+
+    positions_asof_live = (
+        source_ts.get("positions_asof")
+        or rec_doc.get("positions_asof")
+        or rec_doc.get("positions_source_asof")
+        or rec_doc.get("positions_generated_at")
+        or "-"
+    )
+
+    forecast_asof_live = (
+        source_ts.get("forecast_source_asof")
+        or source_ts.get("forecast_asof")
+        or source_ts.get("forecast_generated_at")
+        or rec_doc.get("forecast_asof")
+        or rec_doc.get("forecast_generated_at")
+        or "-"
+    )
+
+    sectors_asof_live = (
+        source_ts.get("sectors_asof")
+        or rec_doc.get("sectors_asof")
+        or rec_doc.get("sectors_generated_at")
+        or "-"
+    )
+
+    positions_age = _age_seconds_now(positions_asof_live)
+    forecast_age = _age_seconds_now(forecast_asof_live)
+    sectors_age = _age_seconds_now(sectors_asof_live)
+
+    max_positions_age_minutes = int(
+        cached_freshness.get("max_positions_age_minutes") or 15
+    )
+
+    positions_fresh = _dashboard_intraday_fresh_or_last_completed_session(
+        positions_asof_live,
+        max_positions_age_minutes,
+    )
+
+    forecast_fresh = _dashboard_intraday_fresh_or_last_completed_session(
+        forecast_asof_live,
+        max_positions_age_minutes,
+    )
+
+    sectors_fresh = _dashboard_intraday_fresh_or_last_completed_session(
+        sectors_asof_live,
+        15,
+    )
+
+    live_dts = [
+        _parse_iso_any(positions_asof_live),
+        _parse_iso_any(forecast_asof_live),
+        _parse_iso_any(sectors_asof_live),
+    ]
+    live_dts = [dt for dt in live_dts if dt is not None]
+    skew_age = (
+        int((max(live_dts) - min(live_dts)).total_seconds())
+        if len(live_dts) >= 2
+        else None
+    )
+
+    freshness_parts = []
+    if positions_fresh is not None:
+        freshness_parts.append(f"p={'yes' if positions_fresh else 'no'}")
+    if forecast_fresh is not None:
+        freshness_parts.append(f"f={'yes' if forecast_fresh else 'no'}")
+    if sectors_fresh is not None:
+        freshness_parts.append(f"s={'yes' if sectors_fresh else 'no'}")
+    freshness_line = ", ".join(freshness_parts) if freshness_parts else "-"
+
+    rendered_now_display = _dt.now(_ET).strftime("%Y-%m-%d %I:%M:%S %p %Z")
+    asof_display = _fmt_et(asof)
+    positions_display = _fmt_et(positions_asof_live)
+    forecast_display = _fmt_et(forecast_asof_live)
+    computed_display = _fmt_et(computed_at)
+    age_display = f"{_fmt_age(positions_age)} / {_fmt_age(forecast_age)} / {_fmt_age(sectors_age)}"
+    skew_display = _fmt_age(skew_age)
+
+    # Presentation-only truncation for the bottom candidate-pairs widget.
+    # This does NOT change recommendation/scoring logic; it only limits what is shown.
+    def _safe_float(v):
+        try:
+            return float(v)
+        except Exception:
+            return None
+
+    def _safe_str(v):
+        return "" if v is None else str(v)
+
+    def _pair_sort_key(row):
+        robust = _safe_float(row.get("robust_edge"))
+        weighted = _safe_float(row.get("weighted_edge"))
+        avg = _safe_float(row.get("avg_edge"))
+        best_effort = robust
+        if best_effort is None:
+            best_effort = weighted
+        if best_effort is None:
+            best_effort = avg
+        if best_effort is None:
+            best_effort = -999.0
+        return (
+            best_effort,
+            weighted if weighted is not None else -999.0,
+            avg if avg is not None else -999.0,
+        )
+
+    def _interesting_pair_rows(
+        rows, selected_pair_row=None, max_rows_if_action=10, max_rows_if_noop=10
+    ):
+
+        if not isinstance(rows, list):
+            return [], 0
+
+        action_is_noop = str(action).upper() == "NOOP"
+
+        cap = max_rows_if_noop if action_is_noop else max_rows_if_action
+
+        def _sig(row):
+
+            return (
+                _safe_str(row.get("from_symbol")),
+                _safe_str(row.get("to_symbol")),
             )
 
-    lines.append(
-        f"{'held_syms':<14}: {', '.join(held_syms) if held_syms else '(none found)'}"
+        def _robust(row):
+
+            v = _safe_float(row.get("robust_edge"))
+
+            return v if v is not None else -999.0
+
+        def _weighted(row):
+
+            v = _safe_float(row.get("weighted_edge"))
+
+            return v if v is not None else -999.0
+
+        def _avg(row):
+
+            v = _safe_float(row.get("avg_edge"))
+
+            return v if v is not None else -999.0
+
+        selected_sig = None
+
+        if isinstance(selected_pair_row, dict):
+            selected_sig = _sig(selected_pair_row)
+
+        chosen = []
+
+        seen = set()
+
+        def add_row(row):
+
+            if not isinstance(row, dict):
+                return
+
+            sig = _sig(row)
+
+            if sig in seen:
+                return
+
+            seen.add(sig)
+
+            chosen.append(row)
+
+        # 1) Selected pair first.
+
+        if selected_sig is not None:
+            for row in rows:
+                if _sig(row) == selected_sig:
+                    add_row(row)
+
+                    break
+
+        # 2) Positive robust-edge rows, strongest first.
+
+        positive_rows = [
+            row
+            for row in rows
+            if _safe_float(row.get("robust_edge")) is not None
+            and _safe_float(row.get("robust_edge")) > 0
+        ]
+
+        positive_rows.sort(
+            key=lambda row: (_robust(row), _weighted(row), _avg(row)),
+            reverse=True,
+        )
+
+        for row in positive_rows:
+            add_row(row)
+
+        # 3) Fill remaining slots with least-bad rows closest to zero.
+
+        remaining_rows = [row for row in rows if _sig(row) not in seen]
+
+        remaining_rows.sort(
+            key=lambda row: (_robust(row), _weighted(row), _avg(row)),
+            reverse=True,
+        )
+
+        for row in remaining_rows:
+            if len(chosen) >= cap:
+                break
+
+            add_row(row)
+
+        displayed = chosen[:cap]
+
+        omitted = max(0, len(rows) - len(displayed))
+
+        return displayed, omitted
+
+    selected_pair = (
+        d.get("selected_pair") if isinstance(d.get("selected_pair"), dict) else {}
     )
-    return "\n".join(lines) + "\n"
+    best = selected_pair.get("to_symbol") or d.get("best_candidate")
+    weakest = selected_pair.get("from_symbol") or d.get("weakest_held")
+
+    held_components = d.get("held_components") or {}
+    candidate_components = d.get("candidate_components") or {}
+    best_components = _merge_comp(
+        best,
+        candidate_components if isinstance(candidate_components, dict) else None,
+    )
+    weakest_components = _merge_comp(
+        weakest,
+        held_components.get(weakest) if isinstance(held_components, dict) else None,
+    )
+
+    delta = _num(d.get("delta_utility"))
+    thr = _num(d.get("threshold"))
+    shortfall = (thr - delta) if (delta is not None and thr is not None) else None
+
+    summary = Table.grid(padding=(0, 2))
+    summary.add_column(style="bold cyan", no_wrap=True)
+    summary.add_column(no_wrap=False)
+
+    action_style = (
+        "bold green"
+        if action == "SWAP"
+        else ("bold yellow" if action == "NOOP" else "bold white")
+    )
+    summary.add_row("rendered", str(rendered_now_display))
+    summary.add_row("snapshot", str(asof_display))
+    summary.add_row("positions", str(positions_display))
+    summary.add_row("forecast", str(forecast_display))
+    summary.add_row("computed", str(computed_display))
+    summary.add_row("fresh", str(freshness_line))
+    summary.add_row("age p/f/s", str(age_display))
+    summary.add_row("skew", str(skew_display))
+    summary.add_row("fp", str(fp))
+    summary.add_row("action", Text(action, style=action_style))
+    summary.add_row("metric", str(metric))
+    summary.add_row("weights", str(weights))
+    summary.add_row("why", str(reason))
+    summary.add_row("best", Text(_comp_line(best, best_components), style="bold green"))
+    summary.add_row(
+        "weakest", Text(_comp_line(weakest, weakest_components), style="bold yellow")
+    )
+    summary.add_row("delta", Text(_fmt(delta), style=_delta_style(delta, thr)))
+    summary.add_row("threshold", Text(_fmt(thr), style="cyan"))
+    if shortfall is not None:
+        summary.add_row("shortfall", Text(_fmt(shortfall), style="yellow"))
+
+    console.print(
+        Panel(
+            summary,
+            title="Recommendation (cached)",
+            border_style="cyan",
+            box=box.ROUNDED,
+        )
+    )
+
+    pair_rows = d.get("candidate_pairs") or []
+    stale_positions = "stale_positions_cache" in str(reason)
+
+    if stale_positions and (not isinstance(pair_rows, list) or not pair_rows):
+        console.print(
+            Panel(
+                Text(
+                    "Forecast candidate pairs are hidden because positions.v1.json is stale. Refresh positions to restore this panel.",
+                    style="yellow",
+                ),
+                title="Forecast candidate pairs",
+                border_style="yellow",
+                box=box.ROUNDED,
+            )
+        )
+    elif isinstance(pair_rows, list) and pair_rows:
+        ptbl = Table(
+            box=box.SIMPLE_HEAVY,
+            show_header=True,
+            header_style="bold magenta",
+            expand=False,
+        )
+        ptbl.add_column("From", justify="left", no_wrap=True)
+        ptbl.add_column("FromBl", justify="right", no_wrap=True)
+        ptbl.add_column("To", justify="left", no_wrap=True)
+        ptbl.add_column("ToBl", justify="right", no_wrap=True)
+        ptbl.add_column("Robust", justify="right", no_wrap=True)
+        ptbl.add_column("Weighted", justify="right", no_wrap=True)
+        ptbl.add_column("Avg", justify="right", no_wrap=True)
+        ptbl.add_column(f"H{H1}", justify="right", no_wrap=True)
+        ptbl.add_column(f"H{H5}", justify="right", no_wrap=True)
+        ptbl.add_column("Why", justify="left", no_wrap=True)
+
+        def _pair_sort_key(r):
+            veto_rank = 1 if bool(r.get("vetoed")) else 0
+            robust_rank = -(_num(r.get("robust_edge")) or -999.0)
+            weighted_rank = -(_num(r.get("weighted_robust_edge")) or -999.0)
+            avg_rank = -(_num(r.get("avg_edge")) or -999.0)
+            return (
+                veto_rank,
+                robust_rank,
+                weighted_rank,
+                avg_rank,
+                str(r.get("from_symbol", "")),
+                str(r.get("to_symbol", "")),
+            )
+
+        sel_from = str(selected_pair.get("from_symbol") or "")
+        sel_to = str(selected_pair.get("to_symbol") or "")
+
+        displayed_pair_rows, omitted_pair_rows = _interesting_pair_rows(
+            pair_rows,
+            selected_pair_row=selected_pair,
+            max_rows_if_action=10,
+            max_rows_if_noop=10,
+        )
+
+        for row in displayed_pair_rows:
+            frm = str(row.get("from_symbol") or "")
+            to = str(row.get("to_symbol") or "")
+            frm_comp = _blend_components(frm) or {}
+            to_comp = _blend_components(to) or {}
+            vetoed = bool(row.get("vetoed"))
+            why = _short_reason(row.get("veto_reason"))
+            is_selected = frm == sel_from and to == sel_to
+
+            frm_text = Text(
+                frm + (" ★" if is_selected else ""),
+                style="bold yellow" if is_selected else ("red" if vetoed else "white"),
+            )
+            to_text = Text(
+                to + (" ★" if is_selected else ""),
+                style="bold green" if is_selected else ("red" if vetoed else "white"),
+            )
+
+            ptbl.add_row(
+                frm_text,
+                Text(
+                    _fmt(frm_comp.get("blended")),
+                    style=_score_style(frm_comp.get("blended")),
+                ),
+                to_text,
+                Text(
+                    _fmt(to_comp.get("blended")),
+                    style=_score_style(to_comp.get("blended")),
+                ),
+                Text(
+                    _fmt(row.get("robust_edge")),
+                    style=_delta_style(row.get("robust_edge"), thr),
+                ),
+                Text(
+                    _fmt(row.get("weighted_robust_edge")),
+                    style=_delta_style(row.get("weighted_robust_edge")),
+                ),
+                Text(
+                    _fmt(row.get("avg_edge")),
+                    style=_delta_style(row.get("avg_edge"), thr),
+                ),
+                Text(
+                    _fmt(_edge_by_h(row, H1)),
+                    style=_delta_style(_edge_by_h(row, H1), 0.0),
+                ),
+                Text(
+                    _fmt(_edge_by_h(row, H5)),
+                    style=_delta_style(_edge_by_h(row, H5), 0.0),
+                ),
+                Text(why, style="bold red" if vetoed else "white"),
+            )
+
+        if omitted_pair_rows > 0:
+            ptbl.add_row(
+                "...",
+                "...",
+                "...",
+                "...",
+                "...",
+                "...",
+                "...",
+                "...",
+                "...",
+                f"{omitted_pair_rows} more pairs omitted",
+            )
+
+        console.print(
+            Panel(
+                ptbl,
+                title="Forecast candidate pairs",
+                border_style="magenta",
+                box=box.ROUNDED,
+            )
+        )
+
+    rows = d.get("candidate_rows") or []
+    if isinstance(rows, list) and rows:
+        tbl = Table(
+            box=box.SIMPLE_HEAVY,
+            show_header=True,
+            header_style="bold cyan",
+            expand=False,
+        )
+        tbl.add_column("Sym", justify="left", no_wrap=True)
+        tbl.add_column("Blend", justify="right", no_wrap=True)
+        tbl.add_column("C", justify="right", no_wrap=True)
+        tbl.add_column("H1", justify="right", no_wrap=True)
+        tbl.add_column("H5", justify="right", no_wrap=True)
+        tbl.add_column("ΔBlend", justify="right", no_wrap=True)
+        tbl.add_column("Thr", justify="right", no_wrap=True)
+        tbl.add_column("Status", justify="left", no_wrap=True)
+
+        def _sort_key(r):
+            status_rank = 0 if str(r.get("status", "")).upper() == "READY" else 1
+            delta_rank = -(_num(r.get("delta_blended")) or -999.0)
+            blend_rank = -(_num(r.get("blended")) or -999.0)
+            return (status_rank, delta_rank, blend_rank, str(r.get("sym", "")))
+
+        for row in sorted(rows, key=_sort_key):
+            sym = str(row.get("sym") or "")
+            is_best = sym == best
+            sym_text = Text(
+                sym + (" ★" if is_best else ""),
+                style="bold cyan" if is_best else "white",
+            )
+            tbl.add_row(
+                sym_text,
+                Text(_fmt(row.get("blended")), style=_score_style(row.get("blended"))),
+                Text(_fmt(row.get("c")), style=_score_style(row.get("c"))),
+                Text(_fmt(row.get("h1")), style=_score_style(row.get("h1"))),
+                Text(_fmt(row.get("h5")), style=_score_style(row.get("h5"))),
+                Text(
+                    _fmt(row.get("delta_blended")),
+                    style=_delta_style(row.get("delta_blended"), thr),
+                ),
+                Text(_fmt(row.get("threshold")), style="cyan"),
+                Text(
+                    str(row.get("status") or "-"),
+                    style=_status_style(row.get("status")),
+                ),
+            )
+
+        console.print(
+            Panel(
+                tbl,
+                title="Forecast candidates",
+                border_style="cyan",
+                box=box.ROUNDED,
+            )
+        )
+
+    return console.export_text(styles=True) + NL
 
 
 def main() -> int:
@@ -632,7 +1652,7 @@ def main() -> int:
                 for r in rows:
                     if isinstance(r, dict) and isinstance(r.get("symbol"), str):
                         sym = r["symbol"].strip().upper()
-                        if sym.startswith("XL") and len(sym) <= 5:
+                        if sym in detail_blocks:
                             held_syms.append(sym)
                 held_syms = sorted(set(held_syms))
         except Exception:
@@ -672,7 +1692,7 @@ def main() -> int:
     #             lines2.append("")
     #             lines2.append(f"  {'Sym':<6}  {'A':>6}  {'B':>6}  {'C':>6}  {'D':>6}  {'E':>6}  {'Total':>8}")
     #             lines2.append("  " + "─" * 62)
-    #             for sym in order_all:
+    #             for sym in overview_order:
     #                 r = by.get(sym)
     #                 if not r:
     #                     continue
@@ -683,24 +1703,8 @@ def main() -> int:
     #         except Exception:
     #             pass
     #
-    # 1b) Overview (expanded universe, totals-only)
-    if inv_syms:
-        try:
-            lines2 = []
-            lines2.append(c("Overview (expanded universe, totals-only)", CYAN))
-            lines2.append(f"{'Sym':<6}  {'Total':>12}")
-            lines2.append("-" * 22)
-            for sym in order_all:
-                u = util.get(sym)
-                if not isinstance(u, float):
-                    continue
-                pct = int(round(u * 100))
-                letter, col = grade_letter(pct)
-                lines2.append(f"{sym:<6}  {pct:>3}% {c(letter, col)}")
-            sys.stdout.write("\n".join(lines2) + "\n\n")
-        except Exception:
-            pass
-
+    # 1b) Overview (expanded universe, totals-only) removed
+    overview_order = list(order_all)
     # 2) Pi Grid
     # OVERVIEW_AE_FROM_SNAPSHOT_V2
     # Rich bordered + colorized A–E totals table from the UI snapshot (cache-only; includes inverses)
@@ -718,6 +1722,9 @@ def main() -> int:
             )
         ).expanduser()
         snap2 = read_json(ui_path2)
+        snap_order2, snap_util2 = _snapshot_order_util(snap2)
+        if snap_order2:
+            overview_order = snap_order2
         data2 = snap2.get("data") if isinstance(snap2, dict) else None
         sec2 = data2.get("sectors") if isinstance(data2, dict) else None
         if isinstance(sec2, list):
@@ -807,7 +1814,6 @@ def main() -> int:
     except Exception:
         pass
     # --- end OVERVIEW_AE_FROM_SNAPSHOT_V2 ---
-    sys.stdout.write(render_pi_grid(order_all, util) + "\n")
 
     # 3) Details for positions (TRI-SCORE ASCII prototype)
 
@@ -835,6 +1841,9 @@ def main() -> int:
     #     except Exception:
     #         pass
     #     # --- end snapshot widgets ---
+    tri_overview = render_overview_triscore(overview_order, held_syms)
+    if tri_overview:
+        sys.stdout.write(tri_overview + chr(10))
 
     sys.stdout.write(
         c("=" * 30 + " Details (your positions) " + "=" * 30, CYAN) + chr(10)

--- a/market_health/market_ui.py
+++ b/market_health/market_ui.py
@@ -18,6 +18,7 @@ from rich.table import Table
 from rich.text import Text
 
 from market_health.engine import SECTORS_DEFAULT, SECTOR_LEADERS, compute_scores
+from market_health.inverse_universe_v1 import load_inverse_pairs
 from market_health.ui_contract_meta import dimension_heading
 
 FORCE_COLOR = bool(
@@ -185,6 +186,29 @@ def load_live_dataset(
     return [build_sector_from_json(obj) for obj in payload]
 
 
+def extend_universe_with_inverses(
+    sectors: list[str], inverse_map_path: str
+) -> tuple[list[str], dict]:
+    loaded = load_inverse_pairs(inverse_map_path)
+    if isinstance(loaded, tuple) and len(loaded) == 2:
+        pairs, status = loaded
+    else:
+        pairs, status = loaded, "ok"
+
+    out = list(sectors)
+    added = 0
+    # include both the long + inverse side if present in map
+    for p in pairs:
+        for sym in (getattr(p, "long", None), getattr(p, "inverse", None)):
+            if isinstance(sym, str):
+                s = sym.strip().upper()
+                if s and s not in out:
+                    out.append(s)
+                    added += 1
+    meta = {"status": status, "pairs": len(pairs), "added": added}
+    return out, meta
+
+
 # ---------- rendering ----------
 def render_header(console: Console, mono: bool = False) -> None:
     ts = dt.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
@@ -208,11 +232,12 @@ def render_header(console: Console, mono: bool = False) -> None:
 
 
 def render_overview(
-    console: Console, rows: List[SectorRow], mono: bool = False
+    console: Console,
+    rows: List[SectorRow],
+    mono: bool = False,
+    title: str = "Overview (A–E totals per sector)",
 ) -> None:
-    tbl = Table(
-        title="Overview (A–E totals per sector)", box=box.SIMPLE_HEAVY, show_lines=False
-    )
+    tbl = Table(title=title, box=box.SIMPLE_HEAVY, show_lines=False)
     tbl.add_column("Sector", justify="left", style="bold cyan")
     for key in "ABCDE":
         tbl.add_column(key, justify="center")
@@ -298,89 +323,80 @@ def _sector_for_symbol(sym: str):
     return None
 
 
+def _rows_to_current_sectors_payload(
+    rows: Optional[List[SectorRow]],
+) -> Optional[List[dict]]:
+    """Convert in-memory SectorRow list into the payload shape used by Tri-Score renderers."""
+    if not rows:
+        return None
+    out: List[dict] = []
+    for r in rows:
+        cats: Dict[str, dict] = {}
+        for k, cat in (r.categories or {}).items():
+            cats[str(k)] = {
+                "checks": [
+                    {"label": c.label, "score": int(c.score)}
+                    for c in (cat.checks or [])
+                ]
+            }
+        out.append({"symbol": r.symbol, "categories": cats})
+    return out
+
+
 def _render_positions_panel(
     console,
     mono: bool = False,
     max_rows: int = 8,
-    sector_style: Optional[Dict[str, str]] = None,
+    sector_style=None,
+    current_rows: Optional[List[SectorRow]] = None,
 ) -> None:
-    """Render a compact positions panel under the Pi Grid (reads ~/.cache/jerboa/positions.v1.json)."""
+    """Render 'My Positions' tri-score panel.
+
+    Prefer ASCII prototype output (matches the 3-digit 0/1/2 cells),
+    fallback to the Rich tri-score renderer.
+    """
+    current_sectors = _rows_to_current_sectors_payload(current_rows)
+
+    # 1) ASCII prototype (preferred)
     try:
-        import json
-        from rich.panel import Panel
-        from rich.table import Table
-        from rich import box
+        from .ui_triscore_ascii import render_positions_triscore_ascii  # type: ignore
 
-        path = os.path.expanduser("~/.cache/jerboa/positions.v1.json")
-        if not os.path.isfile(path):
-            return
-
-        with open(path, "r", encoding="utf-8") as f:
-            data = json.load(f)
-
-        positions = data.get("positions") or []
-        source = data.get("source") or {}
-        src_type = source.get("type") or "unknown"
-
-        if not positions:
-            msg = (
-                "No positions imported yet.\n"
-                "Export a Thinkorswim Position Statement CSV to:\n"
-                "  ~/imports/thinkorswim\n"
-                "Then run:\n"
-                "  jerboa-market-health-positions-refresh"
+        try:
+            txt = render_positions_triscore_ascii(
+                mono=mono,
+                max_rows=max_rows,
+                sector_style=sector_style,
+                current_sectors=current_sectors,
             )
-            if mono:
-                console.print(
-                    "Positions: none (run jerboa-market-health-positions-refresh after exporting ToS CSV)"
-                )
-            else:
-                console.print(
-                    Panel.fit(msg, title=f"Positions ({src_type})", border_style="cyan")
-                )
+        except TypeError:
+            try:
+                txt = render_positions_triscore_ascii(mono=mono)
+            except TypeError:
+                txt = render_positions_triscore_ascii()
+        if txt:
+            console.print(str(txt).rstrip())
             return
-
-        t = Table(box=box.SIMPLE, show_header=True, header_style="bold")
-        t.add_column("Sym")
-        t.add_column("Acct")
-        t.add_column("Type")
-        t.add_column("Qty", justify="right")
-        t.add_column("Details")
-
-        for p in positions[:max_rows]:
-            sym = str(p.get("symbol", "?"))
-            sym_cell = Text(sym)
-            sec = _sector_for_symbol(sym)
-            st = (sector_style or {}).get(sec or "", "")
-            if st and ((not mono) or FORCE_COLOR):
-                sym_cell.stylize(st)
-            acct = str(p.get("account_label") or "")
-            typ = str(p.get("asset_type", "?"))
-            qty = str(p.get("qty", ""))
-
-            details = ""
-            if typ == "option":
-                details = f"{p.get('expiry', '?')}  {p.get('strike', '?')}  {p.get('right', '?')}"
-
-            t.add_row(sym_cell, acct, typ, qty, details)
-
-        title = f"Positions ({len(positions)})  •  source={src_type}"
-        if mono:
-            console.print(title)
-            for p in positions[:max_rows]:
-                sym = str(p.get("symbol", "?"))
-                typ = str(p.get("asset_type", "?"))
-                qty = str(p.get("qty", ""))
-                acct = str(p.get("account_label") or "")
-                det = ""
-                if typ == "option":
-                    det = f"{p.get('expiry', '?')} {p.get('strike', '?')} {p.get('right', '?')}"
-                console.print(f"- {sym}  acct={acct}  {typ}  qty={qty}  {det}".rstrip())
-        else:
-            console.print(Panel(t, title=title, border_style="cyan"))
-
     except Exception:
-        # Never break the widget for positions issues
+        pass
+
+    # 2) Rich renderer fallback
+    try:
+        from .ui_triscore import render_positions_triscore
+
+        try:
+            out = render_positions_triscore(
+                mono=mono,
+                max_rows=max_rows,
+                sector_style=sector_style,
+                current_sectors=current_sectors,
+            )
+        except TypeError:
+            out = render_positions_triscore(mono=mono)
+        if out is not None:
+            console.print(out)
+            return
+    except Exception as e:
+        console.print(f"[yellow]Tri-Score panel unavailable: {e}[/yellow]")
         return
 
 
@@ -449,7 +465,9 @@ def render_pi_grid(
         r.symbol: pct_style((r.total / MAX_TOTAL) if MAX_TOTAL else 0.0, mono)
         for r in rows
     }
-    _render_positions_panel(console, mono=mono, sector_style=style_by_sector)
+    _render_positions_panel(
+        console, mono=mono, sector_style=style_by_sector, current_rows=rows
+    )
 
 
 def _is_ui_contract(obj: object) -> bool:
@@ -464,23 +482,56 @@ def _is_ui_contract(obj: object) -> bool:
     return ("sectors" in d) and ("state" in d) and ("positions" in d)
 
 
-def _rows_from_ui_contract(contract: dict, sectors_filter: list[str] | None) -> list:
-    d = contract.get("data") or {}
-    sectors = d.get("sectors")
+def _rows_from_ui_contract(
+    contract: dict, sectors_filter: list[str] | None
+) -> list[SectorRow]:
+    """Extract SectorRow list from a UI contract (market_health.ui.v1.json).
+
+    Supports:
+      - contract.data.sectors = [ {...}, ... ]
+      - contract.data.sectors.sectors = [ {...}, ... ]
+      - contract.data.sectors.rows = [ {...}, ... ]
+    """
+    data = contract.get("data") or {}
+    sectors = data.get("sectors")
+
+    # Unwrap common nested shapes
+    if isinstance(sectors, dict):
+        for k in ("sectors", "rows", "data"):
+            v = sectors.get(k)
+            if isinstance(v, list):
+                sectors = v
+                break
+
     if not isinstance(sectors, list):
         return []
-    rows = [build_sector_from_json(x) for x in sectors if isinstance(x, dict)]
+
     if sectors_filter:
-        keep = set(sectors_filter)
-        rows = [r for r in rows if getattr(r, "symbol", None) in keep]
-    rows.sort(key=lambda r: getattr(r, "total", 0), reverse=True)
-    return rows
+        want = {s.upper() for s in sectors_filter}
+        sectors = [
+            x
+            for x in sectors
+            if isinstance(x, dict) and str(x.get("symbol", "")).upper() in want
+        ]
+
+    return [build_sector_from_json(x) for x in sectors if isinstance(x, dict)]
 
 
 def parse_args():
     p = argparse.ArgumentParser(description="Market Health – Sector Union (Rich UI)")
     p.add_argument(
         "--sectors", nargs="+", default=SECTORS_DEFAULT, help="Tickers to include"
+    )
+    p.add_argument(
+        "--inverse-map",
+        type=str,
+        default=os.path.expanduser("~/.cache/jerboa/inverse_universe.v1.json"),
+        help="Inverse ETF map used to extend the UI universe.",
+    )
+    p.add_argument(
+        "--no-inverses",
+        action="store_true",
+        help="Disable auto-including inverse ETFs in the UI.",
     )
     p.add_argument(
         "--topk", type=int, default=3, help="How many top sectors to expand in details"
@@ -534,7 +585,13 @@ def main():
 
     def load_rows() -> List[SectorRow]:
         if args.demo:
-            return build_demo_dataset(args.sectors, seed=42)
+            sectors = list(args.sectors)
+            if not getattr(args, "no_inverses", False):
+                sectors, meta = extend_universe_with_inverses(
+                    sectors, getattr(args, "inverse_map", "")
+                )
+                args._inverse_meta = meta
+            return build_demo_dataset(sectors, seed=42)
         if args.json_path:
             try:
                 # If json_path is a UI contract (market_health.ui.v1.json), load rows from contract.data.sectors
@@ -551,7 +608,13 @@ def main():
                 return []
         # live from engine
         try:
-            return load_live_dataset(args.sectors, args.period, args.interval, args.ttl)
+            sectors = list(args.sectors)
+            if not getattr(args, "no_inverses", False):
+                sectors, meta = extend_universe_with_inverses(
+                    sectors, getattr(args, "inverse_map", "")
+                )
+                args._inverse_meta = meta
+            return load_live_dataset(sectors, args.period, args.interval, args.ttl)
         except Exception as e:
             console.print(f"[red]Failed to compute live scores: {e}[/red]")
             return []
@@ -579,7 +642,14 @@ def main():
                 rec_lines = _recommendation_lines_from_contract(contract)
                 if rec_lines:
                     console.print(Panel("\n".join(rec_lines), title="Recommendations"))
-            render_overview(console, rows, mono=args.mono)
+            meta = getattr(args, "_inverse_meta", {})
+            inv_added = meta.get("added", 0) if isinstance(meta, dict) else 0
+            title = (
+                "Overview (A–E totals per sector; incl inverses)"
+                if inv_added
+                else "Overview (A–E totals per sector)"
+            )
+            render_overview(console, rows, mono=args.mono, title=title)
             render_details(console, rows, top_k=args.topk, mono=args.mono)
     else:
         if args.json_path:
@@ -597,10 +667,6 @@ def main():
             return
     else:
         render_once()
-
-
-if __name__ == "__main__":
-    main()
 
 
 def _recommendation_lines_from_contract(contract: dict) -> list[str]:
@@ -700,3 +766,7 @@ def _recommendation_lines_from_contract(contract: dict) -> list[str]:
         val = diag.get("edge", diag.get("delta_utility"))
         lines.append(f"Edge ({dm}): {val}")
     return lines
+
+
+if __name__ == "__main__":
+    main()

--- a/market_health/ui_triscore.py
+++ b/market_health/ui_triscore.py
@@ -1,0 +1,277 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+# ANSI (terminal-only; disable via mono=True)
+RESET = "\x1b[0m"
+DIM = "\x1b[2m"
+RED = "\x1b[31m"
+YEL = "\x1b[33m"
+GRN = "\x1b[32m"
+
+CAT_KEYS = ("A", "B", "C", "D", "E")
+CAT_LABELS = {
+    "A": "Announcements",
+    "B": "Backdrop",
+    "C": "Crowding",
+    "D": "Danger",
+    "E": "Environment",
+}
+
+
+def _pal(mono: bool) -> Dict[str, str]:
+    if mono:
+        return {"RESET": "", "DIM": "", "RED": "", "YEL": "", "GRN": ""}
+    return {"RESET": RESET, "DIM": DIM, "RED": RED, "YEL": YEL, "GRN": GRN}
+
+
+def _load_json(p: Path) -> Dict[str, Any]:
+    try:
+        if p.exists():
+            return json.loads(p.read_text(encoding="utf-8"))
+    except Exception:
+        pass
+    return {}
+
+
+def _looks_like_payload(d: Dict[str, Any]) -> bool:
+    if "categories" in d and isinstance(d["categories"], dict):
+        c = d["categories"]
+        return all(k in c for k in CAT_KEYS)
+    return all(k in d for k in CAT_KEYS)
+
+
+def _find_payload(obj: Any, sym: str) -> Optional[Dict[str, Any]]:
+    sym = sym.upper()
+    if isinstance(obj, dict):
+        s = obj.get("symbol")
+        if isinstance(s, str) and s.strip().upper() == sym and _looks_like_payload(obj):
+            return obj
+        for v in obj.values():
+            got = _find_payload(v, sym)
+            if got:
+                return got
+    elif isinstance(obj, list):
+        for v in obj:
+            got = _find_payload(v, sym)
+            if got:
+                return got
+    return None
+
+
+def _cat_node(payload: Dict[str, Any], cat: str) -> Any:
+    if "categories" in payload and isinstance(payload["categories"], dict):
+        return payload["categories"].get(cat)
+    return payload.get(cat)
+
+
+def _checks(payload: Optional[Dict[str, Any]], cat: str) -> List[Dict[str, Any]]:
+    if not isinstance(payload, dict):
+        return []
+    node = _cat_node(payload, cat)
+    if isinstance(node, dict) and isinstance(node.get("checks"), list):
+        return [c for c in node["checks"] if isinstance(c, dict)]
+    if isinstance(node, list):
+        return [c for c in node if isinstance(c, dict)]
+    return []
+
+
+def _sum_scores(chks: List[Dict[str, Any]]) -> int:
+    t = 0
+    for c in chks:
+        sc = c.get("score")
+        if isinstance(sc, (int, float)):
+            t += int(sc)
+    return t
+
+
+def _c_for_digit(v: Optional[int], pal: Dict[str, str]) -> str:
+    if v is None:
+        return pal["DIM"]
+    if v >= 2:
+        return pal["GRN"]
+    if v == 1:
+        return pal["YEL"]
+    return pal["RED"]
+
+
+def _digit(x: Any, pal: Dict[str, str]) -> str:
+    if isinstance(x, bool):
+        x = int(x)
+    if not isinstance(x, (int, float)):
+        return f"{pal['DIM']}-{pal['RESET']}"
+    v = int(x)
+    if v < 0 or v > 2:
+        return f"{pal['DIM']}?{pal['RESET']}"
+    return f"{_c_for_digit(v, pal)}{v}{pal['RESET']}"
+
+
+def _tri(c: Any, h1: Any, h5: Any, pal: Dict[str, str]) -> str:
+    return f"{_digit(c, pal)}{_digit(h1, pal)}{_digit(h5, pal)}"
+
+
+def _pct_str(sum_score: int, denom: int, pal: Dict[str, str]) -> str:
+    p = (float(sum_score) / float(denom)) if denom > 0 else 0.0
+    col = pal["GRN"] if p >= 0.60 else (pal["YEL"] if p >= 0.40 else pal["RED"])
+    return f"{col}{int(round(p * 100)):>3d}%{pal['RESET']}"
+
+
+def _payload_from_forecast(
+    fs_doc: Dict[str, Any], sym: str, H: int
+) -> Optional[Dict[str, Any]]:
+    scores = fs_doc.get("scores")
+    if not isinstance(scores, dict):
+        return None
+    by_h = scores.get(sym)
+    if not isinstance(by_h, dict):
+        return None
+    if str(H) in by_h and isinstance(by_h[str(H)], dict):
+        return by_h[str(H)]
+    if H in by_h and isinstance(by_h[H], dict):
+        return by_h[H]
+    for k, v in by_h.items():
+        if str(k) == str(H) and isinstance(v, dict):
+            return v
+    return None
+
+
+def render_positions_triscore(
+    *,
+    cache_dir: Optional[str] = None,
+    mono: bool = False,
+    max_rows: int = 8,
+    sector_style=None,
+    current_sectors: Optional[List[Dict[str, Any]]] = None,
+) -> str:
+    """
+    Read-only Tri-Score positions panel.
+    Each cell is C/H1/H5 where:
+      - C  = current health scoring (market_health.ui.v1.json OR market_health.sectors.json)
+      - H1 = forecast horizon 1 (forecast_scores.v1.json)
+      - H5 = forecast horizon 5 (forecast_scores.v1.json)
+    Returns a string (no printing, no cache writes).
+    """
+    pal = _pal(mono)
+
+    cd = Path(cache_dir) if cache_dir else Path(os.path.expanduser("~/.cache/jerboa"))
+    pos_p = cd / "positions.v1.json"
+    ui_p = cd / "market_health.ui.v1.json"
+    sect_p = cd / "market_health.sectors.json"
+    fs_p = cd / "forecast_scores.v1.json"
+
+    pos_doc = _load_json(pos_p)
+    fs_doc = _load_json(fs_p)
+    cur_doc = (
+        {"sectors": current_sectors}
+        if current_sectors is not None
+        else (_load_json(ui_p) or _load_json(sect_p))
+    )
+
+    held: List[str] = []
+    unmapped: List[str] = []
+    pos_rows = pos_doc.get("positions") or []
+    if isinstance(pos_rows, dict):
+        pos_rows = pos_rows.get("positions") or []
+
+    for row in pos_rows:
+        if isinstance(row, dict) and isinstance(row.get("symbol"), str):
+            sym = row["symbol"].strip().upper()
+            if sym.startswith("XL") and len(sym) <= 5:
+                held.append(sym)
+            else:
+                unmapped.append(sym)
+    held = sorted(set(held))
+    if isinstance(max_rows, int) and max_rows > 0:
+        held = held[:max_rows]
+
+    if not held:
+        msg = "No positions detected yet (or no sector ETF positions mapped)."
+        if unmapped:
+            msg += f" Unmapped symbols: {', '.join(sorted(set(unmapped)))}"
+        return msg
+
+    # choose horizons: prefer 1 and 5 if present, else min/max
+    H1, H5 = 1, 5
+    horizons = fs_doc.get("horizons_trading_days")
+    if isinstance(horizons, list):
+        hs: List[int] = []
+        for h in horizons:
+            try:
+                hs.append(int(h))
+            except Exception:
+                pass
+        hs = sorted(set(hs))
+        if hs:
+            H1 = 1 if 1 in hs else hs[0]
+            H5 = 5 if 5 in hs else hs[-1]
+
+    denom_all = len(CAT_KEYS) * 6 * 2  # 5 cats * 6 checks * max score 2
+
+    lines: List[str] = []
+    lines.append("My Positions — Tri-Score (read-only)")
+    lines.append("Each cell shows C/H1/H5 (digits 0=bad, 1=mixed, 2=good).")
+    lines.append(f"cache={cd}")
+    lines.append(f"horizons: H{H1} and H{H5}")
+    lines.append("")
+
+    for sym in held:
+        cur_payload = _find_payload(cur_doc, sym)
+        h1_payload = _payload_from_forecast(fs_doc, sym, H1)
+        h5_payload = _payload_from_forecast(fs_doc, sym, H5)
+
+        cur_sum = h1_sum = h5_sum = 0
+        for cat in CAT_KEYS:
+            cur_sum += _sum_scores(_checks(cur_payload, cat))
+            h1_sum += _sum_scores(_checks(h1_payload, cat))
+            h5_sum += _sum_scores(_checks(h5_payload, cat))
+
+        lines.append(
+            f"──────────────────────── Tri-Score – {sym} ────────────────────────"
+        )
+        lines.append(
+            f"Totals (C/H{H1}/H{H5}):  "
+            f"{_pct_str(cur_sum, denom_all, pal)}  "
+            f"{_pct_str(h1_sum, denom_all, pal)}  "
+            f"{_pct_str(h5_sum, denom_all, pal)}"
+        )
+        lines.append("")
+        lines.append(f"{'Factor':<18}  1   2   3   4   5   6   Tot(C/H{H1}/H{H5})")
+        lines.append(
+            "--------------------------------------------------------------------"
+        )
+
+        for cat in CAT_KEYS:
+            cur = _checks(cur_payload, cat)
+            h1 = _checks(h1_payload, cat)
+            h5 = _checks(h5_payload, cat)
+
+            cells: List[str] = []
+            cur_cat = h1_cat = h5_cat = 0
+            for i in range(6):
+                c_sc = cur[i].get("score") if i < len(cur) else None
+                h1_sc = h1[i].get("score") if i < len(h1) else None
+                h5_sc = h5[i].get("score") if i < len(h5) else None
+                cells.append(_tri(c_sc, h1_sc, h5_sc, pal))
+                if isinstance(c_sc, (int, float)):
+                    cur_cat += int(c_sc)
+                if isinstance(h1_sc, (int, float)):
+                    h1_cat += int(h1_sc)
+                if isinstance(h5_sc, (int, float)):
+                    h5_cat += int(h5_sc)
+
+            label = f"{cat} {CAT_LABELS.get(cat, cat)}"
+            lines.append(
+                f"{label:<18}  " + " ".join(cells) + f"  {cur_cat}/{h1_cat}/{h5_cat}"
+            )
+
+        if unmapped:
+            lines.append("")
+            lines.append(
+                f"Unmapped (not sector ETFs): {', '.join(sorted(set(unmapped)))}"
+            )
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"

--- a/market_health/ui_triscore_ascii.py
+++ b/market_health/ui_triscore_ascii.py
@@ -1,0 +1,423 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+CACHE = Path(os.path.expanduser("~/.cache/jerboa"))
+POS_P = CACHE / "positions.v1.json"
+REC_P = CACHE / "recommendations.v1.json"
+UI_P = CACHE / "market_health.ui.v1.json"
+SECT_P = CACHE / "market_health.sectors.json"
+FS_P = CACHE / "forecast_scores.v1.json"
+
+# ---------- ANSI ----------
+RESET = "\x1b[0m"
+DIM = "\x1b[2m"
+BOLD = "\x1b[1m"
+RED = "\x1b[31m"
+YEL = "\x1b[33m"
+GRN = "\x1b[32m"
+
+CAT_KEYS = ("A", "B", "C", "D", "E")
+
+
+def _c_for_digit(v: Optional[int]) -> str:
+    if v is None:
+        return DIM
+    if v >= 2:
+        return GRN
+    if v == 1:
+        return YEL
+    return RED
+
+
+def _digit(x: Any) -> str:
+    if isinstance(x, bool):
+        x = int(x)
+    if not isinstance(x, (int, float)):
+        return f"{DIM}-{RESET}"
+    v = int(x)
+    if v < 0 or v > 2:
+        return f"{DIM}?{RESET}"
+    return f"{_c_for_digit(v)}{v}{RESET}"
+
+
+def tri(c: Any, h1: Any, h5: Any) -> str:
+    return f"{_digit(c)}{_digit(h1)}{_digit(h5)}"
+
+
+def load(p: Path) -> Dict[str, Any]:
+    try:
+        if p.exists():
+            return json.loads(p.read_text(encoding="utf-8"))
+    except Exception:
+        pass
+    return {}
+
+
+def pct(sum_score: Optional[int], denom: int) -> Optional[float]:
+    if sum_score is None or denom <= 0:
+        return None
+    return float(sum_score) / float(denom)
+
+
+def pct_str(p: Optional[float]) -> str:
+    if p is None:
+        return f"{DIM}n/a{RESET}"
+    col = GRN if p >= 0.60 else (YEL if p >= 0.40 else RED)
+    return f"{col}{int(round(p * 100)):>3d}%{RESET}"
+
+
+# ---------- payload discovery ----------
+def looks_like_payload(d: Dict[str, Any]) -> bool:
+    if "categories" in d and isinstance(d["categories"], dict):
+        c = d["categories"]
+        return all(k in c for k in CAT_KEYS)
+    return all(k in d for k in CAT_KEYS)
+
+
+def find_payload_for_symbol(obj: Any, sym: str) -> Optional[Dict[str, Any]]:
+    sym_u = sym.upper()
+    if isinstance(obj, dict):
+        s = obj.get("symbol")
+        if (
+            isinstance(s, str)
+            and s.strip().upper() == sym_u
+            and looks_like_payload(obj)
+        ):
+            return obj
+        for v in obj.values():
+            got = find_payload_for_symbol(v, sym_u)
+            if got:
+                return got
+    elif isinstance(obj, list):
+        for v in obj:
+            got = find_payload_for_symbol(v, sym_u)
+            if got:
+                return got
+    return None
+
+
+def find_any_payload(obj: Any) -> Optional[Dict[str, Any]]:
+    if isinstance(obj, dict):
+        if looks_like_payload(obj):
+            return obj
+        for v in obj.values():
+            got = find_any_payload(v)
+            if got:
+                return got
+    elif isinstance(obj, list):
+        for v in obj:
+            got = find_any_payload(v)
+            if got:
+                return got
+    return None
+
+
+def cat_node(payload: Dict[str, Any], cat: str) -> Any:
+    if "categories" in payload and isinstance(payload["categories"], dict):
+        return payload["categories"].get(cat)
+    return payload.get(cat)
+
+
+def checks(payload: Optional[Dict[str, Any]], cat: str) -> List[Dict[str, Any]]:
+    if not isinstance(payload, dict):
+        return []
+    node = cat_node(payload, cat)
+    if isinstance(node, dict) and isinstance(node.get("checks"), list):
+        return [c for c in node["checks"] if isinstance(c, dict)]
+    if isinstance(node, list):
+        return [c for c in node if isinstance(c, dict)]
+    return []
+
+
+def score_at(chks: List[Dict[str, Any]], i: int) -> Optional[int]:
+    if i < 0 or i >= len(chks):
+        return None
+    sc = chks[i].get("score")
+    if isinstance(sc, (int, float)):
+        return int(sc)
+    return None
+
+
+def sum_checks(chks: List[Dict[str, Any]]) -> int:
+    t = 0
+    for c in chks[:6]:
+        sc = c.get("score")
+        if isinstance(sc, (int, float)):
+            t += int(sc)
+    return t
+
+
+def sum_payload(payload: Optional[Dict[str, Any]]) -> Optional[int]:
+    if not isinstance(payload, dict):
+        return None
+    tot = 0
+    for cat in CAT_KEYS:
+        tot += sum_checks(checks(payload, cat))
+    return tot
+
+
+def extract_held_symbols(pos_doc: Dict[str, Any]) -> List[str]:
+    # best-effort: extract symbol-like fields anywhere (Schwab/TOS schemas vary)
+    out: List[str] = []
+    KEYS = {
+        "symbol",
+        "ticker",
+        "sym",
+        "underlying",
+        "underlyingSymbol",
+        "tickerSymbol",
+        "rootSymbol",
+    }
+
+    def maybe_add(v: Any) -> None:
+        if isinstance(v, str):
+            t = v.strip().upper()
+            if 1 <= len(t) <= 10 and t.replace("-", "").replace(".", "").isalnum():
+                out.append(t)
+
+    def walk(x: Any) -> None:
+        if isinstance(x, dict):
+            for k, v in x.items():
+                if k in KEYS:
+                    maybe_add(v)
+                # common nested instrument shapes
+                if k.lower() in (
+                    "instrument",
+                    "security",
+                    "asset",
+                    "position",
+                    "holding",
+                ) and isinstance(v, (dict, list)):
+                    walk(v)
+                if isinstance(v, (dict, list)):
+                    walk(v)
+        elif isinstance(x, list):
+            for v in x:
+                walk(v)
+
+    walk(pos_doc)
+
+    # stable unique
+    seen = set()
+    uniq: List[str] = []
+    for sym in out:
+        if sym not in seen:
+            seen.add(sym)
+            uniq.append(sym)
+    return uniq
+
+
+def extract_sector_universe(ui_doc: Dict[str, Any]) -> List[str]:
+    # heuristic: find largest list of dict rows that contain "symbol"/"sec"/"ticker"
+    candidates: List[List[Dict[str, Any]]] = []
+
+    def walk(x: Any) -> None:
+        if isinstance(x, dict):
+            for k, v in x.items():
+                if (
+                    k in ("rows", "sectors", "sector_rows")
+                    and isinstance(v, list)
+                    and v
+                    and isinstance(v[0], dict)
+                ):
+                    if any(key in v[0] for key in ("symbol", "sec", "ticker")):
+                        candidates.append(v)  # type: ignore[arg-type]
+                walk(v)
+        elif isinstance(x, list):
+            for v in x:
+                walk(v)
+
+    walk(ui_doc)
+    rows = max(candidates, key=len) if candidates else []
+    syms: List[str] = []
+    for r in rows:
+        s = None
+        for k in ("symbol", "sec", "ticker"):
+            if isinstance(r.get(k), str):
+                s = r[k].strip().upper()
+                break
+        if s:
+            syms.append(s)
+    return sorted(set(syms))
+
+
+def get_horizons(fs_doc: Dict[str, Any]) -> Tuple[int, int]:
+    hs = fs_doc.get("horizons_trading_days")
+    vals: List[int] = []
+    if isinstance(hs, list):
+        for h in hs:
+            try:
+                vals.append(int(h))
+            except Exception:
+                pass
+    vals = sorted(set(vals))
+    if 1 in vals and 5 in vals:
+        return 1, 5
+    if len(vals) >= 2:
+        return vals[0], vals[1]
+    if len(vals) == 1:
+        return vals[0], vals[0]
+    return 1, 5
+
+
+def current_payload(
+    sym: str, sect_doc: Dict[str, Any], ui_doc: Dict[str, Any]
+) -> Optional[Dict[str, Any]]:
+    # Snapshot-first: prefer UI contract so C matches Overview/Grid snapshot.
+    got = find_payload_for_symbol(ui_doc, sym)
+    if got:
+        return got
+    got = find_payload_for_symbol(sect_doc, sym)
+    if got:
+        return got
+    return None
+
+
+def forecast_payload(
+    sym: str, H: int, fs_doc: Dict[str, Any]
+) -> Optional[Dict[str, Any]]:
+    scores = fs_doc.get("scores")
+    if not isinstance(scores, dict):
+        return None
+    by_h = scores.get(sym)
+    if not isinstance(by_h, dict):
+        return None
+    raw = by_h.get(str(H), by_h.get(H))
+    if raw is None:
+        return None
+    if isinstance(raw, dict) and looks_like_payload(raw):
+        return raw
+    return find_any_payload(raw)
+
+
+def render_positions_triscore_ascii(
+    *,
+    cache_dir: Optional[str] = None,
+    mono: bool = False,
+    max_rows: int = 8,
+    sector_style=None,
+    current_sectors: Optional[List[Dict[str, Any]]] = None,
+) -> str:
+    cd = Path(cache_dir) if cache_dir else CACHE
+    pos_doc = load(cd / "positions.v1.json")
+    fs_doc = load(cd / "forecast_scores.v1.json")
+
+    # Snapshot-first: if ui_doc is a UI contract, prefer embedded positions/forecast
+    # so every widget uses the same payload (no mixed timers).
+    try:
+        _ui = load(cd / "market_health.ui.v1.json")
+        data = _ui.get("data") if isinstance(_ui, dict) else None
+        if isinstance(data, dict):
+            if "positions" in data:
+                pos_doc = data.get("positions") or pos_doc
+            if "forecast_scores" in data:
+                fs_doc = data.get("forecast_scores") or fs_doc
+            # if sectors.json is older, we still prefer ui_doc first (current_payload handles this)
+    except Exception:
+        pass
+    if current_sectors is not None:
+        ui_doc: Dict[str, Any] = {"sectors": current_sectors}
+        sect_doc: Dict[str, Any] = {"sectors": current_sectors}
+    else:
+        ui_doc = load(cd / "market_health.ui.v1.json")
+        sect_doc = load(cd / "market_health.sectors.json")
+
+    held = extract_held_symbols(pos_doc)
+    sector_universe = set(extract_sector_universe(ui_doc))
+
+    sector_held = [s for s in held if s in sector_universe]
+    unmapped = [s for s in held if s not in sector_universe]
+
+    sym_filter = (os.environ.get("SYM") or "").strip().upper()
+    if sym_filter:
+        sector_held = [s for s in sector_held if s == sym_filter]
+        unmapped = [s for s in unmapped if s == sym_filter]
+
+    if isinstance(max_rows, int) and max_rows > 0:
+        sector_held = sector_held[:max_rows]
+
+    h1, h5 = get_horizons(fs_doc)
+
+    lines: List[str] = []
+    lines.append("My Positions — Tri-Score Prototype (read-only)")
+    lines.append("Each cell shows C/H1/H5 (digits 0=red, 1=yellow, 2=green).")
+    lines.append(f"cache={cd}")
+    lines.append(f"horizons: H1={h1}  H5={h5}")
+    lines.append("")
+
+    # If no sector-held symbols, still show unmapped note
+    for sym in sector_held:
+        cur = current_payload(sym, sect_doc, ui_doc)
+        f1 = forecast_payload(sym, h1, fs_doc)
+        f5 = forecast_payload(sym, h5, fs_doc)
+
+        cur_sum = sum_payload(cur)
+        f1_sum = sum_payload(f1)
+        f5_sum = sum_payload(f5)
+
+        denom = 60  # 5 cats * 6 checks * max score 2
+        lines.append(
+            f"== {sym} ==  Totals (C/H1/H5):  {pct_str(pct(cur_sum, denom))}  {pct_str(pct(f1_sum, denom))}  {pct_str(pct(f5_sum, denom))}"
+        )
+        lines.append("")
+        lines.append(
+            f"{'Factor':<18}  {'1':>3} {'2':>3} {'3':>3} {'4':>3} {'5':>3} {'6':>3}   Tot(C/H1/H5)"
+        )
+        lines.append("-" * 68)
+
+        for cat, name in [
+            ("A", "Announcements"),
+            ("B", "Backdrop"),
+            ("C", "Crowding"),
+            ("D", "Danger"),
+            ("E", "Environment"),
+        ]:
+            c_ch = checks(cur, cat)
+            h1_ch = checks(f1, cat)
+            h5_ch = checks(f5, cat)
+
+            cells = []
+            for i in range(6):
+                cells.append(
+                    tri(score_at(c_ch, i), score_at(h1_ch, i), score_at(h5_ch, i))
+                )
+
+            c_tot = sum_checks(c_ch)
+            h1_tot = sum_checks(h1_ch)
+            h5_tot = sum_checks(h5_ch)
+
+            left = f"{cat} {name}"
+            lines.append(
+                f"{left:<18}  "
+                + " ".join(f"{c:>3}" for c in cells)
+                + f"  {c_tot}/{h1_tot}/{h5_tot}"
+            )
+
+        lines.append("")
+        if unmapped:
+            lines.append(
+                f"{DIM}Unmapped (not sector ETFs): {', '.join(unmapped)}{RESET}"
+            )
+        lines.append("")
+
+    if not sector_held:
+        if unmapped:
+            lines.append(
+                f"{DIM}Unmapped (not sector ETFs): {', '.join(unmapped)}{RESET}"
+            )
+        else:
+            lines.append(f"{DIM}No sector ETF positions detected.{RESET}")
+        lines.append("")
+
+    lines.append(
+        f"{DIM}Note:{RESET} C digit comes from current health scoring; H1/H5 digits come from forecast_scores.v1.json."
+    )
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    print(render_positions_triscore_ascii())

--- a/scripts/jerboa/bin/jerboa-market-health-refresh-all
+++ b/scripts/jerboa/bin/jerboa-market-health-refresh-all
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-PY="/root/market-health-cli/.venv/bin/python"
 set -Eeuo pipefail
 
 FORCE=0
@@ -14,6 +13,7 @@ done
 ENV_JSON="${HOME}/.cache/jerboa/environment.v1.json"
 SECT_JSON="${HOME}/.cache/jerboa/market_health.sectors.json"
 POS_JSON="${HOME}/.cache/jerboa/positions.v1.json"
+FS_JSON="${HOME}/.cache/jerboa/forecast_scores.v1.json"
 REC_JSON="${HOME}/.cache/jerboa/recommendations.v1.json"
 
 LOCKDIR="${HOME}/.cache/jerboa/locks"
@@ -24,7 +24,6 @@ mkdir -p "$LOCKDIR" "$STATEDIR"
 LOCK="${LOCKDIR}/market_health_refresh_all.lock"
 exec 9>"$LOCK"
 if ! flock -n 9; then
-  # Record lock contention (useful if timer cadence is too tight)
   python3 - <<'PY'
 import json, os
 from datetime import datetime, timezone
@@ -32,51 +31,84 @@ p = os.path.expanduser("~/.cache/jerboa/state/market_health_refresh_all.state.js
 os.makedirs(os.path.dirname(p), exist_ok=True)
 state = {}
 try:
-  state = json.load(open(p, "r", encoding="utf-8"))
+    state = json.load(open(p, "r", encoding="utf-8"))
 except Exception:
-  state = {}
+    state = {}
 state.update({
-  "schema": "jerboa.market_health_refresh_all.state.v1",
-  "ts": datetime.now(timezone.utc).isoformat(timespec="seconds"),
-  "status": "skipped",
-  "reason": "lock-busy",
+    "schema": "jerboa.market_health_refresh_all.state.v1",
+    "ts": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+    "status": "skipped",
+    "reason": "lock-busy",
 })
 with open(p, "w", encoding="utf-8") as f:
-  json.dump(state, f, indent=2, sort_keys=True); f.write("\n")
+    json.dump(state, f, indent=2, sort_keys=True)
+    f.write("\n")
 PY
   exit 0
 fi
 
 mtime() { stat -c %Y "$1" 2>/dev/null || echo 0; }
+
+POS_MAX_AGE_MINUTES="${JERBOA_POSITIONS_MAX_AGE_MINUTES:-15}"
+is_stale_minutes() {
+  local p="$1"
+  local max_min="$2"
+  [ "${max_min:-0}" -le 0 ] && return 1
+  local ts
+  ts="$(mtime "$p")"
+  [ "$ts" -le 0 ] && return 0
+  local now
+  now="$(date +%s)"
+  [ $(( now - ts )) -gt $(( max_min * 60 )) ]
+}
+
+pos_stale=0
+if is_stale_minutes "$POS_JSON" "$POS_MAX_AGE_MINUTES"; then
+  pos_stale=1
+fi
+
+
 b_env="$(mtime "$ENV_JSON")"
 b_sect="$(mtime "$SECT_JSON")"
 b_pos="$(mtime "$POS_JSON")"
+b_fs="$(mtime "$FS_JSON")"
 b_rec="$(mtime "$REC_JSON")"
 
 pos_rc=0
 mkt_rc=0
+fs_rc=0
 rec_rc=0
 
-# Positions refresh (prefer existing positions.v1.json unless forced or CSV provided)
 if [ "${ARGS[0]:-}" = "--csv" ] && [ -n "${ARGS[1]:-}" ]; then
   "${HOME}/bin/jerboa-market-health-positions-refresh" --csv "${ARGS[1]}" || pos_rc=$?
-elif [ "$FORCE" -eq 1 ] || [ ! -s "$POS_JSON" ] || [ "${JERBOA_POSITIONS_ALWAYS_REFRESH:-0}" = "1" ]; then
+elif [ "$FORCE" -eq 1 ] || [ ! -s "$POS_JSON" ] || [ "${JERBOA_POSITIONS_ALWAYS_REFRESH:-0}" = "1" ] || [ "$pos_stale" -eq 1 ]; then
   "${HOME}/bin/jerboa-market-health-positions-refresh" || pos_rc=$?
 else
-  # positions.v1.json already exists and is non-empty; skip noisy discovery refresh
   pos_rc=0
 fi
 
-# Market refresh (safe arg passing)
 if [ "$FORCE" -eq 1 ]; then
   JERBOA_SUPPRESS_BREADCRUMBS=1 "${HOME}/bin/jerboa-market-health-refresh" --force "${ARGS[@]}" || mkt_rc=$?
 else
   JERBOA_SUPPRESS_BREADCRUMBS=1 "${HOME}/bin/jerboa-market-health-refresh" "${ARGS[@]}" || mkt_rc=$?
 fi
 
+if [ -x "${HOME}/bin/jerboa-market-health-forecast-scores-refresh" ]; then
+  "${HOME}/bin/jerboa-market-health-forecast-scores-refresh" --quiet >/dev/null || fs_rc=$?
+else
+  fs_rc=127
+fi
+
+if [ -x "${HOME}/bin/jerboa-market-health-recommendations-refresh" ]; then
+  "${HOME}/bin/jerboa-market-health-recommendations-refresh" --quiet >/dev/null || rec_rc=$?
+else
+  rec_rc=127
+fi
+
 a_env="$(mtime "$ENV_JSON")"
 a_sect="$(mtime "$SECT_JSON")"
 a_pos="$(mtime "$POS_JSON")"
+a_fs="$(mtime "$FS_JSON")"
 a_rec="$(mtime "$REC_JSON")"
 
 changed_market=0
@@ -84,13 +116,13 @@ changed_pos=0
 changed_rec=0
 [ "$a_env"  -gt "$b_env"  ] && changed_market=1
 [ "$a_sect" -gt "$b_sect" ] && changed_market=1
+[ "$a_fs"   -gt "$b_fs"   ] && changed_market=1
 [ "$a_pos"  -gt "$b_pos"  ] && changed_pos=1
 [ "$a_rec"  -gt "$b_rec"  ] && changed_rec=1
 
-# Decide status + reason
 status="ok"
 reason="updated"
-if [ "$pos_rc" -ne 0 ] || [ "$mkt_rc" -ne 0 ]; then
+if [ "$pos_rc" -ne 0 ] || [ "$mkt_rc" -ne 0 ] || [ "$fs_rc" -ne 0 ] || [ "$rec_rc" -ne 0 ]; then
   status="error"
   reason="subcommand-failed"
 elif [ "$changed_market" -eq 0 ] && [ "$changed_pos" -eq 0 ] && [ "$changed_rec" -eq 0 ]; then
@@ -98,7 +130,6 @@ elif [ "$changed_market" -eq 0 ] && [ "$changed_pos" -eq 0 ] && [ "$changed_rec"
   reason="no-changes"
 fi
 
-# Persist state snapshot for doctor/debug (always)
 python3 - <<PY
 import json, os
 from datetime import datetime, timezone
@@ -110,67 +141,52 @@ state = {
   "status": "$status",
   "reason": "$reason",
   "forced": bool(int("$FORCE")),
-  "rc": {"positions": int("$pos_rc"), "market": int("$mkt_rc"), "recommendations": int("$rec_rc")},
-  "changed": {"market": int("$changed_market"), "positions": int("$changed_pos"), "recommendations": int("$changed_rec")},
+  "rc": {
+    "positions": int("$pos_rc"),
+    "market": int("$mkt_rc"),
+    "forecast": int("$fs_rc"),
+    "recommendations": int("$rec_rc"),
+  },
+  "changed": {
+    "market": int("$changed_market"),
+    "positions": int("$changed_pos"),
+    "recommendations": int("$changed_rec"),
+  },
   "mtimes": {
-    "before": {"env": int("$b_env"), "sectors": int("$b_sect"), "positions": int("$b_pos"), "recommendations": int("$b_rec")},
-    "after":  {"env": int("$a_env"), "sectors": int("$a_sect"), "positions": int("$a_pos"), "recommendations": int("$a_rec")},
+    "before": {
+      "env": int("$b_env"),
+      "sectors": int("$b_sect"),
+      "positions": int("$b_pos"),
+      "forecast": int("$b_fs"),
+      "recommendations": int("$b_rec"),
+    },
+    "after": {
+      "env": int("$a_env"),
+      "sectors": int("$a_sect"),
+      "positions": int("$a_pos"),
+      "forecast": int("$a_fs"),
+      "recommendations": int("$a_rec"),
+    },
   },
 }
 with open(p, "w", encoding="utf-8") as f:
-  json.dump(state, f, indent=2, sort_keys=True); f.write("\n")
+  json.dump(state, f, indent=2, sort_keys=True)
+  f.write("\n")
 PY
 
-# Journald: one line max
-
-# JERBOA_UI_EXPORT_V1
-# Update UI contract (React/web reads this single file)
-
-  # Recommendations refresh (fail-soft)
-  if [ -x "${HOME}/bin/jerboa-market-health-recommendations-refresh" ]; then
-    "${HOME}/bin/jerboa-market-health-recommendations-refresh" --quiet >/dev/null || rec_rc=$?
-  else
-    rec_rc=127
-  fi
-
-
-  # Forecast scores (fail-soft)
-  if [ -x "${HOME}/bin/jerboa-market-health-forecast-scores-refresh" ]; then
-    "${HOME}/bin/jerboa-market-health-forecast-scores-refresh" --quiet >/dev/null || true
-  fi
-
-  "${HOME}/bin/jerboa-market-health-ui-export" --quiet >/dev/null || true
+"${HOME}/bin/jerboa-market-health-ui-export" --quiet >/dev/null || true
 
 if [ -n "${INVOCATION_ID:-}" ]; then
   if [ "$status" = "error" ]; then
-    echo "ERR: refresh-all failed (market_rc=$mkt_rc positions_rc=$pos_rc)"
-  elif [ "$changed_market" -eq 1 ] || [ "$changed_pos" -eq 1 ]; then
-    echo "OK: refresh-all updated (market=$changed_market positions=$changed_pos)"
+    echo "ERR: refresh-all failed (market_rc=$mkt_rc positions_rc=$pos_rc forecast_rc=$fs_rc rec_rc=$rec_rc)"
+  elif [ "$changed_market" -eq 1 ] || [ "$changed_pos" -eq 1 ] || [ "$changed_rec" -eq 1 ]; then
+    echo "OK: refresh-all updated (market=$changed_market positions=$changed_pos rec=$changed_rec)"
   fi
 else
-  echo "refresh-all: status=$status reason=$reason market_changed=$changed_market positions_changed=$changed_pos rec_changed=$changed_rec rec_rc=$rec_rc"
+  echo "refresh-all: status=$status reason=$reason market_changed=$changed_market positions_changed=$changed_pos rec_changed=$changed_rec fs_rc=$fs_rc rec_rc=$rec_rc"
 fi
 
-# Exit non-zero only if a subcommand failed
 if [ "$status" = "error" ]; then
   exit 1
 fi
 exit 0
-# JERBOA_REC_ASOF_SYNC_V1
-# Keep recommendations "asof" coherent with the UI snapshot "asof".
-# This does NOT hit Schwab; it only edits the local JSON file.
-UI_JSON="${HOME}/.cache/jerboa/market_health.ui.v1.json"
-if [ -s "$UI_JSON" ] && [ -s "$REC_JSON" ]; then
-  ui_asof="$("$PY" - <<'PYASOF'
-import json
-from pathlib import Path
-d=json.loads(Path("/root/.cache/jerboa/market_health.ui.v1.json").read_text())
-print(d.get("asof",""))
-PYASOF
-  )"
-  if [ -n "$ui_asof" ]; then
-    REC_JSON="$REC_JSON" UI_ASOF="$ui_asof" "$PY" -c 'import os,json; from pathlib import Path; ui=os.environ.get("UI_ASOF",""); rp=Path(os.environ["REC_JSON"]); d=json.loads(rp.read_text(encoding="utf-8")); d["asof"]=ui; rec=d.get("recommendation"); (isinstance(rec,dict) and rec.__setitem__("asof",ui)); ("generated_at" in d and d.__setitem__("generated_at",ui)); rp.write_text(json.dumps(d, indent=2, sort_keys=True)+chr(10), encoding="utf-8")+chr(10), encoding="utf-8")'
-  fi
-fi
-# --- end JERBOA_REC_ASOF_SYNC_V1 ---
-

--- a/scripts/jerboa/bin/jerboa-market-health-ui-export
+++ b/scripts/jerboa/bin/jerboa-market-health-ui-export
@@ -13,7 +13,8 @@ SECT_JSON="${HOME}/.cache/jerboa/market_health.sectors.json"
 POS_JSON="${HOME}/.cache/jerboa/positions.v1.json"
 
 # Ensure python can import from repo checkout regardless of invocation dir
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+SELF="$(readlink -f "${BASH_SOURCE[0]}")"
+REPO_ROOT="$(cd "$(dirname "$SELF")/../../.." && pwd)"
 cd "$REPO_ROOT"
 
 mkdir -p "$(dirname "$OUT_JSON")"
@@ -34,11 +35,12 @@ if command -v cygpath >/dev/null 2>&1; then
   esac
 fi
 
-HOME="$HOME_FOR_PY" "$PYTHON" - <<'PY'
+PYTHONPATH="$REPO_ROOT" HOME="$HOME_FOR_PY" "$PYTHON" - <<'PY'
 import json, os, sys
 from datetime import datetime, timezone
 from pathlib import Path
 from market_health.ui_contract_meta import DIMENSIONS_META_V1
+from market_health.universe import get_asset_meta
 
 # Windows-friendly cache root override (tests set JERBOA_HOME_WIN)
 HOME_ROOT = Path(os.environ.get('JERBOA_HOME_WIN') or os.path.expanduser('~'))
@@ -66,6 +68,52 @@ def meta(p: Path):
         return {"path": str(p), "exists": False, "mtime": 0, "bytes": 0}
     st = p.stat()
     return {"path": str(p), "exists": True, "mtime": int(st.st_mtime), "bytes": int(st.st_size)}
+
+def enrich_sector_rows(obj):
+    if not isinstance(obj, list):
+        return obj
+    out = []
+    for row in obj:
+        if not isinstance(row, dict):
+            out.append(row)
+            continue
+        sym = row.get("symbol")
+        if not isinstance(sym, str) or not sym.strip():
+            out.append(row)
+            continue
+        meta_obj = get_asset_meta(sym)
+        new_row = dict(row)
+        new_row.setdefault("asset_type", meta_obj.asset_type)
+        new_row.setdefault("group", meta_obj.group)
+        new_row.setdefault("metal_type", meta_obj.metal_type)
+        new_row.setdefault("is_basket", meta_obj.is_basket)
+        out.append(new_row)
+    return out
+
+def recommendation_summary_blob(rec_blob):
+    out = {
+        "action": None,
+        "reason": None,
+        "fallback_reason": None,
+        "has_candidate_rows": False,
+    }
+    if not isinstance(rec_blob, dict):
+        return out
+    rec = rec_blob.get("recommendation")
+    if not isinstance(rec, dict):
+        rec = rec_blob if isinstance(rec_blob, dict) else {}
+    if not isinstance(rec, dict):
+        return out
+    out["action"] = rec.get("action")
+    out["reason"] = rec.get("reason")
+    diag = rec.get("diagnostics")
+    if isinstance(diag, dict):
+        cand = diag.get("candidate_rows")
+        out["has_candidate_rows"] = isinstance(cand, list) and len(cand) > 0
+        out["fallback_reason"] = diag.get("fallback_reason")
+    if out["fallback_reason"] is None and out["action"] == "NOOP":
+        out["fallback_reason"] = out["reason"]
+    return out
 
 def status_line_fallback(state: dict | None) -> str:
     if not isinstance(state, dict):
@@ -96,6 +144,9 @@ env   = read_json(env_p)
 sect  = read_json(sect_p)
 pos   = read_json(pos_p)
 
+if isinstance(sect, list):
+    sect = enrich_sector_rows(sect)
+
 rec_raw = read_json(rec_p)
 
 forecast_raw = read_json(forecast_p)
@@ -120,6 +171,8 @@ elif isinstance(forecast_raw, dict) and forecast_raw.get("_error"):
 
 if not status_line:
     status_line = status_line_fallback(state)
+
+rec_summary = recommendation_summary_blob(rec)
 
 # Small derived summary (safe / schema-agnostic)
 pos_list = []
@@ -228,6 +281,8 @@ payload = {
     "summary": {
         "positions_count": len(pos_list),
         "recommendations_status": rec_status,
+        "recommendation_action": rec_summary.get("action"),
+        "recommendation_reason": rec_summary.get("reason"),
         "forecast_scores_status": forecast_status,
           "events_count": len(events_list),
           "events_status": (events.get("status","?") if isinstance(events, dict) else "?"),
@@ -241,6 +296,7 @@ payload = {
         "positions": pos,
         "dimensions_meta": DIMENSIONS_META_V1,
         "recommendations": rec,
+        "recommendation_summary": rec_summary,
         "forecast_scores": forecast,
           "events": events,
     },


### PR DESCRIPTION
## Summary
Restores the canonical Market Health UI on pi-grid.

## Restored behavior
- Sector Union header
- A–E totals table
- expanded compact tri-score overview
- detailed positions tri-score section
- boxed recommendation panel
- forecast candidate pairs table

## Notes
This restores the richer UI as the only canonical UI for normal usage.
Global-market and Japan work should proceed on top of this restored UI baseline.