### PR TITLE
Use clustered executable Stop/Buy levels

### DIFF
--- a/market_health/dashboard_legacy.py
+++ b/market_health/dashboard_legacy.py
@@ -852,8 +852,53 @@ def _direct_structure_summary_from_df(df):
     support_cushion_atr = max(0.0, (last_close - recent_low) / atr_last)
     overhead_resistance_atr = max(0.0, (recent_high - last_close) / atr_last)
 
-    stop = recent_low - (0.25 * atr_last)
-    buy = recent_high + (0.25 * atr_last)
+    fallback_stop = recent_low - (0.25 * atr_last)
+    fallback_buy = recent_high + (0.25 * atr_last)
+    stop = fallback_stop
+    buy = fallback_buy
+    stop_source = "recent_low_atr_fallback"
+    buy_source = "recent_high_atr_fallback"
+
+    try:
+        from market_health.stop_buy_levels import (
+            generate_stop_buy_candidates,
+            strongest_stop_buy_clusters,
+        )
+
+        ohlcv_df = next(
+            (
+                value
+                for value in locals().values()
+                if hasattr(value, "columns")
+                and hasattr(value, "empty")
+                and "Close" in value.columns
+            ),
+            None,
+        )
+
+        if ohlcv_df is not None:
+            candidates = generate_stop_buy_candidates(ohlcv_df)
+            clusters = strongest_stop_buy_clusters(
+                candidates,
+                current_price=last_close,
+                atr=atr_last,
+                min_cluster_size=2,
+            )
+            floor_cluster = clusters.get("floor")
+            ceiling_cluster = clusters.get("ceiling")
+
+            if floor_cluster is not None:
+                stop = float(floor_cluster["lower"]) - (0.25 * atr_last)
+                stop_source = "clustered_floor"
+
+            if ceiling_cluster is not None:
+                buy = float(ceiling_cluster["upper"]) + (0.25 * atr_last)
+                buy_source = "clustered_ceiling"
+    except Exception:
+        stop = fallback_stop
+        buy = fallback_buy
+        stop_source = "recent_low_atr_fallback"
+        buy_source = "recent_high_atr_fallback"
 
     state_tags = []
     if support_cushion_atr <= 0.25:
@@ -879,6 +924,8 @@ def _direct_structure_summary_from_df(df):
         "stop_candidate": round(stop, 6),
         "catastrophic_stop_candidate": round(stop, 6),
         "buy": round(buy, 6),
+        "stop_source": stop_source,
+        "buy_source": buy_source,
         "buy_candidate": round(buy, 6),
         "stop_buy_candidate": round(buy, 6),
         "breakout_trigger": round(buy, 6),

--- a/tests/test_clustered_stop_buy_dashboard_integration.py
+++ b/tests/test_clustered_stop_buy_dashboard_integration.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from market_health.stop_buy_levels import (
+    generate_stop_buy_candidates,
+    strongest_stop_buy_clusters,
+)
+
+
+def test_clustered_executable_stop_buy_math_uses_cluster_edges_plus_atr_buffer():
+    df = pd.DataFrame(
+        {
+            "High": [
+                100.0,
+                101.0,
+                102.0,
+                105.0,
+                104.8,
+                105.1,
+                103.0,
+                102.0,
+                101.0,
+                100.0,
+                99.0,
+                99.2,
+                98.9,
+                100.0,
+                101.0,
+                102.0,
+            ],
+            "Low": [
+                96.0,
+                97.0,
+                98.0,
+                100.0,
+                99.8,
+                100.1,
+                98.0,
+                97.0,
+                96.0,
+                95.0,
+                94.0,
+                94.2,
+                94.1,
+                95.0,
+                96.0,
+                97.0,
+            ],
+            "Close": [
+                98.0,
+                99.0,
+                100.0,
+                102.0,
+                103.0,
+                104.0,
+                101.0,
+                99.0,
+                98.0,
+                97.0,
+                96.0,
+                96.4,
+                96.1,
+                98.0,
+                99.0,
+                100.0,
+            ],
+            "Volume": [1000.0] * 16,
+        }
+    )
+
+    high = df["High"]
+    low = df["Low"]
+    close = df["Close"]
+    prev_close = close.shift(1)
+
+    tr = pd.concat(
+        [
+            high - low,
+            (high - prev_close).abs(),
+            (low - prev_close).abs(),
+        ],
+        axis=1,
+    ).max(axis=1)
+
+    atr_last = float(tr.rolling(14, min_periods=5).mean().iloc[-1])
+
+    candidates = generate_stop_buy_candidates(df)
+    clusters = strongest_stop_buy_clusters(
+        candidates,
+        current_price=float(close.iloc[-1]),
+        atr=atr_last,
+        min_cluster_size=2,
+    )
+
+    assert clusters["floor"] is not None
+    assert clusters["ceiling"] is not None
+
+    stop = float(clusters["floor"]["lower"]) - (0.25 * atr_last)
+    buy = float(clusters["ceiling"]["upper"]) + (0.25 * atr_last)
+
+    assert stop < float(close.iloc[-1])
+    assert buy > float(close.iloc[-1])

--- a/tests/test_stop_buy_fallback_math.py
+++ b/tests/test_stop_buy_fallback_math.py
@@ -3,19 +3,22 @@ from __future__ import annotations
 from pathlib import Path
 
 
-def test_dashboard_legacy_documents_current_stop_buy_fallback_math():
+def test_dashboard_legacy_uses_clustered_stop_buy_with_fallback_math():
     source = Path("market_health/dashboard_legacy.py").read_text(encoding="utf-8")
 
     assert "atr = tr.rolling(14, min_periods=5).mean()" in source
-    assert (
-        "support_cushion_atr = max(0.0, (last_close - recent_low) / atr_last)" in source
-    )
-    assert (
-        "overhead_resistance_atr = max(0.0, (recent_high - last_close) / atr_last)"
-        in source
-    )
-    assert "stop = recent_low - (0.25 * atr_last)" in source
-    assert "buy = recent_high + (0.25 * atr_last)" in source
+
+    assert "fallback_stop = recent_low - (0.25 * atr_last)" in source
+    assert "fallback_buy = recent_high + (0.25 * atr_last)" in source
+
+    assert "generate_stop_buy_candidates" in source
+    assert "strongest_stop_buy_clusters" in source
+    assert "min_cluster_size=2" in source
+
+    assert 'stop_source = "clustered_floor"' in source
+    assert 'buy_source = "clustered_ceiling"' in source
+    assert 'stop_source = "recent_low_atr_fallback"' in source
+    assert 'buy_source = "recent_high_atr_fallback"' in source
 
     assert '"stop": round(stop, 6)' in source
     assert '"stop_candidate": round(stop, 6)' in source
@@ -31,3 +34,5 @@ def test_dashboard_table_keeps_simple_stop_and_buy_columns():
 
     assert 'tbl.add_column("Stop"' in source
     assert 'tbl.add_column("Buy"' in source
+    assert 'tbl.add_column("Stop Source"' not in source
+    assert 'tbl.add_column("Buy Source"' not in source


### PR DESCRIPTION
Refs #300.
Refs #305.

Summary:
- Replaces dashboard Stop/Buy calculation with clustered executable levels when usable clusters exist.
- Stop now uses strongest floor cluster lower edge minus 0.25 ATR.
- Buy now uses strongest ceiling cluster upper edge plus 0.25 ATR.
- Keeps recent-low/recent-high ATR math as fallback only.
- Keeps the terminal output simple with only the existing Stop and Buy columns.
- Adds hidden stop_source and buy_source metadata for audit/reporting without adding dashboard columns.

Scope:
- No dashboard column changes.
- No C/H1/H5 scoring changes.
- No ranking changes.
- No swap-candidate logic.

Validation:
- python -m compileall -q market_health/dashboard_legacy.py tests/test_stop_buy_fallback_math.py tests/test_clustered_stop_buy_dashboard_integration.py
- python -m ruff format market_health/dashboard_legacy.py tests/test_stop_buy_fallback_math.py tests/test_clustered_stop_buy_dashboard_integration.py
- python -m ruff check market_health/dashboard_legacy.py tests/test_stop_buy_fallback_math.py tests/test_clustered_stop_buy_dashboard_integration.py
- python -m pytest -q tests/test_stop_buy_fallback_math.py tests/test_clustered_stop_buy_dashboard_integration.py tests/test_stop_buy_clustering.py tests/test_stop_buy_levels.py