### PR TITLE
Point packaged CLI entry points at current MH CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,9 +19,9 @@ dependencies = [
 ]
 
 [project.scripts]
-market-health = "market_ui:main"
-market-health-pi = "market_ui:main"
-mh = "market_ui:main"
+market-health = "market_health.mh_cli:main"
+market-health-pi = "market_health.mh_cli:main"
+mh = "market_health.mh_cli:main"
 [tool.setuptools]
 packages = ["market_health"]
 py-modules = ["market_ui"]


### PR DESCRIPTION
Fixes fresh installs so market-health, market-health-pi, and mh use the current market_health.mh_cli entry point instead of the legacy market_ui entry point.