### PR TITLE
Add global broad-market ETF universe batch

### DIFF
--- a/market_health/etf_universe_v1.py
+++ b/market_health/etf_universe_v1.py
@@ -78,6 +78,75 @@ DEFAULT_ETFS: list[dict[str, Any]] = [
     },
 ]
 
+
+GLOBAL_BROAD_MARKET_ETF_ROWS: list[tuple[str, str, str, str]] = [
+    # symbol, country, region, overlap_key
+    ("EWC", "Canada", "Americas", "country_canada"),
+    ("EWW", "Mexico", "Americas", "country_mexico"),
+    ("EWZ", "Brazil", "Americas", "country_brazil"),
+    ("ECH", "Chile", "Americas", "country_chile"),
+    ("EPU", "Peru", "Americas", "country_peru"),
+    ("ARGT", "Argentina", "Americas", "country_argentina"),
+    ("EWU", "United Kingdom", "Europe", "country_united_kingdom"),
+    ("EWG", "Germany", "Europe", "country_germany"),
+    ("EWQ", "France", "Europe", "country_france"),
+    ("EWI", "Italy", "Europe", "country_italy"),
+    ("EWP", "Spain", "Europe", "country_spain"),
+    ("EWL", "Switzerland", "Europe", "country_switzerland"),
+    ("EWN", "Netherlands", "Europe", "country_netherlands"),
+    ("EWD", "Sweden", "Europe", "country_sweden"),
+    ("EDEN", "Denmark", "Europe", "country_denmark"),
+    ("EFNL", "Finland", "Europe", "country_finland"),
+    ("EIRL", "Ireland", "Europe", "country_ireland"),
+    ("EWO", "Austria", "Europe", "country_austria"),
+    ("EWK", "Belgium", "Europe", "country_belgium"),
+    ("ENOR", "Norway", "Europe", "country_norway"),
+    ("EPOL", "Poland", "Europe", "country_poland"),
+    ("TUR", "Turkey", "Europe", "country_turkey"),
+    ("GREK", "Greece", "Europe", "country_greece"),
+    ("EWA", "Australia", "Asia-Pacific", "country_australia"),
+    ("EWH", "Hong Kong", "Asia-Pacific", "country_hong_kong"),
+    ("INDA", "India", "Asia-Pacific", "country_india"),
+    ("MCHI", "China", "Asia-Pacific", "country_china"),
+    ("EWY", "South Korea", "Asia-Pacific", "country_south_korea"),
+    ("EWT", "Taiwan", "Asia-Pacific", "country_taiwan"),
+    ("EWS", "Singapore", "Asia-Pacific", "country_singapore"),
+    ("EWM", "Malaysia", "Asia-Pacific", "country_malaysia"),
+    ("EIDO", "Indonesia", "Asia-Pacific", "country_indonesia"),
+    ("THD", "Thailand", "Asia-Pacific", "country_thailand"),
+    ("EPHE", "Philippines", "Asia-Pacific", "country_philippines"),
+    ("ENZL", "New Zealand", "Asia-Pacific", "country_new_zealand"),
+    ("VNAM", "Vietnam", "Asia-Pacific", "country_vietnam"),
+    ("EIS", "Israel", "Middle East / Africa", "country_israel"),
+    ("KSA", "Saudi Arabia", "Middle East / Africa", "country_saudi_arabia"),
+    ("QAT", "Qatar", "Middle East / Africa", "country_qatar"),
+    (
+        "UAE",
+        "United Arab Emirates",
+        "Middle East / Africa",
+        "country_united_arab_emirates",
+    ),
+    ("EZA", "South Africa", "Middle East / Africa", "country_south_africa"),
+]
+
+
+GLOBAL_BROAD_MARKET_ETFS: list[dict[str, Any]] = [
+    {
+        "symbol": symbol,
+        "enabled": True,
+        "inverse_or_levered": False,
+        "strategy_wrapper": False,
+        "overlap_key": overlap_key,
+        "family": "global_broad_market",
+        "country": country,
+        "region": region,
+        "exposure": "single_country_broad_equity",
+    }
+    for symbol, country, region, overlap_key in GLOBAL_BROAD_MARKET_ETF_ROWS
+]
+
+DEFAULT_ETFS.extend(GLOBAL_BROAD_MARKET_ETFS)
+
 ENV_VAR = "JERBOA_ETF_UNIVERSE_JSON"
 
 

--- a/tests/test_global_broad_market_etfs.py
+++ b/tests/test_global_broad_market_etfs.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from market_health.etf_universe_v1 import load_etf_universe
+from market_health.universe import classify_asset_symbol, get_default_scoring_symbols
+
+
+GLOBAL_BROAD_MARKET_SYMBOLS = {
+    "EWC",
+    "EWW",
+    "EWZ",
+    "ECH",
+    "EPU",
+    "ARGT",
+    "EWU",
+    "EWG",
+    "EWQ",
+    "EWI",
+    "EWP",
+    "EWL",
+    "EWN",
+    "EWD",
+    "EDEN",
+    "EFNL",
+    "EIRL",
+    "EWO",
+    "EWK",
+    "ENOR",
+    "EPOL",
+    "TUR",
+    "GREK",
+    "EWA",
+    "EWH",
+    "INDA",
+    "MCHI",
+    "EWY",
+    "EWT",
+    "EWS",
+    "EWM",
+    "EIDO",
+    "THD",
+    "EPHE",
+    "ENZL",
+    "VNAM",
+    "EIS",
+    "KSA",
+    "QAT",
+    "UAE",
+    "EZA",
+}
+
+
+def test_global_broad_market_etfs_are_in_default_registry(monkeypatch):
+    monkeypatch.delenv("JERBOA_ETF_UNIVERSE_JSON", raising=False)
+
+    rows = load_etf_universe()
+    by_symbol = {str(row.get("symbol", "")).upper(): row for row in rows}
+
+    missing = sorted(GLOBAL_BROAD_MARKET_SYMBOLS - set(by_symbol))
+    assert not missing
+
+    for sym in GLOBAL_BROAD_MARKET_SYMBOLS:
+        row = by_symbol[sym]
+        assert row["enabled"] is True
+        assert row["inverse_or_levered"] is False
+        assert row["strategy_wrapper"] is False
+        assert row["family"] == "global_broad_market"
+        assert row["exposure"] == "single_country_broad_equity"
+        assert str(row["overlap_key"]).startswith("country_")
+
+
+def test_global_broad_market_etfs_are_rankable_when_etf_universe_enabled(monkeypatch):
+    monkeypatch.setenv("MH_ENABLE_ETF_UNIVERSE", "1")
+    monkeypatch.delenv("JERBOA_ETF_UNIVERSE_JSON", raising=False)
+
+    symbols = set(get_default_scoring_symbols())
+    missing = sorted(GLOBAL_BROAD_MARKET_SYMBOLS - symbols)
+    assert not missing
+
+    meta = classify_asset_symbol("INDA")
+    assert meta.asset_type == "etf"
+    assert meta.group == "ETF"
+    assert meta.inverse_or_levered is False
+    assert meta.strategy_wrapper is False
+    assert meta.overlap_key == "country_india"
+
+
+def test_global_broad_market_etfs_do_not_replace_existing_etfs(monkeypatch):
+    monkeypatch.delenv("JERBOA_ETF_UNIVERSE_JSON", raising=False)
+
+    symbols = {str(row.get("symbol", "")).upper() for row in load_etf_universe()}
+
+    existing_etfs = {
+        "IBIT",
+        "BITI",
+        "SBIT",
+        "BTCI",
+        "QYLD",
+        "JEPI",
+        "BLOK",
+        "BITC",
+        "ETHA",
+        "BKCH",
+    }
+
+    assert existing_etfs.issubset(symbols)
+    assert GLOBAL_BROAD_MARKET_SYMBOLS.issubset(symbols)


### PR DESCRIPTION
Refs #279.
Refs #280.
Refs #281.
Refs #282.
Refs #283.

Summary:
- Adds the first broad single-country ETF batch to the ETF universe registry.
- Keeps the ETFs rankable when MH_ENABLE_ETF_UNIVERSE=1.
- Adds overlap keys such as country_india, country_brazil, and country_canada for duplicate-exposure control.
- Adds focused tests proving the country ETFs are enabled, non-levered, not strategy wrappers, and included in the expanded scoring universe.

Validation:
- python -m compileall -q market_health/etf_universe_v1.py tests/test_global_broad_market_etfs.py
- python -m ruff format market_health/etf_universe_v1.py tests/test_global_broad_market_etfs.py
- python -m ruff check market_health/etf_universe_v1.py tests/test_global_broad_market_etfs.py
- python -m pytest -q tests/test_global_broad_market_etfs.py