### PR TITLE
M39 ETF universe v1

### DIFF
--- a/market_health/dashboard_legacy.py
+++ b/market_health/dashboard_legacy.py
@@ -605,7 +605,6 @@ def render_overview_triscore(order, held_syms):
         return "   -"
 
     ui = _jload(ui_p)
-    fs = _jload(fs_p)
 
     raw_sectors = (
         ((ui.get("data") or {}).get("sectors") or {}) if isinstance(ui, dict) else {}

--- a/market_health/dashboard_legacy.py
+++ b/market_health/dashboard_legacy.py
@@ -14,6 +14,8 @@ import sys
 from pathlib import Path
 from typing import Any
 from market_health.engine import compute_scores
+from market_health.forecast_features import OHLCV
+from market_health.forecast_score_provider import compute_forecast_universe
 from market_health.universe import get_default_scoring_symbols
 from market_health.inverse_universe_v1 import load_inverse_pairs
 import argparse
@@ -886,6 +888,104 @@ def _dashboard_intraday_fresh_or_last_completed_session(value, max_age_minutes=1
     next_open = future_rows[0][1] if future_rows else (now_utc + timedelta(days=5))
 
     return dt_session == last_completed_session or (last_close <= dt <= next_open)
+
+
+def _has_forecast_payload(
+    forecast_scores: dict[str, Any] | None,
+    sym: str,
+    horizons: tuple[int, ...] = (1, 5),
+) -> bool:
+    if not isinstance(forecast_scores, dict):
+        return False
+
+    by_h = forecast_scores.get(sym.upper())
+    if not isinstance(by_h, dict):
+        return False
+
+    for h in horizons:
+        payload = by_h.get(h) or by_h.get(str(h))
+        if not isinstance(payload, dict):
+            return False
+        if not isinstance(payload.get("forecast_score"), (int, float)):
+            return False
+    return True
+
+
+def _df_to_ohlcv(df):
+    if df is None or getattr(df, "empty", True):
+        return None
+
+    cols = {str(c).lower(): c for c in df.columns}
+    required = {"close", "high", "low", "volume"}
+    if not required.issubset(cols):
+        return None
+
+    return OHLCV(
+        close=[float(x) for x in df[cols["close"]].tolist()],
+        high=[float(x) for x in df[cols["high"]].tolist()],
+        low=[float(x) for x in df[cols["low"]].tolist()],
+        volume=[float(x) for x in df[cols["volume"]].fillna(0).tolist()],
+    )
+
+
+def _backfill_missing_forecast_scores(
+    forecast_doc: dict[str, Any] | None,
+    *,
+    symbols: list[str],
+    data,
+    horizons: tuple[int, ...] = (1, 5),
+):
+    doc = dict(forecast_doc or {})
+    scores = dict(doc.get("scores") or {})
+
+    missing = [
+        str(sym).upper()
+        for sym in symbols
+        if isinstance(sym, str)
+        and sym.strip()
+        and not _has_forecast_payload(scores, str(sym).upper(), horizons)
+    ]
+    if not missing:
+        doc["scores"] = scores
+        doc.setdefault("horizons_trading_days", list(horizons))
+        return doc
+
+    if not isinstance(data, dict):
+        doc["scores"] = scores
+        doc.setdefault("horizons_trading_days", list(horizons))
+        return doc
+
+    spy = _df_to_ohlcv(data.get("SPY"))
+    if spy is None:
+        doc["scores"] = scores
+        doc.setdefault("horizons_trading_days", list(horizons))
+        return doc
+
+    universe = {}
+    for sym in missing:
+        ohlcv = _df_to_ohlcv(data.get(sym))
+        if ohlcv is None:
+            continue
+        if len(ohlcv.close) < 30:
+            continue
+        universe[sym] = ohlcv
+
+    if universe:
+        extra_scores = compute_forecast_universe(
+            universe=universe,
+            spy=spy,
+            horizons_trading_days=horizons,
+            calendar={
+                "schema": "calendar.v1",
+                "windows": {"by_h": {str(h): {} for h in horizons}},
+            },
+        )
+        for sym, by_h in extra_scores.items():
+            scores[str(sym).upper()] = by_h
+
+    doc["scores"] = scores
+    doc.setdefault("horizons_trading_days", list(horizons))
+    return doc
 
 
 def render_reco(order, util, rec_doc, held_syms):
@@ -1851,6 +1951,18 @@ def main() -> int:
         )
 
         rows2 = compute_scores(sectors=overview_order, period=period, interval=interval)
+
+        data2 = None
+
+        if isinstance(rows2, tuple) and len(rows2) == 2:
+            rows2, data2 = rows2
+
+        forecast_doc = _backfill_missing_forecast_scores(
+            forecast_doc=forecast_doc,
+            symbols=overview_order,
+            data=data2,
+            horizons=(1, 5),
+        )
         if isinstance(rows2, tuple) and len(rows2) == 2:
             rows2 = rows2[0]
 

--- a/market_health/dashboard_legacy.py
+++ b/market_health/dashboard_legacy.py
@@ -757,60 +757,25 @@ def render_overview_triscore(order, held_syms):
         if isinstance(forecast_scores, dict):
             by_h = forecast_scores.get(sym)
             if isinstance(by_h, dict):
-                curr_meta = util.get(sym, {}) if isinstance(util, dict) else {}
-                c_num = _num(curr_meta.get("current_utility"))
-                h1_num = _num(curr_meta.get("h1_utility"))
-                h5_num = _num(curr_meta.get("h5_utility"))
-                blend_num = _num(curr_meta.get("utility"))
+                h1_backfill = (by_h.get(1) or by_h.get("1") or {}).get("forecast_score")
+                h5_backfill = (by_h.get(5) or by_h.get("5") or {}).get("forecast_score")
 
-                if h1_num is None:
-                    h1_num = _num(
-                        (by_h.get(1) or by_h.get("1") or {}).get("forecast_score")
-                    )
-                if h5_num is None:
-                    h5_num = _num(
-                        (by_h.get(5) or by_h.get("5") or {}).get("forecast_score")
-                    )
+                if h1_pct is None and isinstance(h1_backfill, (int, float)):
+                    h1_pct = float(h1_backfill)
+                if h5_pct is None and isinstance(h5_backfill, (int, float)):
+                    h5_pct = float(h5_backfill)
 
-                if (
-                    blend_num is None
-                    and c_num is not None
-                    and h1_num is not None
-                    and h5_num is not None
-                ):
-                    blend_num = (c_num * 0.5) + (h1_num * 0.25) + (h5_num * 0.25)
+                if c_pct is not None and h1_pct is not None and h5_pct is not None:
+                    blend_pct = (0.50 * c_pct) + (0.25 * h1_pct) + (0.25 * h5_pct)
 
-                d1_num = (
-                    (h1_num - c_num)
-                    if h1_num is not None and c_num is not None
-                    else None
-                )
-                d5_num = (
-                    (h5_num - c_num)
-                    if h5_num is not None and c_num is not None
-                    else None
-                )
+                d1 = None if c_pct is None or h1_pct is None else (h1_pct - c_pct)
+                d5 = None if c_pct is None or h5_pct is None else (h5_pct - c_pct)
 
-                if blend is None and blend_num is not None:
-                    blend = blend_num
-                    blend_pct = blend_num
-                    blend_txt = f"[{_score_style(blend_num)}]{_fmt_pct(blend_num)}[/]"
-
-                if h1 is None and h1_num is not None:
-                    h1 = h1_num
-                    h1_txt = f"[{_score_style(h1_num)}]{_fmt_pct(h1_num)}[/]"
-
-                if h5 is None and h5_num is not None:
-                    h5 = h5_num
-                    h5_txt = f"[{_score_style(h5_num)}]{_fmt_pct(h5_num)}[/]"
-
-                if d1 is None and d1_num is not None:
-                    d1 = d1_num
-                    d1_txt = f"[{_delta_style(d1_num)}]{_fmt_delta(d1_num)}[/]"
-
-                if d5 is None and d5_num is not None:
-                    d5 = d5_num
-                    d5_txt = f"[{_delta_style(d5_num)}]{_fmt_delta(d5_num)}[/]"
+                blend_txt = f"[{_pct_style(blend_pct)}]{_fmt_pct(blend_pct)}[/]"
+                h1_txt = f"[{_pct_style(h1_pct)}]{_fmt_pct(h1_pct)}[/]"
+                h5_txt = f"[{_pct_style(h5_pct)}]{_fmt_pct(h5_pct)}[/]"
+                d1_txt = f"[{_delta_style(d1)}]{_fmt_delta(d1)}[/]"
+                d5_txt = f"[{_delta_style(d5)}]{_fmt_delta(d5)}[/]"
 
         rows.append(
             {

--- a/market_health/dashboard_legacy.py
+++ b/market_health/dashboard_legacy.py
@@ -696,10 +696,9 @@ def render_overview_triscore(order, held_syms):
     except Exception:
         fs_doc = {}
 
-    overview_scores = compute_scores(sectors=order, period="6mo", interval="1d")
-    overview_data = {}
-    if isinstance(overview_scores, tuple) and len(overview_scores) == 2:
-        _overview_rows_unused, overview_data = overview_scores
+    _overview_rows_unused, overview_data = _unpack_scores(
+        compute_scores(sectors=order, period="6mo", interval="1d")
+    )
 
     fs_doc = _backfill_missing_forecast_scores(
         forecast_doc=fs_doc,
@@ -731,8 +730,8 @@ def render_overview_triscore(order, held_syms):
             continue
 
         c_pct = _sum_cat_pct(row)
-        h1_pct = _forecast_pct(scores, sym, 1)
-        h5_pct = _forecast_pct(scores, sym, 5)
+        h1_pct = _forecast_pct(forecast_scores, sym, 1)
+        h5_pct = _forecast_pct(forecast_scores, sym, 5)
 
         d1 = None if c_pct is None or h1_pct is None else (h1_pct - c_pct)
         d5 = None if c_pct is None or h5_pct is None else (h5_pct - c_pct)

--- a/market_health/dashboard_legacy.py
+++ b/market_health/dashboard_legacy.py
@@ -625,7 +625,6 @@ def render_overview_triscore(order, held_syms):
                 sector_map[sym] = row
 
     raw_scores = (fs.get("scores") or {}) if isinstance(fs, dict) else {}
-    scores = raw_scores if isinstance(raw_scores, dict) else {}
     held_set = {str(s).strip().upper() for s in (held_syms or []) if str(s).strip()}
 
     syms = []
@@ -697,7 +696,11 @@ def render_overview_triscore(order, held_syms):
         fs_doc = {}
 
     _overview_rows_unused, overview_data = _unpack_scores(
-        compute_scores(sectors=order, period="6mo", interval="1d")
+        compute_scores(
+            sectors=list(dict.fromkeys(["SPY", *order])),
+            period="6mo",
+            interval="1d",
+        )
     )
 
     fs_doc = _backfill_missing_forecast_scores(

--- a/market_health/dashboard_legacy.py
+++ b/market_health/dashboard_legacy.py
@@ -686,6 +686,29 @@ def render_overview_triscore(order, held_syms):
     table.add_column("Δ1", justify="right", no_wrap=True, width=4)
     table.add_column("Δ5", justify="right", no_wrap=True, width=4)
 
+    fs_doc = {}
+    try:
+        fs_doc = json.loads(
+            (Path.home() / ".cache" / "jerboa" / "forecast_scores.v1.json").read_text(
+                encoding="utf-8"
+            )
+        )
+    except Exception:
+        fs_doc = {}
+
+    overview_scores = compute_scores(sectors=order, period="6mo", interval="1d")
+    overview_data = {}
+    if isinstance(overview_scores, tuple) and len(overview_scores) == 2:
+        _overview_rows_unused, overview_data = overview_scores
+
+    fs_doc = _backfill_missing_forecast_scores(
+        forecast_doc=fs_doc,
+        symbols=[str(sym).upper() for sym in order if isinstance(sym, str)],
+        data=overview_data,
+        horizons=(1, 5),
+    )
+    forecast_scores = fs_doc.get("scores") if isinstance(fs_doc, dict) else {}
+
     extras_map = {}
     try:
         missing_syms = [s for s in syms if s not in sector_map]
@@ -730,6 +753,64 @@ def render_overview_triscore(order, held_syms):
         h5_txt = f"[{_pct_style(h5_pct)}]{_fmt_pct(h5_pct)}[/]"
         d1_txt = f"[{_delta_style(d1)}]{_fmt_delta(d1)}[/]"
         d5_txt = f"[{_delta_style(d5)}]{_fmt_delta(d5)}[/]"
+
+        if isinstance(forecast_scores, dict):
+            by_h = forecast_scores.get(sym)
+            if isinstance(by_h, dict):
+                curr_meta = util.get(sym, {}) if isinstance(util, dict) else {}
+                c_num = _num(curr_meta.get("current_utility"))
+                h1_num = _num(curr_meta.get("h1_utility"))
+                h5_num = _num(curr_meta.get("h5_utility"))
+                blend_num = _num(curr_meta.get("utility"))
+
+                if h1_num is None:
+                    h1_num = _num(
+                        (by_h.get(1) or by_h.get("1") or {}).get("forecast_score")
+                    )
+                if h5_num is None:
+                    h5_num = _num(
+                        (by_h.get(5) or by_h.get("5") or {}).get("forecast_score")
+                    )
+
+                if (
+                    blend_num is None
+                    and c_num is not None
+                    and h1_num is not None
+                    and h5_num is not None
+                ):
+                    blend_num = (c_num * 0.5) + (h1_num * 0.25) + (h5_num * 0.25)
+
+                d1_num = (
+                    (h1_num - c_num)
+                    if h1_num is not None and c_num is not None
+                    else None
+                )
+                d5_num = (
+                    (h5_num - c_num)
+                    if h5_num is not None and c_num is not None
+                    else None
+                )
+
+                if blend is None and blend_num is not None:
+                    blend = blend_num
+                    blend_pct = blend_num
+                    blend_txt = f"[{_score_style(blend_num)}]{_fmt_pct(blend_num)}[/]"
+
+                if h1 is None and h1_num is not None:
+                    h1 = h1_num
+                    h1_txt = f"[{_score_style(h1_num)}]{_fmt_pct(h1_num)}[/]"
+
+                if h5 is None and h5_num is not None:
+                    h5 = h5_num
+                    h5_txt = f"[{_score_style(h5_num)}]{_fmt_pct(h5_num)}[/]"
+
+                if d1 is None and d1_num is not None:
+                    d1 = d1_num
+                    d1_txt = f"[{_delta_style(d1_num)}]{_fmt_delta(d1_num)}[/]"
+
+                if d5 is None and d5_num is not None:
+                    d5 = d5_num
+                    d5_txt = f"[{_delta_style(d5_num)}]{_fmt_delta(d5_num)}[/]"
 
         rows.append(
             {

--- a/market_health/dashboard_legacy.py
+++ b/market_health/dashboard_legacy.py
@@ -1963,6 +1963,9 @@ def main() -> int:
             data=data2,
             horizons=(1, 5),
         )
+        forecast_scores = (
+            forecast_doc.get("scores") if isinstance(forecast_doc, dict) else {}
+        )
         if isinstance(rows2, tuple) and len(rows2) == 2:
             rows2 = rows2[0]
 
@@ -1993,6 +1996,52 @@ def main() -> int:
                     except Exception:
                         pass
             return total
+
+        if isinstance(forecast_scores, dict):
+            for sym, row in by2.items():
+                if not isinstance(row, dict):
+                    continue
+
+                by_h = forecast_scores.get(sym)
+                if not isinstance(by_h, dict):
+                    continue
+
+                h1_payload = by_h.get(1) or by_h.get("1") or {}
+                h5_payload = by_h.get(5) or by_h.get("5") or {}
+
+                h1_score = h1_payload.get("forecast_score")
+                h5_score = h5_payload.get("forecast_score")
+
+                current_utility = _cat_sum(row, "A") + _cat_sum(row, "B")
+                current_utility += _cat_sum(row, "C") + _cat_sum(row, "D")
+                current_utility += _cat_sum(row, "E")
+                current_utility = float(current_utility) / 60.0
+
+                row["current_utility"] = current_utility
+                row["c"] = current_utility
+
+                if isinstance(h1_score, (int, float)):
+                    row["h1_utility"] = float(h1_score)
+                    row["h1"] = float(h1_score)
+
+                if isinstance(h5_score, (int, float)):
+                    row["h5_utility"] = float(h5_score)
+                    row["h5"] = float(h5_score)
+
+                if isinstance(h1_score, (int, float)) and isinstance(
+                    h5_score, (int, float)
+                ):
+                    blended = (
+                        (current_utility * 0.5)
+                        + (float(h1_score) * 0.25)
+                        + (float(h5_score) * 0.25)
+                    )
+                    row["utility"] = blended
+                    row["blended"] = blended
+                    row["delta_h1"] = float(h1_score) - current_utility
+                    row["delta_h5"] = float(h5_score) - current_utility
+                    row["d1"] = float(h1_score) - current_utility
+                    row["d5"] = float(h5_score) - current_utility
 
         def _style(val, denom):
             if denom == 12:

--- a/market_health/dashboard_legacy.py
+++ b/market_health/dashboard_legacy.py
@@ -1958,7 +1958,7 @@ def main() -> int:
             rows2, data2 = rows2
 
         forecast_doc = _backfill_missing_forecast_scores(
-            forecast_doc=forecast_doc,
+            forecast_doc={},
             symbols=overview_order,
             data=data2,
             horizons=(1, 5),

--- a/market_health/dashboard_legacy.py
+++ b/market_health/dashboard_legacy.py
@@ -480,8 +480,6 @@ def fmt_u(u: float | None) -> str:
     return f"{u:.3f} / {u * 100:.1f}%"
 
 
-
-
 def _load_inverse_symbols_from_cache():
     try:
         inv_path = os.path.expanduser("~/.cache/jerboa/inverse_universe.v1.json")
@@ -512,6 +510,7 @@ def _load_inverse_symbols_from_cache():
             deduped.append(sym)
     return deduped
 
+
 def _expanded_overview_order(base_order, held_syms):
     out = []
     seen = set()
@@ -525,7 +524,12 @@ def _expanded_overview_order(base_order, held_syms):
         seen.add(s)
         out.append(s)
 
-    for seq in (base_order, held_syms, _load_inverse_symbols_from_cache(), get_default_scoring_symbols()):
+    for seq in (
+        base_order,
+        held_syms,
+        _load_inverse_symbols_from_cache(),
+        get_default_scoring_symbols(),
+    ):
         if isinstance(seq, (list, tuple)):
             for sym in seq:
                 _add(sym)
@@ -802,6 +806,7 @@ def _dashboard_intraday_fresh_or_last_completed_session(value, max_age_minutes=1
     except ModuleNotFoundError:
         try:
             from zoneinfo import ZoneInfo
+
             et_tz = ZoneInfo("America/New_York")
         except Exception:
             et_tz = timezone(timedelta(hours=-5), "ET")
@@ -859,6 +864,7 @@ def _dashboard_intraday_fresh_or_last_completed_session(value, max_age_minutes=1
 
     try:
         from zoneinfo import ZoneInfo
+
         session_tz = ZoneInfo("America/New_York")
     except Exception:
         session_tz = timezone(timedelta(hours=-5), "ET")
@@ -880,6 +886,7 @@ def _dashboard_intraday_fresh_or_last_completed_session(value, max_age_minutes=1
     next_open = future_rows[0][1] if future_rows else (now_utc + timedelta(days=5))
 
     return dt_session == last_completed_session or (last_close <= dt <= next_open)
+
 
 def render_reco(order, util, rec_doc, held_syms):
     NL = chr(10)
@@ -1832,8 +1839,16 @@ def main() -> int:
         from rich import box
 
         inputs = rec_doc.get("inputs") if isinstance(rec_doc, dict) else None
-        period = str(inputs.get("period")) if isinstance(inputs, dict) and inputs.get("period") else "6mo"
-        interval = str(inputs.get("interval")) if isinstance(inputs, dict) and inputs.get("interval") else "1d"
+        period = (
+            str(inputs.get("period"))
+            if isinstance(inputs, dict) and inputs.get("period")
+            else "6mo"
+        )
+        interval = (
+            str(inputs.get("interval"))
+            if isinstance(inputs, dict) and inputs.get("interval")
+            else "1d"
+        )
 
         rows2 = compute_scores(sectors=overview_order, period=period, interval=interval)
         if isinstance(rows2, tuple) and len(rows2) == 2:

--- a/market_health/dashboard_legacy.py
+++ b/market_health/dashboard_legacy.py
@@ -544,7 +544,6 @@ def render_overview_triscore(order, held_syms):
     NL = chr(10)
     cache = Path.home() / ".cache" / "jerboa"
     ui_p = cache / "market_health.ui.v1.json"
-    fs_p = cache / "forecast_scores.v1.json"
 
     def _jload(path):
         try:
@@ -974,6 +973,53 @@ def _df_to_ohlcv(df):
     )
 
 
+def _download_price_frames(symbols, *, period: str = "6mo", interval: str = "1d"):
+    syms = [
+        str(sym).upper().strip()
+        for sym in (symbols or [])
+        if isinstance(sym, str) and str(sym).strip()
+    ]
+    if not syms:
+        return {}
+
+    try:
+        import yfinance as yf
+    except Exception:
+        return {}
+
+    out = {}
+    for sym in syms:
+        try:
+            df = yf.download(
+                sym,
+                period=period,
+                interval=interval,
+                auto_adjust=False,
+                progress=False,
+                threads=False,
+            )
+        except Exception:
+            continue
+
+        if df is None or getattr(df, "empty", True):
+            continue
+
+        # Normalize possible multi-index columns from yfinance.
+        cols = getattr(df, "columns", None)
+        if cols is not None and getattr(cols, "nlevels", 1) > 1:
+            try:
+                df = df.droplevel(-1, axis=1)
+            except Exception:
+                try:
+                    df = df.xs(sym, axis=1, level=0)
+                except Exception:
+                    pass
+
+        out[sym] = df
+
+    return out
+
+
 def _backfill_missing_forecast_scores(
     forecast_doc: dict[str, Any] | None,
     *,
@@ -996,12 +1042,23 @@ def _backfill_missing_forecast_scores(
         doc.setdefault("horizons_trading_days", list(horizons))
         return doc
 
-    if not isinstance(data, dict):
-        doc["scores"] = scores
-        doc.setdefault("horizons_trading_days", list(horizons))
-        return doc
+    data_map = dict(data) if isinstance(data, dict) else {}
 
-    spy = _df_to_ohlcv(data.get("SPY"))
+    # Fallback: compact tri-score calls compute_scores(), which only returns rows.
+    # In that path we need to fetch price frames ourselves for SPY + missing symbols.
+    need_frames = ["SPY", *missing]
+    need_download = [
+        sym
+        for sym in need_frames
+        if not isinstance(data_map.get(sym), object)
+        or getattr(data_map.get(sym), "empty", True)
+    ]
+    if need_download:
+        downloaded = _download_price_frames(need_download, period="6mo", interval="1d")
+        for sym, df in downloaded.items():
+            data_map[str(sym).upper()] = df
+
+    spy = _df_to_ohlcv(data_map.get("SPY"))
     if spy is None:
         doc["scores"] = scores
         doc.setdefault("horizons_trading_days", list(horizons))
@@ -1009,7 +1066,7 @@ def _backfill_missing_forecast_scores(
 
     universe = {}
     for sym in missing:
-        ohlcv = _df_to_ohlcv(data.get(sym))
+        ohlcv = _df_to_ohlcv(data_map.get(sym))
         if ohlcv is None:
             continue
         if len(ohlcv.close) < 30:

--- a/market_health/dashboard_legacy.py
+++ b/market_health/dashboard_legacy.py
@@ -624,7 +624,6 @@ def render_overview_triscore(order, held_syms):
             if sym:
                 sector_map[sym] = row
 
-    raw_scores = (fs.get("scores") or {}) if isinstance(fs, dict) else {}
     held_set = {str(s).strip().upper() for s in (held_syms or []) if str(s).strip()}
 
     syms = []

--- a/market_health/engine.py
+++ b/market_health/engine.py
@@ -949,6 +949,9 @@ def compute_scores(
                 "group": meta.group,
                 "metal_type": meta.metal_type,
                 "is_basket": meta.is_basket,
+                "inverse_or_levered": meta.inverse_or_levered,
+                "strategy_wrapper": meta.strategy_wrapper,
+                "overlap_key": meta.overlap_key,
                 "categories": cats,
             }
         )

--- a/market_health/etf_universe_v1.py
+++ b/market_health/etf_universe_v1.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+DEFAULT_ETFS: list[dict[str, Any]] = [
+    {
+        "symbol": "IBIT",
+        "enabled": True,
+        "inverse_or_levered": False,
+        "strategy_wrapper": False,
+        "overlap_key": "bitcoin",
+    },
+    {
+        "symbol": "BITI",
+        "enabled": True,
+        "inverse_or_levered": True,
+        "strategy_wrapper": False,
+        "overlap_key": "bitcoin",
+    },
+    {
+        "symbol": "SBIT",
+        "enabled": True,
+        "inverse_or_levered": True,
+        "strategy_wrapper": False,
+        "overlap_key": "bitcoin",
+    },
+    {
+        "symbol": "BTCI",
+        "enabled": True,
+        "inverse_or_levered": False,
+        "strategy_wrapper": True,
+        "overlap_key": "bitcoin",
+    },
+    {
+        "symbol": "QYLD",
+        "enabled": True,
+        "inverse_or_levered": False,
+        "strategy_wrapper": True,
+        "overlap_key": "equity_income",
+    },
+    {
+        "symbol": "JEPI",
+        "enabled": True,
+        "inverse_or_levered": False,
+        "strategy_wrapper": True,
+        "overlap_key": "equity_income",
+    },
+    {
+        "symbol": "BLOK",
+        "enabled": True,
+        "inverse_or_levered": False,
+        "strategy_wrapper": False,
+        "overlap_key": "blockchain",
+    },
+    {
+        "symbol": "BITC",
+        "enabled": True,
+        "inverse_or_levered": False,
+        "strategy_wrapper": True,
+        "overlap_key": "bitcoin",
+    },
+    {
+        "symbol": "ETHA",
+        "enabled": True,
+        "inverse_or_levered": False,
+        "strategy_wrapper": False,
+        "overlap_key": "ethereum",
+    },
+    {
+        "symbol": "BKCH",
+        "enabled": True,
+        "inverse_or_levered": False,
+        "strategy_wrapper": False,
+        "overlap_key": "blockchain",
+    },
+]
+
+ENV_VAR = "JERBOA_ETF_UNIVERSE_JSON"
+
+
+def _read_json(p: Path) -> Any:
+    try:
+        return json.loads(p.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+
+
+def load_etf_universe(
+    path: str | os.PathLike[str] | None = None,
+) -> list[dict[str, Any]]:
+    """
+    Load ETF config.
+
+    Only reads from disk if:
+      - `path` is provided, OR
+      - env var JERBOA_ETF_UNIVERSE_JSON is set.
+
+    Otherwise returns DEFAULT_ETFS (deterministic for tests/CI).
+    """
+    p: Path | None = None
+    if path:
+        p = Path(path).expanduser()
+    else:
+        env = os.environ.get(ENV_VAR)
+        if env:
+            p = Path(env).expanduser()
+
+    if p and p.exists():
+        doc = _read_json(p)
+        if isinstance(doc, dict) and isinstance(doc.get("symbols"), list):
+            return [x for x in doc["symbols"] if isinstance(x, dict)]
+        if isinstance(doc, list):
+            return [x for x in doc if isinstance(x, dict)]
+
+    return list(DEFAULT_ETFS)

--- a/market_health/recommendations_engine.py
+++ b/market_health/recommendations_engine.py
@@ -16,6 +16,8 @@ Pure/deterministic: no IO, no network, no timestamps.
 
 from __future__ import annotations
 
+from market_health.universe import get_asset_meta
+
 from dataclasses import dataclass
 from typing import Any, Dict, Iterable, List, Literal, Optional, Tuple
 
@@ -267,6 +269,8 @@ def recommend(
     applied_list.append("max_precious_holdings")
     if block_gltr_component_overlap:
         applied_list.append("block_gltr_component_overlap")
+    applied_list.append("block_inverse_or_levered_etf")
+    applied_list.append("block_overlap_key")
     if sector_cap is not None:
         applied_list.append("sector_cap")
     if turnover_cap is not None:
@@ -305,11 +309,29 @@ def recommend(
         if not isinstance(sym, str) or not sym.strip():
             continue
         sym_u = sym.strip().upper()
+        meta_obj = get_asset_meta(sym_u)
         row_meta[sym_u] = {
-            "asset_type": row.get("asset_type"),
-            "group": row.get("group"),
-            "metal_type": row.get("metal_type"),
-            "is_basket": row.get("is_basket"),
+            "asset_type": row.get("asset_type")
+            if row.get("asset_type") is not None
+            else meta_obj.asset_type,
+            "group": row.get("group")
+            if row.get("group") is not None
+            else meta_obj.group,
+            "metal_type": row.get("metal_type")
+            if row.get("metal_type") is not None
+            else meta_obj.metal_type,
+            "is_basket": row.get("is_basket")
+            if row.get("is_basket") is not None
+            else meta_obj.is_basket,
+            "inverse_or_levered": row.get("inverse_or_levered")
+            if row.get("inverse_or_levered") is not None
+            else meta_obj.inverse_or_levered,
+            "strategy_wrapper": row.get("strategy_wrapper")
+            if row.get("strategy_wrapper") is not None
+            else meta_obj.strategy_wrapper,
+            "overlap_key": row.get("overlap_key")
+            if row.get("overlap_key") is not None
+            else meta_obj.overlap_key,
         }
         sec = row.get("sector")
         if isinstance(sec, str) and sec.strip():
@@ -369,26 +391,41 @@ def recommend(
 
     def _policy_reasons(candidate: str) -> List[str]:
         reasons: List[str] = []
-        if not _is_precious(candidate):
-            return reasons
 
-        after_precious = _after_swap_precious(candidate)
+        if _is_precious(candidate):
+            after_precious = _after_swap_precious(candidate)
 
-        if len(after_precious) > max_precious_holdings:
-            reasons.append("policy:max_precious_holdings")
+            if len(after_precious) > max_precious_holdings:
+                reasons.append("policy:max_precious_holdings")
 
-        if block_gltr_component_overlap:
-            after_metals = [
-                row_meta.get(sym, {}).get("metal_type") for sym in after_precious
-            ]
-            has_basket = any(m == "basket" for m in after_metals)
-            has_single = any(
-                isinstance(m, str) and m not in {"basket"} for m in after_metals
-            )
-            if has_basket and has_single:
-                reasons.append("policy:block_gltr_component_overlap")
+            if block_gltr_component_overlap:
+                after_metals = [
+                    row_meta.get(sym, {}).get("metal_type") for sym in after_precious
+                ]
+                has_basket = any(m == "basket" for m in after_metals)
+                has_single = any(
+                    isinstance(m, str) and m not in {"basket"} for m in after_metals
+                )
+                if has_basket and has_single:
+                    reasons.append("policy:block_gltr_component_overlap")
 
-        return reasons
+        candidate_meta = row_meta.get(candidate, {})
+        if candidate_meta.get("group") == "ETF":
+            if bool(candidate_meta.get("inverse_or_levered")):
+                reasons.append("policy:block_inverse_or_levered_etf")
+
+            overlap_key = candidate_meta.get("overlap_key")
+            if isinstance(overlap_key, str) and overlap_key.strip():
+                overlap_key = overlap_key.strip()
+                for held_sym in held_present:
+                    if held_sym == weakest:
+                        continue
+                    held_key = row_meta.get(held_sym, {}).get("overlap_key")
+                    if isinstance(held_key, str) and held_key.strip() == overlap_key:
+                        reasons.append("policy:block_overlap_key")
+                        break
+
+        return list(dict.fromkeys(reasons))
 
     candidate_rows: List[Dict[str, Any]] = []
     candidate_row_index: Dict[str, Dict[str, Any]] = {}

--- a/market_health/universe.py
+++ b/market_health/universe.py
@@ -94,6 +94,8 @@ def get_default_scoring_symbols(include_precious: Optional[bool] = None) -> list
     symbols = list(SECTOR_SYMBOLS)
     if include_precious:
         symbols.extend(PRECIOUS_SYMBOLS)
+    if etf_universe_enabled():
+        symbols.extend(get_configured_etf_symbols())
     return symbols
 
 

--- a/market_health/universe.py
+++ b/market_health/universe.py
@@ -14,6 +14,9 @@ class AssetMeta:
         None  # gold | silver | platinum | palladium | basket | None
     )
     is_basket: bool = False
+    inverse_or_levered: bool = False
+    strategy_wrapper: bool = False
+    overlap_key: Optional[str] = None
 
 
 SECTOR_SYMBOLS = [
@@ -75,16 +78,24 @@ def etf_universe_enabled() -> bool:
     return _flag("MH_ENABLE_ETF_UNIVERSE", "0")
 
 
-def get_configured_etf_symbols() -> list[str]:
+def get_configured_etf_registry() -> dict[str, dict[str, object]]:
     if not etf_universe_enabled():
-        return []
+        return {}
 
-    out: list[str] = []
+    out: dict[str, dict[str, object]] = {}
     for row in load_etf_universe():
+        if not isinstance(row, dict):
+            continue
         sym = str(row.get("symbol", "")).upper().strip()
         if sym and bool(row.get("enabled", True)):
-            out.append(sym)
+            row2 = dict(row)
+            row2["symbol"] = sym
+            out[sym] = row2
     return out
+
+
+def get_configured_etf_symbols() -> list[str]:
+    return list(get_configured_etf_registry().keys())
 
 
 def get_default_scoring_symbols(include_precious: Optional[bool] = None) -> list[str]:
@@ -133,8 +144,21 @@ def classify_asset_symbol(symbol: str) -> AssetMeta:
             is_basket=True,
         )
 
-    if sym in get_configured_etf_symbols():
-        return AssetMeta(symbol=sym, asset_type="etf", group="ETF")
+    etf_row = get_configured_etf_registry().get(sym)
+    if etf_row is not None:
+        overlap_key = etf_row.get("overlap_key")
+        return AssetMeta(
+            symbol=sym,
+            asset_type="etf",
+            group="ETF",
+            inverse_or_levered=bool(etf_row.get("inverse_or_levered", False)),
+            strategy_wrapper=bool(etf_row.get("strategy_wrapper", False)),
+            overlap_key=(
+                str(overlap_key).strip()
+                if isinstance(overlap_key, str) and overlap_key.strip()
+                else None
+            ),
+        )
 
     if sym in PARKING_SYMBOLS:
         return AssetMeta(symbol=sym, asset_type="parking", group="PARKING")

--- a/market_health/universe.py
+++ b/market_health/universe.py
@@ -2,12 +2,14 @@ from dataclasses import dataclass
 from typing import Optional
 import os
 
+from market_health.etf_universe_v1 import load_etf_universe
+
 
 @dataclass(frozen=True)
 class AssetMeta:
     symbol: str
-    asset_type: str  # sector | inverse | precious | parking | unsupported
-    group: str  # SECTOR | INVERSE | PRECIOUS | PARKING | UNSUPPORTED
+    asset_type: str  # sector | inverse | precious | parking | etf | unsupported
+    group: str  # SECTOR | INVERSE | PRECIOUS | PARKING | ETF | UNSUPPORTED
     metal_type: Optional[str] = (
         None  # gold | silver | platinum | palladium | basket | None
     )
@@ -69,6 +71,22 @@ def precious_metals_enabled() -> bool:
     return _flag("MH_ENABLE_PRECIOUS_METALS", "1")
 
 
+def etf_universe_enabled() -> bool:
+    return _flag("MH_ENABLE_ETF_UNIVERSE", "0")
+
+
+def get_configured_etf_symbols() -> list[str]:
+    if not etf_universe_enabled():
+        return []
+
+    out: list[str] = []
+    for row in load_etf_universe():
+        sym = str(row.get("symbol", "")).upper().strip()
+        if sym and bool(row.get("enabled", True)):
+            out.append(sym)
+    return out
+
+
 def get_default_scoring_symbols(include_precious: Optional[bool] = None) -> list[str]:
     if include_precious is None:
         include_precious = precious_metals_enabled()
@@ -112,6 +130,9 @@ def classify_asset_symbol(symbol: str) -> AssetMeta:
             metal_type="basket",
             is_basket=True,
         )
+
+    if sym in get_configured_etf_symbols():
+        return AssetMeta(symbol=sym, asset_type="etf", group="ETF")
 
     if sym in PARKING_SYMBOLS:
         return AssetMeta(symbol=sym, asset_type="parking", group="PARKING")

--- a/scripts/export_recommendations_v1.py
+++ b/scripts/export_recommendations_v1.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 import argparse
 import os
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timezone, timedelta, time
 from pathlib import Path
 from typing import Any, Dict, List
 
@@ -112,8 +112,6 @@ def _get_market_calendar_module():
 
 
 def _is_market_session_fresh(value: Any, max_age_minutes: int = 15):
-    from datetime import datetime, timezone, timedelta, time
-
     dt = _parse_iso_utc(value)
     if dt is None:
         return False

--- a/scripts/export_recommendations_v1.py
+++ b/scripts/export_recommendations_v1.py
@@ -124,6 +124,7 @@ def _is_market_session_fresh(value: Any, max_age_minutes: int = 15):
     except ModuleNotFoundError:
         try:
             from zoneinfo import ZoneInfo
+
             et_tz = ZoneInfo("America/New_York")
         except Exception:
             et_tz = timezone(timedelta(hours=-5), "ET")
@@ -181,6 +182,7 @@ def _is_market_session_fresh(value: Any, max_age_minutes: int = 15):
 
     try:
         from zoneinfo import ZoneInfo
+
         session_tz = ZoneInfo("America/New_York")
     except Exception:
         session_tz = timezone(timedelta(hours=-5), "ET")
@@ -203,6 +205,7 @@ def _is_market_session_fresh(value: Any, max_age_minutes: int = 15):
 
     return dt_session == last_completed_session or (last_close <= dt <= next_open)
 
+
 def _is_same_or_last_completed_session(value: Any):
     dt = _parse_iso_utc(value)
     if dt is None:
@@ -211,6 +214,7 @@ def _is_same_or_last_completed_session(value: Any):
     now_utc = datetime.now(timezone.utc)
     try:
         from zoneinfo import ZoneInfo
+
         session_tz = ZoneInfo("America/New_York")
     except Exception:
         session_tz = timezone(timedelta(hours=-5), "ET")
@@ -556,6 +560,7 @@ def _intraday_fresh_or_last_completed_session(value, max_age_minutes=15):
     except ModuleNotFoundError:
         try:
             from zoneinfo import ZoneInfo
+
             et_tz = ZoneInfo("America/New_York")
         except Exception:
             et_tz = timezone(timedelta(hours=-5), "ET")
@@ -613,6 +618,7 @@ def _intraday_fresh_or_last_completed_session(value, max_age_minutes=15):
 
     try:
         from zoneinfo import ZoneInfo
+
         session_tz = ZoneInfo("America/New_York")
     except Exception:
         session_tz = timezone(timedelta(hours=-5), "ET")
@@ -634,6 +640,7 @@ def _intraday_fresh_or_last_completed_session(value, max_age_minutes=15):
     next_open = future_rows[0][1] if future_rows else (now_utc + timedelta(days=5))
 
     return dt_session == last_completed_session or (last_close <= dt <= next_open)
+
 
 def main() -> int:
     ap = argparse.ArgumentParser(

--- a/scripts/jerboa/bin/jerboa-market-health-ui-export
+++ b/scripts/jerboa/bin/jerboa-market-health-ui-export
@@ -87,6 +87,9 @@ def enrich_sector_rows(obj):
         new_row.setdefault("group", meta_obj.group)
         new_row.setdefault("metal_type", meta_obj.metal_type)
         new_row.setdefault("is_basket", meta_obj.is_basket)
+        new_row.setdefault("inverse_or_levered", meta_obj.inverse_or_levered)
+        new_row.setdefault("strategy_wrapper", meta_obj.strategy_wrapper)
+        new_row.setdefault("overlap_key", meta_obj.overlap_key)
         out.append(new_row)
     return out
 

--- a/tests/fixtures/expected/ui_contract.signature.tsv
+++ b/tests/fixtures/expected/ui_contract.signature.tsv
@@ -132,8 +132,11 @@ data.sectors[].categories.F.checks	list[dict]
 data.sectors[].categories.F.checks[].label	str
 data.sectors[].categories.F.checks[].score	int
 data.sectors[].group	str
+data.sectors[].inverse_or_levered	bool
 data.sectors[].is_basket	bool
 data.sectors[].metal_type	NoneType
+data.sectors[].overlap_key	NoneType
+data.sectors[].strategy_wrapper	bool
 data.sectors[].symbol	str
 data.state.changed.market	int
 data.state.changed.positions	int

--- a/tests/fixtures/golden.recommendation.forecast.v1.json
+++ b/tests/fixtures/golden.recommendation.forecast.v1.json
@@ -15,6 +15,8 @@
   "recommendation": {
     "action": "NOOP",
     "constraints_applied": [
+      "block_inverse_or_levered_etf",
+      "block_overlap_key",
       "max_precious_holdings",
       "max_swaps_per_day",
       "min_delta"

--- a/tests/fixtures/scenarios/etf_policy/jerboa_cache/positions.v1.json
+++ b/tests/fixtures/scenarios/etf_policy/jerboa_cache/positions.v1.json
@@ -1,0 +1,7 @@
+{
+  "schema": "positions.v1",
+  "positions": [
+    {"symbol": "XLB", "market_value": 100.0},
+    {"symbol": "IBIT", "market_value": 900.0}
+  ]
+}

--- a/tests/fixtures/scenarios/etf_policy/jerboa_cache/recommendations.v1.json
+++ b/tests/fixtures/scenarios/etf_policy/jerboa_cache/recommendations.v1.json
@@ -1,0 +1,219 @@
+{
+  "asof": "2026-04-04T17:01:06Z",
+  "computation_fingerprint": "c4cf1fbd37f43a19f28663b4d409cef7795ecb71e76912a41c093ba19c7b9aa2",
+  "computed_at": "2026-04-04T17:01:06.768221Z",
+  "freshness": {
+    "forecast_age_seconds": null,
+    "forecast_is_fresh": false,
+    "max_positions_age_minutes": 15,
+    "positions_age_seconds": 0,
+    "positions_is_fresh": true,
+    "sectors_age_seconds": null,
+    "sectors_is_fresh": false,
+    "source_skew_seconds": 0
+  },
+  "generated_at": "2026-04-04T17:01:06.790648Z",
+  "input_hashes": {
+    "forecast": null,
+    "positions": "00d351980123cad5c1c97ea412422a5573cd2ebccae13da4db69b150a74b6e9e",
+    "sectors": null
+  },
+  "inputs": {
+    "block_gltr_component_overlap": true,
+    "cooldown_trading_days": 0,
+    "disagreement_veto_edge": 0.0,
+    "forecast_asof": null,
+    "forecast_generated_at": null,
+    "forecast_mode": false,
+    "forecast_path": "/tmp/tmpbp0bgjvz/.cache/jerboa/forecast_scores.v1.json",
+    "forecast_source_asof": null,
+    "forecast_status": "disabled",
+    "hhi_cap": 0.2,
+    "horizon_trading_days": 5,
+    "interval": "1d",
+    "max_positions_age_minutes": 15,
+    "max_precious_holdings": 1,
+    "max_weight_per_symbol": 0.25,
+    "min_delta": 0.12,
+    "min_distinct_symbols": 4,
+    "min_floor": 0.55,
+    "min_improvement_threshold": 0.12,
+    "period": "6mo",
+    "positions_asof": "2026-04-04T17:01:06Z",
+    "positions_classified": {
+      "ETF": [
+        "IBIT"
+      ],
+      "INVERSE": [],
+      "PARKING": [],
+      "PRECIOUS": [],
+      "SECTOR": [
+        "XLB"
+      ],
+      "UNSUPPORTED": []
+    },
+    "positions_is_fresh": true,
+    "positions_mapped": [
+      "IBIT",
+      "XLB"
+    ],
+    "positions_mode": "sectorized",
+    "positions_mtime_epoch": 1775322066,
+    "positions_path": "/root/market-health-cli/tests/fixtures/scenarios/etf_policy/jerboa_cache/positions.v1.json",
+    "positions_supported_outside_universe": [],
+    "positions_unmapped": [],
+    "scores_source": "compute_scores",
+    "sectors_asof": null,
+    "sgov_is_policy_fallback": true,
+    "sgov_symbol": "SGOV",
+    "snapshot_epoch": 1775322066
+  },
+  "recommendation": {
+    "action": "SWAP",
+    "constraints_applied": [
+      "min_delta",
+      "max_swaps_per_day",
+      "min_floor",
+      "sgov_policy_fallback",
+      "max_precious_holdings",
+      "block_gltr_component_overlap",
+      "block_inverse_or_levered_etf",
+      "block_overlap_key"
+    ],
+    "diagnostics": {
+      "best_candidate": "BITI",
+      "candidate_components": {
+        "blended": 0.75,
+        "c": 0.75,
+        "h1": null,
+        "h5": null
+      },
+      "candidate_rows": [
+        {
+          "asset_type": "etf",
+          "blended": 0.75,
+          "c": 0.75,
+          "delta_blended": 0.35,
+          "group": "ETF",
+          "h1": null,
+          "h5": null,
+          "is_basket": false,
+          "metal_type": null,
+          "min_floor": 0.55,
+          "passes_delta": true,
+          "passes_floor": true,
+          "passes_policy": false,
+          "rejection_reasons": [
+            "policy:block_inverse_or_levered_etf",
+            "policy:block_overlap_key"
+          ],
+          "status": "BLOCKED",
+          "sym": "BITI",
+          "threshold": 0.12
+        },
+        {
+          "asset_type": "etf",
+          "blended": 0.7,
+          "c": 0.7,
+          "delta_blended": 0.29999999999999993,
+          "group": "ETF",
+          "h1": null,
+          "h5": null,
+          "is_basket": false,
+          "metal_type": null,
+          "min_floor": 0.55,
+          "passes_delta": true,
+          "passes_floor": true,
+          "passes_policy": false,
+          "rejection_reasons": [
+            "policy:block_overlap_key"
+          ],
+          "status": "BLOCKED",
+          "sym": "BITC",
+          "threshold": 0.12
+        },
+        {
+          "asset_type": "parking",
+          "blended": 0.35,
+          "c": 0.35,
+          "delta_blended": -0.050000000000000044,
+          "group": "PARKING",
+          "h1": null,
+          "h5": null,
+          "is_basket": false,
+          "metal_type": null,
+          "min_floor": 0.55,
+          "passes_delta": null,
+          "passes_floor": null,
+          "passes_policy": null,
+          "rejection_reasons": [
+            "fallback_only"
+          ],
+          "status": "FALLBACK_ONLY",
+          "sym": "SGOV",
+          "threshold": 0.12
+        }
+      ],
+      "candidate_utility": 0.75,
+      "decision_metric": "blended_utility",
+      "delta_utility": 0.35,
+      "edge": 0.35,
+      "fallback_reason": "policy_blocked",
+      "health_score_from": 0.4,
+      "health_score_to": 0.75,
+      "held": [
+        "IBIT",
+        "XLB"
+      ],
+      "held_components": {
+        "IBIT": {
+          "blended": 0.5,
+          "c": 0.5,
+          "h1": null,
+          "h5": null
+        },
+        "XLB": {
+          "blended": 0.4,
+          "c": 0.4,
+          "h1": null,
+          "h5": null
+        }
+      },
+      "held_scored": [
+        "IBIT",
+        "XLB"
+      ],
+      "held_utilities": {
+        "IBIT": 0.5,
+        "XLB": 0.4
+      },
+      "horizon_trading_days": 5,
+      "min_delta": 0.12,
+      "min_floor": 0.55,
+      "selection_mode": "sgov_fallback",
+      "threshold": 0.12,
+      "utility_weights": {
+        "c": 0.5,
+        "h1": 0.25,
+        "h5": 0.25
+      },
+      "weakest_held": "XLB"
+    },
+    "from_symbol": "XLB",
+    "horizon_trading_days": 5,
+    "reason": "No candidate clears policy gates; fallback to SGOV.",
+    "target_trade_date": "2026-04-13",
+    "to_symbol": "SGOV"
+  },
+  "schema": "recommendations.v1",
+  "snapshot_asof": "2026-04-04T17:01:06Z",
+  "snapshot_id": "c4cf1fbd37f4",
+  "source_timestamps": {
+    "forecast_asof": null,
+    "forecast_generated_at": null,
+    "forecast_source_asof": null,
+    "positions_asof": "2026-04-04T17:01:06Z",
+    "sectors_asof": null,
+    "snapshot_asof": "2026-04-04T17:01:06Z"
+  }
+}

--- a/tests/test_dashboard_etf_triscore_pm19.py
+++ b/tests/test_dashboard_etf_triscore_pm19.py
@@ -1,0 +1,72 @@
+import pandas as pd
+
+from market_health.dashboard_legacy import _backfill_missing_forecast_scores
+from market_health.recommendations_engine import blended_utility_from_scores
+
+
+def _row(symbol: str, pts: int, checks: int = 10, **extra):
+    checks_list = [{"label": f"c{i}", "score": 0} for i in range(checks)]
+    remaining = pts
+    i = 0
+    while remaining > 0 and i < checks:
+        add = 2 if remaining >= 2 else 1
+        checks_list[i]["score"] = add
+        remaining -= add
+        i += 1
+    row = {"symbol": symbol, "categories": {"A": {"checks": checks_list}}}
+    row.update(extra)
+    return row
+
+
+def _df(base: float, step: float = 0.25, n: int = 90):
+    vals = [base + i * step for i in range(n)]
+    return pd.DataFrame(
+        {
+            "Open": vals,
+            "High": [v + 0.5 for v in vals],
+            "Low": [v - 0.5 for v in vals],
+            "Close": vals,
+            "Volume": [1_000_000] * len(vals),
+        }
+    )
+
+
+def test_dashboard_backfills_missing_etf_forecast_scores():
+    rows = [
+        _row("XLB", 8, asset_type="sector", group="SECTOR"),
+        _row("IBIT", 8, asset_type="etf", group="ETF"),
+    ]
+
+    forecast_doc = {
+        "horizons_trading_days": [1, 5],
+        "scores": {
+            "XLB": {
+                "1": {"forecast_score": 0.55},
+                "5": {"forecast_score": 0.60},
+            }
+        },
+    }
+
+    data = {
+        "SPY": _df(100.0, 0.20),
+        "XLB": _df(90.0, 0.10),
+        "IBIT": _df(50.0, 0.40),
+    }
+
+    merged = _backfill_missing_forecast_scores(
+        forecast_doc,
+        symbols=["XLB", "IBIT"],
+        data=data,
+        horizons=(1, 5),
+    )
+
+    util = blended_utility_from_scores(
+        rows,
+        forecast_scores=merged["scores"],
+        forecast_horizons=(1, 5),
+    )
+
+    assert "IBIT" in merged["scores"]
+    assert util["IBIT"]["h1_utility"] is not None
+    assert util["IBIT"]["h5_utility"] is not None
+    assert util["IBIT"]["utility"] is not None

--- a/tests/test_engine_asset_metadata.py
+++ b/tests/test_engine_asset_metadata.py
@@ -75,3 +75,42 @@ def test_compute_scores_attaches_parking_metadata():
     assert row["metal_type"] is None
     assert row["is_basket"] is False
     assert "categories" in row
+
+
+def test_compute_scores_attaches_etf_metadata(monkeypatch):
+    monkeypatch.setenv("MH_ENABLE_ETF_UNIVERSE", "1")
+    rows = compute_scores(
+        sectors=["IBIT"],
+        period="6mo",
+        interval="1d",
+        ttl_sec=0,
+        download_fn=fake_download,
+    )
+    row = rows[0]
+    assert row["symbol"] == "IBIT"
+    assert row["asset_type"] == "etf"
+    assert row["group"] == "ETF"
+    assert row["metal_type"] is None
+    assert row["is_basket"] is False
+    assert row["inverse_or_levered"] is False
+    assert row["strategy_wrapper"] is False
+    assert row["overlap_key"] == "bitcoin"
+    assert "categories" in row
+
+
+def test_compute_scores_attaches_inverse_etf_metadata(monkeypatch):
+    monkeypatch.setenv("MH_ENABLE_ETF_UNIVERSE", "1")
+    rows = compute_scores(
+        sectors=["BITI"],
+        period="6mo",
+        interval="1d",
+        ttl_sec=0,
+        download_fn=fake_download,
+    )
+    row = rows[0]
+    assert row["symbol"] == "BITI"
+    assert row["asset_type"] == "etf"
+    assert row["group"] == "ETF"
+    assert row["inverse_or_levered"] is True
+    assert row["strategy_wrapper"] is False
+    assert row["overlap_key"] == "bitcoin"

--- a/tests/test_export_recommendations_etf_pm18.py
+++ b/tests/test_export_recommendations_etf_pm18.py
@@ -1,0 +1,96 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_pm18_export_preserves_etf_policy_and_classification(tmp_path: Path):
+    positions = {
+        "schema": "positions.v1",
+        "positions": [
+            {"symbol": "XLB", "market_value": 100.0},
+            {"symbol": "IBIT", "market_value": 900.0},
+        ],
+    }
+
+    positions_p = tmp_path / "positions.json"
+    out_p = tmp_path / "recommendations.json"
+    positions_p.write_text(json.dumps(positions), encoding="utf-8")
+
+    shim = tmp_path / "shim"
+    shim.mkdir()
+    (shim / "market_health").mkdir()
+    (shim / "market_health" / "__init__.py").write_text(
+        "from pkgutil import extend_path\n__path__ = extend_path(__path__, __name__)\n",
+        encoding="utf-8",
+    )
+    (shim / "market_health" / "engine.py").write_text(
+        """def compute_scores(*args, **kwargs):
+    def row(symbol, pts):
+        checks = []
+        remaining = pts
+        for i in range(10):
+            score = 0
+            if remaining > 0:
+                score = 2 if remaining >= 2 else 1
+                remaining -= score
+            checks.append({"label": f"c{i}", "score": score})
+        return {"symbol": symbol, "categories": {"A": {"checks": checks}}}
+    return [
+        row("XLB", 8),
+        row("IBIT", 10),
+        row("BITI", 15),
+        row("BITC", 14),
+        row("SGOV", 7),
+    ]
+""",
+        encoding="utf-8",
+    )
+
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path)
+    env["JERBOA_HOME_WIN"] = str(tmp_path)
+    env["MH_ENABLE_ETF_UNIVERSE"] = "1"
+    env["PYTHONPATH"] = str(shim) + os.pathsep + str(Path.cwd())
+
+    subprocess.run(
+        [
+            sys.executable,
+            "scripts/export_recommendations_v1.py",
+            "--positions",
+            str(positions_p),
+            "--out",
+            str(out_p),
+            "--min-improvement",
+            "0.12",
+            "--min-floor",
+            "0.55",
+            "--quiet",
+        ],
+        check=True,
+        env=env,
+    )
+
+    doc = json.loads(out_p.read_text(encoding="utf-8"))
+    inputs = doc["inputs"]
+    rec = doc["recommendation"]
+    diag = rec["diagnostics"]
+    rows = {row["sym"]: row for row in diag["candidate_rows"]}
+
+    assert inputs["positions_mode"] == "sectorized"
+    assert "IBIT" in inputs["positions_mapped"]
+    assert "XLB" in inputs["positions_mapped"]
+    assert inputs["positions_classified"]["ETF"] == ["IBIT"]
+
+    assert rec["action"] == "SWAP"
+    assert rec["from_symbol"] == "XLB"
+    assert rec["to_symbol"] == "SGOV"
+    assert diag["selection_mode"] == "sgov_fallback"
+    assert diag["fallback_reason"] == "policy_blocked"
+
+    assert "block_inverse_or_levered_etf" in rec["constraints_applied"]
+    assert "block_overlap_key" in rec["constraints_applied"]
+
+    assert "policy:block_inverse_or_levered_etf" in rows["BITI"]["rejection_reasons"]
+    assert "policy:block_overlap_key" in rows["BITC"]["rejection_reasons"]

--- a/tests/test_forecast_recommendations_etf_pm15.py
+++ b/tests/test_forecast_recommendations_etf_pm15.py
@@ -1,0 +1,78 @@
+from market_health.forecast_recommendations import recommend_forecast_mode
+
+
+def _forecast_constraints(scores, **overrides):
+    base = {
+        "forecast_scores": scores,
+        "forecast_horizons": (1, 5),
+        "horizon_trading_days": 5,
+        "min_improvement_threshold": 0.01,
+        "disagreement_veto_edge": 0.0,
+        "max_swaps_per_day": 1,
+        "swaps_today": 0,
+        "cooldown_trading_days": 0,
+        "cooldown_history": [],
+        "max_weight_per_symbol": 1.0,
+        "min_distinct_symbols": 1,
+        "hhi_cap": 1.0,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_etf_candidate_can_be_selected_in_forecast_mode():
+    scores = {
+        "AAA": {
+            1: {"forecast_score": 0.20},
+            5: {"forecast_score": 0.20},
+        },
+        "ETHA": {
+            1: {"forecast_score": 0.45},
+            5: {"forecast_score": 0.45},
+        },
+        "IBIT": {
+            1: {"forecast_score": 0.60},
+            5: {"forecast_score": 0.60},
+        },
+    }
+
+    rec = recommend_forecast_mode(
+        positions={"positions": [{"symbol": "AAA", "market_value": 1000.0}]},
+        constraints=_forecast_constraints(scores),
+    )
+
+    assert rec.action == "SWAP"
+    assert rec.from_symbol == "AAA"
+    assert rec.to_symbol == "IBIT"
+    assert rec.diagnostics["best_candidate"] == "IBIT"
+    assert rec.diagnostics["selected_pair"]["to_symbol"] == "IBIT"
+
+
+def test_etf_candidates_appear_in_candidate_pairs_diagnostics():
+    scores = {
+        "AAA": {
+            1: {"forecast_score": 0.20},
+            5: {"forecast_score": 0.20},
+        },
+        "ETHA": {
+            1: {"forecast_score": 0.45},
+            5: {"forecast_score": 0.45},
+        },
+        "IBIT": {
+            1: {"forecast_score": 0.60},
+            5: {"forecast_score": 0.60},
+        },
+    }
+
+    rec = recommend_forecast_mode(
+        positions={"positions": [{"symbol": "AAA", "market_value": 1000.0}]},
+        constraints=_forecast_constraints(scores),
+    )
+
+    assert rec.action == "SWAP"
+
+    pairs = rec.diagnostics["candidate_pairs"]
+    observed = {(p["from_symbol"], p["to_symbol"]) for p in pairs}
+
+    assert ("AAA", "ETHA") in observed
+    assert ("AAA", "IBIT") in observed

--- a/tests/test_positions_sectorize_pm6.py
+++ b/tests/test_positions_sectorize_pm6.py
@@ -37,3 +37,41 @@ def test_sectorize_positions_maps_precious_when_in_universe():
     assert meta["supported_outside_universe"] == []
     assert meta["unmapped"] == []
     assert meta["classified"]["PRECIOUS"] == ["GLDM"]
+
+
+def test_sectorize_positions_maps_enabled_etf_holdings_when_in_universe(monkeypatch):
+    monkeypatch.setenv("MH_ENABLE_ETF_UNIVERSE", "1")
+    positions = {
+        "schema": "positions.v1",
+        "positions": [
+            {"symbol": "IBIT", "market_value": 1000.0},
+            {"symbol": "ETHA", "market_value": 500.0},
+        ],
+    }
+
+    out, meta = sectorize_positions(positions, {"XLE", "IBIT", "ETHA"})
+
+    assert out["positions"] == [
+        {"symbol": "ETHA", "market_value": 500.0},
+        {"symbol": "IBIT", "market_value": 1000.0},
+    ]
+    assert meta["mapped"] == ["ETHA", "IBIT"]
+    assert meta["supported_outside_universe"] == []
+    assert meta["unmapped"] == []
+    assert meta["classified"]["ETF"] == ["ETHA", "IBIT"]
+
+
+def test_sectorize_positions_marks_enabled_etf_holdings_supported_outside_universe(monkeypatch):
+    monkeypatch.setenv("MH_ENABLE_ETF_UNIVERSE", "1")
+    positions = {
+        "schema": "positions.v1",
+        "positions": [{"symbol": "IBIT", "market_value": 1000.0}],
+    }
+
+    out, meta = sectorize_positions(positions, {"XLE"})
+
+    assert out["positions"] == []
+    assert meta["mapped"] == []
+    assert meta["supported_outside_universe"] == ["IBIT"]
+    assert meta["unmapped"] == []
+    assert meta["classified"]["ETF"] == ["IBIT"]

--- a/tests/test_positions_sectorize_pm6.py
+++ b/tests/test_positions_sectorize_pm6.py
@@ -61,7 +61,9 @@ def test_sectorize_positions_maps_enabled_etf_holdings_when_in_universe(monkeypa
     assert meta["classified"]["ETF"] == ["ETHA", "IBIT"]
 
 
-def test_sectorize_positions_marks_enabled_etf_holdings_supported_outside_universe(monkeypatch):
+def test_sectorize_positions_marks_enabled_etf_holdings_supported_outside_universe(
+    monkeypatch,
+):
     monkeypatch.setenv("MH_ENABLE_ETF_UNIVERSE", "1")
     positions = {
         "schema": "positions.v1",

--- a/tests/test_recommendations_etf_policy_pm17.py
+++ b/tests/test_recommendations_etf_policy_pm17.py
@@ -1,0 +1,100 @@
+from market_health.recommendations_engine import recommend
+
+
+def _row(symbol: str, pts: int, checks: int = 10, **extra):
+    checks_list = [{"label": f"c{i}", "score": 0} for i in range(checks)]
+    remaining = pts
+    i = 0
+    while remaining > 0 and i < checks:
+        add = 2 if remaining >= 2 else 1
+        checks_list[i]["score"] = add
+        remaining -= add
+        i += 1
+    row = {"symbol": symbol, "categories": {"A": {"checks": checks_list}}}
+    row.update(extra)
+    return row
+
+
+def _candidate_rows(rec):
+    return {row["sym"]: row for row in rec.diagnostics["candidate_rows"]}
+
+
+def test_inverse_or_levered_etf_is_blocked_by_policy(monkeypatch):
+    monkeypatch.setenv("MH_ENABLE_ETF_UNIVERSE", "1")
+
+    scores = [
+        _row("XLB", 8, asset_type="sector", group="SECTOR"),
+        _row("BITI", 14),
+        _row("SGOV", 7, asset_type="parking", group="PARKING"),
+    ]
+    pos = {"positions": [{"symbol": "XLB"}]}
+
+    rec = recommend(
+        positions=pos,
+        scores=scores,
+        constraints={
+            "min_floor": 0.55,
+            "min_delta": 0.12,
+            "sgov_symbol": "SGOV",
+            "sgov_is_policy_fallback": True,
+        },
+    )
+
+    assert rec.action == "SWAP"
+    assert rec.to_symbol == "SGOV"
+    rows = _candidate_rows(rec)
+    assert "policy:block_inverse_or_levered_etf" in rows["BITI"]["rejection_reasons"]
+
+
+def test_overlap_key_blocks_duplicate_etf_exposure(monkeypatch):
+    monkeypatch.setenv("MH_ENABLE_ETF_UNIVERSE", "1")
+
+    scores = [
+        _row("XLB", 8, asset_type="sector", group="SECTOR"),
+        _row("IBIT", 12),
+        _row("BITC", 14),
+        _row("SGOV", 7, asset_type="parking", group="PARKING"),
+    ]
+    pos = {"positions": [{"symbol": "XLB"}, {"symbol": "IBIT"}]}
+
+    rec = recommend(
+        positions=pos,
+        scores=scores,
+        constraints={
+            "min_floor": 0.55,
+            "min_delta": 0.12,
+            "sgov_symbol": "SGOV",
+            "sgov_is_policy_fallback": True,
+        },
+    )
+
+    assert rec.action == "SWAP"
+    assert rec.to_symbol == "SGOV"
+    rows = _candidate_rows(rec)
+    assert "policy:block_overlap_key" in rows["BITC"]["rejection_reasons"]
+
+
+def test_overlap_key_does_not_block_when_replacing_same_exposure(monkeypatch):
+    monkeypatch.setenv("MH_ENABLE_ETF_UNIVERSE", "1")
+
+    scores = [
+        _row("IBIT", 8),
+        _row("BITC", 14),
+        _row("SGOV", 7, asset_type="parking", group="PARKING"),
+    ]
+    pos = {"positions": [{"symbol": "IBIT"}]}
+
+    rec = recommend(
+        positions=pos,
+        scores=scores,
+        constraints={
+            "min_floor": 0.55,
+            "min_delta": 0.12,
+            "sgov_symbol": "SGOV",
+            "sgov_is_policy_fallback": True,
+        },
+    )
+
+    assert rec.action == "SWAP"
+    assert rec.from_symbol == "IBIT"
+    assert rec.to_symbol == "BITC"

--- a/tests/test_recommendations_fixture_etf_pm18.py
+++ b/tests/test_recommendations_fixture_etf_pm18.py
@@ -1,0 +1,38 @@
+import json
+from pathlib import Path
+
+
+def test_pm18_etf_policy_fixture_captures_etf_inputs_and_policy_blocks():
+    p = Path("tests/fixtures/scenarios/etf_policy/jerboa_cache/recommendations.v1.json")
+    assert p.exists(), "Missing ETF policy scenario fixture"
+
+    data = json.loads(p.read_text(encoding="utf-8"))
+    assert data.get("schema") == "recommendations.v1"
+
+    inputs = data.get("inputs") or {}
+    classified = inputs.get("positions_classified") or {}
+
+    assert inputs.get("positions_mode") == "sectorized"
+    assert "IBIT" in (inputs.get("positions_mapped") or [])
+    assert "XLB" in (inputs.get("positions_mapped") or [])
+    assert classified.get("ETF") == ["IBIT"]
+
+    rec = data.get("recommendation") or {}
+    diag = rec.get("diagnostics") or {}
+    rows = {row["sym"]: row for row in diag.get("candidate_rows") or []}
+
+    assert rec.get("action") == "SWAP"
+    assert rec.get("from_symbol") == "XLB"
+    assert rec.get("to_symbol") == "SGOV"
+    assert diag.get("selection_mode") == "sgov_fallback"
+    assert diag.get("fallback_reason") == "policy_blocked"
+
+    assert "block_inverse_or_levered_etf" in (rec.get("constraints_applied") or [])
+    assert "block_overlap_key" in (rec.get("constraints_applied") or [])
+
+    assert "BITI" in rows
+    assert "BITC" in rows
+    assert "SGOV" in rows
+
+    assert "policy:block_inverse_or_levered_etf" in rows["BITI"]["rejection_reasons"]
+    assert "policy:block_overlap_key" in rows["BITC"]["rejection_reasons"]

--- a/tests/test_universe_feature_flag.py
+++ b/tests/test_universe_feature_flag.py
@@ -75,3 +75,23 @@ def test_engine_sectors_default_includes_etfs_when_enabled_on_reload(monkeypatch
     assert "IBIT" in engine.SECTORS_DEFAULT
     assert "ETHA" in engine.SECTORS_DEFAULT
     assert "QYLD" in engine.SECTORS_DEFAULT
+
+
+def test_enabled_etf_metadata_exposes_registry_flags(monkeypatch):
+    monkeypatch.setenv("MH_ENABLE_ETF_UNIVERSE", "1")
+    meta = universe.classify_asset_symbol("BITI")
+    assert meta.asset_type == "etf"
+    assert meta.group == "ETF"
+    assert meta.inverse_or_levered is True
+    assert meta.strategy_wrapper is False
+    assert meta.overlap_key == "bitcoin"
+
+
+def test_enabled_strategy_wrapper_etf_metadata(monkeypatch):
+    monkeypatch.setenv("MH_ENABLE_ETF_UNIVERSE", "1")
+    meta = universe.classify_asset_symbol("QYLD")
+    assert meta.asset_type == "etf"
+    assert meta.group == "ETF"
+    assert meta.inverse_or_levered is False
+    assert meta.strategy_wrapper is True
+    assert meta.overlap_key == "equity_income"

--- a/tests/test_universe_feature_flag.py
+++ b/tests/test_universe_feature_flag.py
@@ -26,3 +26,27 @@ def test_engine_sectors_default_respects_feature_flag_on_reload(monkeypatch):
     importlib.reload(engine)
     assert "GLDM" in engine.SECTORS_DEFAULT
     assert "GLTR" in engine.SECTORS_DEFAULT
+
+
+def test_etf_universe_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("MH_ENABLE_ETF_UNIVERSE", raising=False)
+    assert universe.etf_universe_enabled() is False
+    assert "IBIT" not in universe.get_configured_etf_symbols()
+    meta = universe.classify_asset_symbol("IBIT")
+    assert meta.asset_type == "unsupported"
+    assert meta.group == "UNSUPPORTED"
+
+
+def test_etf_universe_enabled_exposes_configured_symbols(monkeypatch):
+    monkeypatch.setenv("MH_ENABLE_ETF_UNIVERSE", "1")
+    syms = universe.get_configured_etf_symbols()
+    assert "IBIT" in syms
+    assert "ETHA" in syms
+    assert "QYLD" in syms
+
+
+def test_classify_asset_symbol_recognizes_enabled_etf(monkeypatch):
+    monkeypatch.setenv("MH_ENABLE_ETF_UNIVERSE", "1")
+    meta = universe.classify_asset_symbol("IBIT")
+    assert meta.asset_type == "etf"
+    assert meta.group == "ETF"

--- a/tests/test_universe_feature_flag.py
+++ b/tests/test_universe_feature_flag.py
@@ -50,3 +50,28 @@ def test_classify_asset_symbol_recognizes_enabled_etf(monkeypatch):
     meta = universe.classify_asset_symbol("IBIT")
     assert meta.asset_type == "etf"
     assert meta.group == "ETF"
+
+
+def test_default_scoring_symbols_excludes_etfs_when_disabled(monkeypatch):
+    monkeypatch.delenv("MH_ENABLE_ETF_UNIVERSE", raising=False)
+    syms = universe.get_default_scoring_symbols()
+    assert "IBIT" not in syms
+    assert "ETHA" not in syms
+    assert "QYLD" not in syms
+
+
+def test_default_scoring_symbols_includes_etfs_when_enabled(monkeypatch):
+    monkeypatch.setenv("MH_ENABLE_ETF_UNIVERSE", "1")
+    syms = universe.get_default_scoring_symbols()
+    assert "IBIT" in syms
+    assert "ETHA" in syms
+    assert "QYLD" in syms
+
+
+def test_engine_sectors_default_includes_etfs_when_enabled_on_reload(monkeypatch):
+    monkeypatch.setenv("MH_ENABLE_ETF_UNIVERSE", "1")
+    importlib.reload(universe)
+    importlib.reload(engine)
+    assert "IBIT" in engine.SECTORS_DEFAULT
+    assert "ETHA" in engine.SECTORS_DEFAULT
+    assert "QYLD" in engine.SECTORS_DEFAULT


### PR DESCRIPTION
Closes #257
Closes #258
Closes #259
Closes #260
Closes #261
Closes #262

Implements the M39 ETF universe v1 work, including:
- feature-flagged ETF registry/classification
- scored universe expansion
- position sectorization support for ETFs
- forecast recommendation participation for ETF candidates
- minimal ETF policy hooks for inverse/levered and overlap-key cases
- ETF golden fixtures and export regressions
- New York session freshness fix and refreshed affected expectations

Smoke tested in mh_dev and validated locally with full pytest.