### PR TITLE
Surface global market metadata in UI export

### DIFF
--- a/scripts/jerboa/bin/jerboa-market-health-ui-export
+++ b/scripts/jerboa/bin/jerboa-market-health-ui-export
@@ -44,6 +44,10 @@ try:
     from market_health.market_catalog import get_symbol_meta as _get_symbol_meta
 except Exception:
     _get_symbol_meta = None
+try:
+    from market_health.market_catalog import get_symbol_meta as _get_symbol_meta
+except Exception:
+    _get_symbol_meta = None
 
 # Windows-friendly cache root override (tests set JERBOA_HOME_WIN)
 HOME_ROOT = Path(os.environ.get('JERBOA_HOME_WIN') or os.path.expanduser('~'))
@@ -84,14 +88,23 @@ def enrich_sector_rows(obj):
         if not isinstance(sym, str) or not sym.strip():
             out.append(row)
             continue
+        asset_meta = get_asset_meta(sym)
+        market_meta = get_symbol_meta(sym.strip().upper())
         new_row = dict(row)
-        if _get_symbol_meta is not None:
-            meta_obj = _get_symbol_meta(sym)
-            if meta_obj is not None:
-                new_row.setdefault("asset_type", getattr(meta_obj, "asset_type", None))
-                new_row.setdefault("group", getattr(meta_obj, "group", None))
-                new_row.setdefault("metal_type", getattr(meta_obj, "metal_type", None))
-                new_row.setdefault("is_basket", getattr(meta_obj, "is_basket", None))
+        new_row.setdefault("asset_type", asset_meta.asset_type)
+        new_row.setdefault("group", asset_meta.group)
+        new_row.setdefault("metal_type", asset_meta.metal_type)
+        new_row.setdefault("is_basket", asset_meta.is_basket)
+        if market_meta is not None:
+            new_row.setdefault("market", market_meta.market)
+            new_row.setdefault("region", market_meta.region)
+            new_row.setdefault("kind", market_meta.kind)
+            new_row.setdefault("bucket_id", market_meta.bucket_id)
+            new_row.setdefault("family_id", market_meta.family_id)
+            new_row.setdefault("benchmark_symbol", market_meta.benchmark_symbol)
+            new_row.setdefault("calendar_id", market_meta.calendar_id)
+            new_row.setdefault("currency", market_meta.currency)
+            new_row.setdefault("taxonomy", market_meta.taxonomy)
         out.append(new_row)
     return out
 
@@ -193,6 +206,32 @@ for item in pos_list:
     if len(symbols) >= 12:
         break
 
+def symbols_sample_meta(symbols):
+    out = []
+    if not isinstance(symbols, list):
+        return out
+    for sym in symbols:
+        if not isinstance(sym, str) or not sym.strip():
+            continue
+        meta_obj = get_symbol_meta(sym.strip().upper())
+        if meta_obj is None:
+            continue
+        out.append(
+            {
+                "symbol": meta_obj.symbol,
+                "market": meta_obj.market,
+                "region": meta_obj.region,
+                "kind": meta_obj.kind,
+                "bucket_id": meta_obj.bucket_id,
+                "family_id": meta_obj.family_id,
+                "benchmark_symbol": meta_obj.benchmark_symbol,
+                "calendar_id": meta_obj.calendar_id,
+                "currency": meta_obj.currency,
+                "taxonomy": meta_obj.taxonomy,
+            }
+        )
+    return out
+
 
   # --- Category A: events/catalysts provider boundary (graceful) ---
 ev_cfg_p = Path(os.path.expanduser("~/.config/jerboa/event_provider.json"))
@@ -290,6 +329,7 @@ payload = {
           "events_count": len(events_list),
           "events_status": (events.get("status","?") if isinstance(events, dict) else "?"),
         "symbols_sample": symbols,
+        "symbols_sample_meta": symbols_sample_meta(symbols),
     },
     # Keep full data for now (still one file); React reads just what it needs.
     "data": {

--- a/scripts/ui_export_ui_contract_v1.py
+++ b/scripts/ui_export_ui_contract_v1.py
@@ -2,6 +2,7 @@ import json
 import os
 from datetime import datetime, timezone
 from pathlib import Path
+from market_health.market_catalog import get_symbol_meta
 
 out_json = Path(os.path.expanduser("~/.cache/jerboa/market_health.ui.v1.json"))
 out_json.parent.mkdir(parents=True, exist_ok=True)
@@ -34,6 +35,61 @@ def meta(p: Path):
     }
 
 
+def enrich_sector_rows(obj):
+    if not isinstance(obj, list):
+        return obj
+    out = []
+    for row in obj:
+        if not isinstance(row, dict):
+            out.append(row)
+            continue
+        sym = row.get("symbol")
+        if not isinstance(sym, str) or not sym.strip():
+            out.append(row)
+            continue
+        meta_obj = get_symbol_meta(sym.strip().upper())
+        new_row = dict(row)
+        if meta_obj is not None:
+            new_row.setdefault("market", meta_obj.market)
+            new_row.setdefault("region", meta_obj.region)
+            new_row.setdefault("kind", meta_obj.kind)
+            new_row.setdefault("bucket_id", meta_obj.bucket_id)
+            new_row.setdefault("family_id", meta_obj.family_id)
+            new_row.setdefault("benchmark_symbol", meta_obj.benchmark_symbol)
+            new_row.setdefault("calendar_id", meta_obj.calendar_id)
+            new_row.setdefault("currency", meta_obj.currency)
+            new_row.setdefault("taxonomy", meta_obj.taxonomy)
+        out.append(new_row)
+    return out
+
+
+def symbols_sample_meta(symbols):
+    out = []
+    if not isinstance(symbols, list):
+        return out
+    for sym in symbols:
+        if not isinstance(sym, str) or not sym.strip():
+            continue
+        meta_obj = get_symbol_meta(sym.strip().upper())
+        if meta_obj is None:
+            continue
+        out.append(
+            {
+                "symbol": meta_obj.symbol,
+                "market": meta_obj.market,
+                "region": meta_obj.region,
+                "kind": meta_obj.kind,
+                "bucket_id": meta_obj.bucket_id,
+                "family_id": meta_obj.family_id,
+                "benchmark_symbol": meta_obj.benchmark_symbol,
+                "calendar_id": meta_obj.calendar_id,
+                "currency": meta_obj.currency,
+                "taxonomy": meta_obj.taxonomy,
+            }
+        )
+    return out
+
+
 def status_line_fallback(state: dict | None) -> str:
     if not isinstance(state, dict):
         return "market-health: STATE missing"
@@ -64,6 +120,9 @@ state = read_json(state_p)
 env = read_json(env_p)
 sect = read_json(sect_p)
 pos = read_json(pos_p)
+
+if isinstance(sect, list):
+    sect = enrich_sector_rows(sect)
 
 if not status_line:
     status_line = status_line_fallback(state)
@@ -177,6 +236,7 @@ payload = {
     },
     "summary": {
         "symbols_sample": symbols,
+        "symbols_sample_meta": symbols_sample_meta(symbols),
         "positions_count": len(pos_list),
         "events_count": len(events_list),
         "events_status": (

--- a/tests/test_ui_export_global_market_metadata_v1.py
+++ b/tests/test_ui_export_global_market_metadata_v1.py
@@ -1,0 +1,22 @@
+from scripts.ui_export_ui_contract_v1 import enrich_sector_rows, symbols_sample_meta
+
+
+def test_enrich_sector_rows_adds_market_metadata_for_ewj() -> None:
+    rows = enrich_sector_rows([{"symbol": "EWJ", "categories": {}}])
+
+    assert rows[0]["symbol"] == "EWJ"
+    assert rows[0]["market"] == "JP"
+    assert rows[0]["region"] == "APAC"
+    assert rows[0]["family_id"] == "broad_equity"
+    assert rows[0]["benchmark_symbol"] == "TOPIX"
+    assert rows[0]["calendar_id"] == "JPX"
+    assert rows[0]["currency"] == "JPY"
+    assert rows[0]["taxonomy"] == "topix17"
+
+
+def test_symbols_sample_meta_only_returns_known_global_market_symbols() -> None:
+    meta = symbols_sample_meta(["XLU", "EWJ"])
+
+    assert len(meta) == 1
+    assert meta[0]["symbol"] == "EWJ"
+    assert meta[0]["market"] == "JP"


### PR DESCRIPTION
Closes #196

## Summary
- enriches UI-export sector rows with global market metadata
- adds symbol sample metadata for metadata-backed non-US symbols
- keeps Jerboa UI export and standalone UI contract export aligned
- adds focused tests proving EWJ surfaces JP/APAC/TOPIX metadata

## Notes
This PR updates the UI/export contract only.
It does not change scoring, forecast thresholds, or recommendation decisions.