### PR TITLE
Add Japan broad-market vertical slice

### DIFF
--- a/config/symbols/global_markets.yaml
+++ b/config/symbols/global_markets.yaml
@@ -1,5 +1,5 @@
 symbols:
-  - symbol: JP_BROAD
+  - symbol: EWJ
     market: JP
     region: APAC
     kind: broad_market

--- a/market_health/engine.py
+++ b/market_health/engine.py
@@ -187,6 +187,7 @@ SECTORS_DEFAULT = [
     "XLY",
     "XLK",
     "XLE",
+    "EWJ",
 ]
 
 # Curated leaders per sector for the Leaders%>20D proxy
@@ -194,6 +195,7 @@ SECTOR_LEADERS: Dict[str, List[str]] = {
     "XLK": ["AAPL", "MSFT", "NVDA", "AVGO", "META", "GOOGL", "AMD", "CRM"],
     "XLF": ["JPM", "BAC", "WFC", "GS", "MS", "C", "BLK"],
     "XLE": ["XOM", "CVX", "COP", "SLB", "EOG", "PSX"],
+    "EWJ": ["TM", "SONY", "MUFG", "SMFG", "NTTYY"],
     "XLY": ["AMZN", "TSLA", "HD", "MCD", "NKE", "LOW"],
     "XLI": ["CAT", "HON", "GE", "BA", "UPS", "DE"],
     "XLB": ["LIN", "SHW", "ECL", "NUE", "DOW"],

--- a/tests/test_market_catalog_v1.py
+++ b/tests/test_market_catalog_v1.py
@@ -22,7 +22,7 @@ def test_japan_market_profile_and_symbol_catalog_load() -> None:
 
     assert len(symbols) == 1
     sym = symbols[0]
-    assert sym.symbol == "JP_BROAD"
+    assert sym.symbol == "EWJ"
     assert sym.family_id == "broad_equity"
     assert sym.calendar_id == "JPX"
 


### PR DESCRIPTION
Closes #192

## Summary
- replaces placeholder Japan broad-market symbol with EWJ
- adds EWJ to the active scored universe
- adds EWJ leaders mapping for current scoring
- updates catalog validation test for EWJ

## Validation
- compute_scores() returns EWJ
- ~/.cache/jerboa/market_health.sectors.json contains EWJ
- ~/.cache/jerboa/market_health.ui.v1.json contains EWJ
- mh renders EWJ in the canonical UI

## Notes
This is the first executable Japan broad-market slice only.
Forecast integration, recommendation wiring, and diversity logic follow in later issues.