### PR TITLE
Point mh_dev and packaged CLI at dashboard legacy entrypoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,9 +19,9 @@ dependencies = [
 ]
 
 [project.scripts]
-market-health = "market_health.mh_cli:main"
-market-health-pi = "market_health.mh_cli:main"
-mh = "market_health.mh_cli:main"
+market-health = "market_health.dashboard_legacy:main"
+market-health-pi = "market_health.dashboard_legacy:main"
+mh = "market_health.dashboard_legacy:main"
 [tool.setuptools]
 packages = ["market_health"]
 py-modules = ["market_ui"]


### PR DESCRIPTION
Fixes mh_dev and fresh installs so the CLI launches the interactive dashboard instead of the export-style entrypoint.