### PR TITLE
Make installed market health update path symlink-safe

### DIFF
--- a/scripts/jerboa/bin/jerboa-market-health-forecast-scores-refresh
+++ b/scripts/jerboa/bin/jerboa-market-health-forecast-scores-refresh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
+SCRIPT_PATH="$(readlink -f "${BASH_SOURCE[0]}")"
+SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+cd "$REPO_ROOT"
 
 QUIET=0
 if [ "${1:-}" = "--quiet" ]; then QUIET=1; shift; fi

--- a/scripts/jerboa/bin/jerboa-market-health-positions-refresh
+++ b/scripts/jerboa/bin/jerboa-market-health-positions-refresh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-# Resolve repo root relative to this script
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+# Resolve repo root from the real script path (works through ~/bin symlinks)
+SCRIPT_PATH="$(readlink -f "${BASH_SOURCE[0]}")"
+SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 cd "$REPO_ROOT"
 
 OUT="${HOME}/.cache/jerboa/positions.v1.json"

--- a/scripts/jerboa/bin/jerboa-market-health-recommendations-refresh
+++ b/scripts/jerboa/bin/jerboa-market-health-recommendations-refresh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
+SCRIPT_PATH="$(readlink -f "${BASH_SOURCE[0]}")"
+SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+cd "$REPO_ROOT"
 
 QUIET=0
 if [ "${1:-}" = "--quiet" ]; then QUIET=1; shift; fi

--- a/scripts/jerboa/bin/jerboa-market-health-refresh
+++ b/scripts/jerboa/bin/jerboa-market-health-refresh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
+SCRIPT_PATH="$(readlink -f "${BASH_SOURCE[0]}")"
+SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+cd "$REPO_ROOT"
 # JERBOA_SUPPRESS_BREADCRUMBS_V1
 SUPPRESS_BREADCRUMBS="${JERBOA_SUPPRESS_BREADCRUMBS:-0}"
 

--- a/scripts/jerboa/bin/jerboa-market-health-refresh-all
+++ b/scripts/jerboa/bin/jerboa-market-health-refresh-all
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
 POSITIONS_REFRESH="${SCRIPT_DIR}/jerboa-market-health-positions-refresh"
 FORECAST_REFRESH="${SCRIPT_DIR}/jerboa-market-health-forecast-scores-refresh"
 RECOMMEND_REFRESH="${SCRIPT_DIR}/jerboa-market-health-recommendations-refresh"

--- a/scripts/jerboa/install_market_health.sh
+++ b/scripts/jerboa/install_market_health.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_PATH="$(readlink -f "${BASH_SOURCE[0]}")"
+SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
 REPO="$(
   cd "$SCRIPT_DIR" 2>/dev/null && git rev-parse --show-toplevel 2>/dev/null || true
 )"
@@ -36,6 +37,8 @@ do
 done
 hash -r
 
+ln -snf "$REPO/scripts/jerboa/update_market_health.sh" "$HOME/bin/jerboa-market-health-update"
+
 echo "== Install systemd units -> ~/.config/systemd/user (copy from repo) =="
 install -m 0644 "$REPO/scripts/jerboa/systemd/user/jerboa-market-health-refresh-all.service" \
                "$UNITDIR/jerboa-market-health-refresh-all.service"
@@ -45,20 +48,29 @@ install -m 0644 "$REPO/scripts/jerboa/systemd/user/jerboa-market-health-refresh-
                "$UNITDIR/jerboa-market-health-refresh-all-failure.service"
 
 echo "== Reload + enable timer =="
-systemctl --user daemon-reload
-systemctl --user enable --now jerboa-market-health-refresh-all.timer
+if command -v systemctl >/dev/null 2>&1; then
+  systemctl --user daemon-reload
+  systemctl --user enable jerboa-market-health-refresh-all.timer
+  systemctl --user restart jerboa-market-health-refresh-all.timer || systemctl --user start jerboa-market-health-refresh-all.timer
 
-echo "== Show timer status + next trigger =="
-systemctl --user is-enabled jerboa-market-health-refresh-all.timer
-systemctl --user is-active  jerboa-market-health-refresh-all.timer
-systemctl --user list-timers --all | grep -n 'jerboa-market-health-refresh-all' || true
+  systemctl --user is-enabled jerboa-market-health-refresh-all.timer
+  systemctl --user is-active  jerboa-market-health-refresh-all.timer
+  systemctl --user list-timers --all | grep -n 'jerboa-market-health-refresh-all' || true
+else
+  echo "WARN: systemctl not available; skipped user timer reload/restart"
+fi
 
 echo "== One-shot transient test (forced) =="
-systemd-run --user --unit=jerboa-mh-install-probe --wait --collect \
-  "$HOME/bin/jerboa-market-health-refresh-all" --force >/dev/null
+if command -v systemd-run >/dev/null 2>&1; then
+  systemd-run --user --unit=jerboa-mh-install-probe --wait --collect \
+    "$HOME/bin/jerboa-market-health-refresh-all" --force >/dev/null
 
-echo "== Probe logs (last 120 lines) =="
-journalctl --user -u jerboa-mh-install-probe -n 120 --no-pager || true
+  echo "== Probe logs (last 120 lines) =="
+  journalctl --user -u jerboa-mh-install-probe -n 120 --no-pager || true
+else
+  echo "WARN: systemd-run not available; running direct forced refresh instead"
+  "$HOME/bin/jerboa-market-health-refresh-all" --force >/dev/null || true
+fi
 
 echo "== Status line (for banner) =="
 "$HOME/bin/jerboa-market-health-status" || true
@@ -67,4 +79,8 @@ echo "DONE: install complete"
 
 
 # Enable localhost UI server
-systemctl --user enable --now jerboa-market-health-ui.service >/dev/null 2>&1 || true
+if command -v systemctl >/dev/null 2>&1; then
+  systemctl --user enable --now jerboa-market-health-ui.service >/dev/null 2>&1 || true
+else
+  echo "WARN: systemctl not available; skipped UI service enable"
+fi

--- a/scripts/jerboa/update_market_health.sh
+++ b/scripts/jerboa/update_market_health.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
+exec "${SCRIPT_DIR}/install_market_health.sh" "$@"


### PR DESCRIPTION
Makes install/update and installed market-health wrappers resolve their real script path so ~/bin symlinks, timer reloads, and direct user updates work reliably. Adds a stable jerboa-market-health-update command and guards install-time systemd operations when systemctl or systemd-run are unavailable.