### PR TITLE
Add Stop/Buy candidate clustering

### DIFF
--- a/market_health/stop_buy_levels.py
+++ b/market_health/stop_buy_levels.py
@@ -432,3 +432,217 @@ def generate_stop_buy_candidates(
             ),
         )
     ]
+
+
+def _candidate_level(candidate: dict[str, Any]) -> float | None:
+    try:
+        return float(candidate["level"])
+    except Exception:
+        return None
+
+
+def _candidate_weight(candidate: dict[str, Any]) -> float:
+    try:
+        return max(float(candidate.get("weight", 1.0)), 0.0)
+    except Exception:
+        return 1.0
+
+
+def _candidate_recency(candidate: dict[str, Any]) -> int | None:
+    try:
+        value = candidate.get("recency")
+        return None if value is None else int(value)
+    except Exception:
+        return None
+
+
+def _cluster_threshold(
+    *,
+    reference_level: float,
+    current_price: float | None,
+    atr: float | None,
+    max_distance_pct: float,
+    max_distance_atr: float,
+) -> float:
+    anchors = [abs(float(reference_level))]
+
+    if current_price is not None:
+        anchors.append(abs(float(current_price)))
+
+    pct_threshold = max(anchors) * float(max_distance_pct)
+
+    if atr is not None and atr > 0:
+        atr_threshold = float(atr) * float(max_distance_atr)
+        return max(pct_threshold, atr_threshold)
+
+    return pct_threshold
+
+
+def cluster_stop_buy_candidates(
+    candidates: list[dict[str, Any]],
+    *,
+    kind: CandidateKind | None = None,
+    current_price: float | None = None,
+    atr: float | None = None,
+    max_distance_pct: float = 0.0075,
+    max_distance_atr: float = 0.50,
+    min_cluster_weight: float = 0.0,
+    min_cluster_size: int = 1,
+) -> list[dict[str, Any]]:
+    """Cluster nearby Stop/Buy candidates and leave distant levels as separate outliers.
+
+    This is clustering only. It does not select final dashboard Stop/Buy levels and
+    does not change existing dashboard behavior.
+    """
+
+    normalized: list[dict[str, Any]] = []
+
+    for candidate in candidates:
+        if not isinstance(candidate, dict):
+            continue
+
+        candidate_kind = candidate.get("kind")
+        if candidate_kind not in {"floor", "ceiling"}:
+            continue
+        if kind is not None and candidate_kind != kind:
+            continue
+
+        level = _candidate_level(candidate)
+        if level is None:
+            continue
+
+        weight = _candidate_weight(candidate)
+
+        normalized.append(
+            {
+                "level": float(level),
+                "kind": candidate_kind,
+                "source": str(candidate.get("source") or "unknown"),
+                "weight": weight,
+                "recency": _candidate_recency(candidate),
+                "detail": candidate.get("detail"),
+            }
+        )
+
+    normalized.sort(key=lambda item: (item["kind"], item["level"], item["source"]))
+
+    clusters_raw: list[list[dict[str, Any]]] = []
+
+    for candidate in normalized:
+        if not clusters_raw:
+            clusters_raw.append([candidate])
+            continue
+
+        previous_cluster = clusters_raw[-1]
+        previous_kind = previous_cluster[0]["kind"]
+
+        if candidate["kind"] != previous_kind:
+            clusters_raw.append([candidate])
+            continue
+
+        total_weight = sum(_candidate_weight(item) for item in previous_cluster)
+        if total_weight > 0:
+            reference_level = (
+                sum(
+                    float(item["level"]) * _candidate_weight(item)
+                    for item in previous_cluster
+                )
+                / total_weight
+            )
+        else:
+            reference_level = float(previous_cluster[-1]["level"])
+
+        threshold = _cluster_threshold(
+            reference_level=reference_level,
+            current_price=current_price,
+            atr=atr,
+            max_distance_pct=max_distance_pct,
+            max_distance_atr=max_distance_atr,
+        )
+
+        if abs(float(candidate["level"]) - reference_level) <= threshold:
+            previous_cluster.append(candidate)
+        else:
+            clusters_raw.append([candidate])
+
+    clusters: list[dict[str, Any]] = []
+
+    for cluster in clusters_raw:
+        total_weight = sum(_candidate_weight(item) for item in cluster)
+        if len(cluster) < int(min_cluster_size):
+            continue
+        if total_weight < float(min_cluster_weight):
+            continue
+
+        levels = [float(item["level"]) for item in cluster]
+        if total_weight > 0:
+            center = (
+                sum(float(item["level"]) * _candidate_weight(item) for item in cluster)
+                / total_weight
+            )
+        else:
+            center = sum(levels) / len(levels)
+
+        recencies = [
+            int(item["recency"]) for item in cluster if item.get("recency") is not None
+        ]
+        sources = sorted({str(item["source"]) for item in cluster})
+
+        cluster_kind = str(cluster[0]["kind"])
+        strength = total_weight * (1.0 + 0.15 * max(len(sources) - 1, 0))
+
+        clusters.append(
+            {
+                "kind": cluster_kind,
+                "center": round(float(center), 6),
+                "lower": round(float(min(levels)), 6),
+                "upper": round(float(max(levels)), 6),
+                "weight": round(float(total_weight), 6),
+                "strength": round(float(strength), 6),
+                "count": len(cluster),
+                "sources": sources,
+                "nearest_recency": min(recencies) if recencies else None,
+                "is_outlier": len(cluster) == 1,
+            }
+        )
+
+    return sorted(
+        clusters,
+        key=lambda item: (
+            str(item["kind"]),
+            -float(item["strength"]),
+            -int(item["count"]),
+            float(item["center"]),
+        ),
+    )
+
+
+def strongest_stop_buy_clusters(
+    candidates: list[dict[str, Any]],
+    *,
+    current_price: float | None = None,
+    atr: float | None = None,
+    max_distance_pct: float = 0.0075,
+    max_distance_atr: float = 0.50,
+    min_cluster_weight: float = 0.0,
+    min_cluster_size: int = 1,
+) -> dict[str, dict[str, Any] | None]:
+    """Return the strongest floor and ceiling clusters from candidate levels."""
+
+    clusters = cluster_stop_buy_candidates(
+        candidates,
+        current_price=current_price,
+        atr=atr,
+        max_distance_pct=max_distance_pct,
+        max_distance_atr=max_distance_atr,
+        min_cluster_weight=min_cluster_weight,
+        min_cluster_size=min_cluster_size,
+    )
+
+    floors = [cluster for cluster in clusters if cluster["kind"] == "floor"]
+    ceilings = [cluster for cluster in clusters if cluster["kind"] == "ceiling"]
+
+    return {
+        "floor": floors[0] if floors else None,
+        "ceiling": ceilings[0] if ceilings else None,
+    }

--- a/tests/test_stop_buy_clustering.py
+++ b/tests/test_stop_buy_clustering.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from market_health.stop_buy_levels import (
+    cluster_stop_buy_candidates,
+    strongest_stop_buy_clusters,
+)
+
+
+def test_cluster_stop_buy_candidates_groups_nearby_floor_levels():
+    candidates = [
+        {"level": 98.00, "kind": "floor", "source": "swing_low", "weight": 1.0},
+        {"level": 98.25, "kind": "floor", "source": "ema_21", "weight": 0.7},
+        {"level": 98.40, "kind": "floor", "source": "rolling_low_20d", "weight": 0.85},
+        {"level": 90.00, "kind": "floor", "source": "distant_low", "weight": 1.0},
+    ]
+
+    clusters = cluster_stop_buy_candidates(
+        candidates,
+        kind="floor",
+        current_price=100.0,
+        atr=2.0,
+        max_distance_pct=0.005,
+        max_distance_atr=0.50,
+    )
+
+    assert len(clusters) == 2
+
+    strongest = clusters[0]
+    outlier = clusters[1]
+
+    assert strongest["kind"] == "floor"
+    assert strongest["count"] == 3
+    assert strongest["is_outlier"] is False
+    assert strongest["lower"] == 98.0
+    assert strongest["upper"] == 98.4
+    assert set(strongest["sources"]) == {"ema_21", "rolling_low_20d", "swing_low"}
+
+    assert outlier["count"] == 1
+    assert outlier["is_outlier"] is True
+    assert outlier["center"] == 90.0
+
+
+def test_cluster_stop_buy_candidates_groups_nearby_ceiling_levels():
+    candidates = [
+        {"level": 105.00, "kind": "ceiling", "source": "swing_high", "weight": 1.0},
+        {
+            "level": 105.35,
+            "kind": "ceiling",
+            "source": "rolling_high_20d",
+            "weight": 0.85,
+        },
+        {"level": 112.00, "kind": "ceiling", "source": "distant_high", "weight": 1.0},
+    ]
+
+    clusters = cluster_stop_buy_candidates(
+        candidates,
+        kind="ceiling",
+        current_price=100.0,
+        atr=2.0,
+        max_distance_pct=0.005,
+        max_distance_atr=0.50,
+    )
+
+    assert len(clusters) == 2
+
+    strongest = clusters[0]
+
+    assert strongest["kind"] == "ceiling"
+    assert strongest["count"] == 2
+    assert strongest["is_outlier"] is False
+    assert strongest["lower"] == 105.0
+    assert strongest["upper"] == 105.35
+    assert set(strongest["sources"]) == {"rolling_high_20d", "swing_high"}
+
+
+def test_strongest_stop_buy_clusters_returns_best_floor_and_ceiling():
+    candidates = [
+        {"level": 97.90, "kind": "floor", "source": "swing_low", "weight": 1.0},
+        {"level": 98.10, "kind": "floor", "source": "ema_21", "weight": 0.7},
+        {"level": 104.90, "kind": "ceiling", "source": "swing_high", "weight": 1.0},
+        {
+            "level": 105.10,
+            "kind": "ceiling",
+            "source": "rolling_high_20d",
+            "weight": 0.85,
+        },
+    ]
+
+    result = strongest_stop_buy_clusters(candidates, current_price=100.0, atr=2.0)
+
+    assert result["floor"] is not None
+    assert result["ceiling"] is not None
+    assert result["floor"]["kind"] == "floor"
+    assert result["ceiling"]["kind"] == "ceiling"
+    assert result["floor"]["count"] == 2
+    assert result["ceiling"]["count"] == 2
+
+
+def test_cluster_stop_buy_candidates_filters_by_minimum_cluster_size():
+    candidates = [
+        {"level": 98.00, "kind": "floor", "source": "swing_low", "weight": 1.0},
+        {"level": 90.00, "kind": "floor", "source": "distant_low", "weight": 1.0},
+    ]
+
+    clusters = cluster_stop_buy_candidates(
+        candidates,
+        kind="floor",
+        current_price=100.0,
+        min_cluster_size=2,
+    )
+
+    assert clusters == []
+
+
+def test_cluster_stop_buy_candidates_ignores_invalid_candidates():
+    candidates = [
+        {"level": "not-a-number", "kind": "floor", "source": "bad", "weight": 1.0},
+        {"level": 98.0, "kind": "unknown", "source": "bad", "weight": 1.0},
+        {"level": 98.0, "kind": "floor", "source": "good", "weight": 1.0},
+    ]
+
+    clusters = cluster_stop_buy_candidates(candidates, current_price=100.0)
+
+    assert len(clusters) == 1
+    assert clusters[0]["sources"] == ["good"]


### PR DESCRIPTION
Refs #300.
Refs #304.

Summary:
- Adds clustering and outlier handling for generated Stop/Buy candidates.
- Groups nearby floor and ceiling candidate levels using percentage and ATR-normalized distance thresholds.
- Produces cluster center, lower/upper bounds, total weight, strength, count, sources, nearest recency, and outlier flag.
- Adds helper to return strongest floor and strongest ceiling clusters.
- Does not change dashboard Stop/Buy behavior yet.

Scope:
- No dashboard column changes.
- No final Stop/Buy selection yet.
- No trading behavior changes.
- No C/H1/H5 scoring changes.

Validation:
- python -m compileall -q market_health/stop_buy_levels.py tests/test_stop_buy_clustering.py
- python -m ruff format market_health/stop_buy_levels.py tests/test_stop_buy_clustering.py
- python -m ruff check market_health/stop_buy_levels.py tests/test_stop_buy_clustering.py
- python -m pytest -q tests/test_stop_buy_clustering.py tests/test_stop_buy_levels.py