### PR TITLE
Collect M43 held-position snapshots

### DIFF
--- a/market_health/alert_snapshots.py
+++ b/market_health/alert_snapshots.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import datetime as dt
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Optional
+
+from market_health.alert_store import add_symbol_snapshot
+
+
+def _utc_now_iso() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _as_list(value: Any) -> List[Mapping[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    return [x for x in value if isinstance(x, Mapping)]
+
+
+def _first_value(row: Mapping[str, Any], names: Iterable[str]) -> Any:
+    for name in names:
+        if name in row:
+            return row[name]
+    return None
+
+
+def _as_float(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+
+    text = str(value).strip()
+    if not text or text in {"-", "—", "N/A", "n/a", "None", "null"}:
+        return None
+
+    text = text.replace("%", "").replace("$", "").replace(",", "")
+    try:
+        return float(text)
+    except ValueError:
+        return None
+
+
+def _as_text(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _symbol_from_row(row: Mapping[str, Any]) -> Optional[str]:
+    value = _first_value(row, ("symbol", "Symbol", "sym", "Sym", "ticker", "Ticker"))
+    text = _as_text(value)
+    return text.upper() if text else None
+
+
+def _rows_by_symbol(rows: Iterable[Mapping[str, Any]]) -> Dict[str, Mapping[str, Any]]:
+    out: Dict[str, Mapping[str, Any]] = {}
+    for row in rows:
+        symbol = _symbol_from_row(row)
+        if symbol:
+            out[symbol] = row
+    return out
+
+
+def _position_rows(ui_doc: Mapping[str, Any]) -> List[Mapping[str, Any]]:
+    data = ui_doc.get("data")
+    if not isinstance(data, Mapping):
+        return []
+
+    positions_doc = data.get("positions")
+    if isinstance(positions_doc, Mapping):
+        return _as_list(positions_doc.get("positions"))
+    return _as_list(positions_doc)
+
+
+def _sector_rows(ui_doc: Mapping[str, Any]) -> List[Mapping[str, Any]]:
+    data = ui_doc.get("data")
+    if not isinstance(data, Mapping):
+        return []
+    return _as_list(data.get("sectors"))
+
+
+@dataclass(frozen=True)
+class HeldPositionSnapshot:
+    symbol: str
+    ts_utc: str
+    current_score: Optional[float] = None
+    blend_score: Optional[float] = None
+    h1_score: Optional[float] = None
+    h5_score: Optional[float] = None
+    state: Optional[str] = None
+    stop_price: Optional[float] = None
+    buy_price: Optional[float] = None
+    sup_atr: Optional[float] = None
+    res_atr: Optional[float] = None
+    last_price: Optional[float] = None
+    source: Optional[Dict[str, Any]] = None
+
+
+def collect_held_position_snapshots(
+    ui_doc: Mapping[str, Any],
+    *,
+    ts_utc: Optional[str] = None,
+) -> List[HeldPositionSnapshot]:
+    """Normalize held-position rows from a market_health.ui.v1-style document.
+
+    This collector intentionally consumes JSON/artifact data rather than terminal
+    dashboard output. It accepts multiple field spellings so later UI contract
+    changes can be adapted without breaking the storage layer.
+    """
+
+    snapshot_ts = ts_utc or _as_text(ui_doc.get("asof")) or _utc_now_iso()
+    sectors_by_symbol = _rows_by_symbol(_sector_rows(ui_doc))
+
+    snapshots: List[HeldPositionSnapshot] = []
+    for pos in _position_rows(ui_doc):
+        symbol = _symbol_from_row(pos)
+        if not symbol:
+            continue
+
+        sector = sectors_by_symbol.get(symbol, {})
+
+        def pick(*names: str) -> Any:
+            return (
+                _first_value(pos, names)
+                if _first_value(pos, names) is not None
+                else _first_value(sector, names)
+            )
+
+        source = {
+            "schema": ui_doc.get("schema"),
+            "asof": ui_doc.get("asof"),
+            "position": dict(pos),
+        }
+        if sector:
+            source["sector"] = dict(sector)
+
+        snapshots.append(
+            HeldPositionSnapshot(
+                symbol=symbol,
+                ts_utc=snapshot_ts,
+                current_score=_as_float(pick("current_score", "current", "C", "score")),
+                blend_score=_as_float(pick("blend_score", "Blend", "blend")),
+                h1_score=_as_float(pick("h1_score", "H1", "h1")),
+                h5_score=_as_float(pick("h5_score", "H5", "h5")),
+                state=_as_text(pick("state", "State")),
+                stop_price=_as_float(pick("stop_price", "Stop", "stop")),
+                buy_price=_as_float(pick("buy_price", "Buy", "buy")),
+                sup_atr=_as_float(pick("sup_atr", "SupATR", "support_atr")),
+                res_atr=_as_float(pick("res_atr", "ResATR", "resistance_atr")),
+                last_price=_as_float(pick("last_price", "Last", "price", "mark")),
+                source=source,
+            )
+        )
+
+    return snapshots
+
+
+def load_ui_doc(path: Path) -> Mapping[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, Mapping):
+        raise ValueError(f"expected object JSON document: {path}")
+    return data
+
+
+def collect_held_position_snapshots_from_file(path: Path) -> List[HeldPositionSnapshot]:
+    return collect_held_position_snapshots(load_ui_doc(path))
+
+
+def write_held_position_snapshots(
+    *,
+    db_path: Path,
+    run_id: int,
+    ui_doc: Mapping[str, Any],
+    ts_utc: Optional[str] = None,
+) -> List[int]:
+    row_ids: List[int] = []
+    for snap in collect_held_position_snapshots(ui_doc, ts_utc=ts_utc):
+        row_ids.append(
+            add_symbol_snapshot(
+                db_path=db_path,
+                run_id=run_id,
+                symbol=snap.symbol,
+                ts_utc=snap.ts_utc,
+                is_held=True,
+                current_score=snap.current_score,
+                blend_score=snap.blend_score,
+                h1_score=snap.h1_score,
+                h5_score=snap.h5_score,
+                state=snap.state,
+                stop_price=snap.stop_price,
+                buy_price=snap.buy_price,
+                sup_atr=snap.sup_atr,
+                res_atr=snap.res_atr,
+                last_price=snap.last_price,
+                source=snap.source,
+            )
+        )
+    return row_ids
+
+
+def write_held_position_snapshots_from_file(
+    *,
+    db_path: Path,
+    run_id: int,
+    ui_path: Path,
+    ts_utc: Optional[str] = None,
+) -> List[int]:
+    return write_held_position_snapshots(
+        db_path=db_path,
+        run_id=run_id,
+        ui_doc=load_ui_doc(ui_path),
+        ts_utc=ts_utc,
+    )

--- a/tests/test_alert_snapshots.py
+++ b/tests/test_alert_snapshots.py
@@ -1,0 +1,173 @@
+import json
+import sqlite3
+from pathlib import Path
+
+from market_health.alert_snapshots import (
+    collect_held_position_snapshots,
+    collect_held_position_snapshots_from_file,
+    write_held_position_snapshots,
+    write_held_position_snapshots_from_file,
+)
+from market_health.alert_store import count_rows, start_run
+
+
+def _ui_doc() -> dict:
+    return {
+        "schema": "jerboa.market_health.ui.v1",
+        "asof": "2026-04-30T15:00:00Z",
+        "data": {
+            "positions": {
+                "schema": "positions.v1",
+                "positions": [
+                    {"symbol": "spy", "qty": 2, "last_price": "$510.25"},
+                    {
+                        "Symbol": "XLF",
+                        "State": "DMG",
+                        "Stop": "43.10",
+                        "Buy": "45.25",
+                    },
+                ],
+            },
+            "sectors": [
+                {
+                    "symbol": "SPY",
+                    "C": "72.5",
+                    "Blend": "70.0",
+                    "H1": "66.0",
+                    "H5": "61.0",
+                    "State": "clean",
+                    "SupATR": "1.2",
+                    "ResATR": "0.8",
+                },
+                {
+                    "Sym": "XLF",
+                    "C": 55,
+                    "Blend": 58,
+                    "H1": 49,
+                    "H5": 47,
+                    "SupATR": 1.9,
+                    "ResATR": 1.1,
+                    "Last": 44.5,
+                },
+            ],
+        },
+    }
+
+
+def test_collect_held_position_snapshots_merges_position_and_sector_fields() -> None:
+    snapshots = collect_held_position_snapshots(_ui_doc())
+
+    assert [s.symbol for s in snapshots] == ["SPY", "XLF"]
+
+    spy = snapshots[0]
+    assert spy.ts_utc == "2026-04-30T15:00:00Z"
+    assert spy.current_score == 72.5
+    assert spy.blend_score == 70.0
+    assert spy.h1_score == 66.0
+    assert spy.h5_score == 61.0
+    assert spy.state == "clean"
+    assert spy.stop_price is None
+    assert spy.buy_price is None
+    assert spy.sup_atr == 1.2
+    assert spy.res_atr == 0.8
+    assert spy.last_price == 510.25
+    assert spy.source is not None
+    assert spy.source["position"]["symbol"] == "spy"
+    assert spy.source["sector"]["symbol"] == "SPY"
+
+    xlf = snapshots[1]
+    assert xlf.current_score == 55.0
+    assert xlf.state == "DMG"
+    assert xlf.stop_price == 43.10
+    assert xlf.buy_price == 45.25
+    assert xlf.last_price == 44.5
+
+
+def test_collect_handles_empty_positions() -> None:
+    doc = {
+        "schema": "jerboa.market_health.ui.v1",
+        "asof": "2026-04-30T15:00:00Z",
+        "data": {"positions": {"positions": []}, "sectors": []},
+    }
+
+    assert collect_held_position_snapshots(doc) == []
+
+
+def test_collect_from_file(tmp_path: Path) -> None:
+    ui_path = tmp_path / "market_health.ui.v1.json"
+    ui_path.write_text(json.dumps(_ui_doc()), encoding="utf-8")
+
+    snapshots = collect_held_position_snapshots_from_file(ui_path)
+
+    assert [s.symbol for s in snapshots] == ["SPY", "XLF"]
+
+
+def test_write_held_position_snapshots_to_alert_store(tmp_path: Path) -> None:
+    db = tmp_path / "market_health_alerts.v1.sqlite"
+    run_id = start_run(db_path=db, mode="dry-run", trigger_name="manual")
+
+    row_ids = write_held_position_snapshots(
+        db_path=db,
+        run_id=run_id,
+        ui_doc=_ui_doc(),
+    )
+
+    assert row_ids == [1, 2]
+    assert count_rows(db, "symbol_snapshots") == 2
+
+    conn = sqlite3.connect(str(db))
+    rows = conn.execute(
+        """
+        SELECT symbol, current_score, blend_score, h1_score, h5_score,
+               state, stop_price, buy_price, sup_atr, res_atr, last_price,
+               source_json
+        FROM symbol_snapshots
+        ORDER BY id
+        """
+    ).fetchall()
+    conn.close()
+
+    assert rows[0][0] == "SPY"
+    assert rows[0][1:11] == (
+        72.5,
+        70.0,
+        66.0,
+        61.0,
+        "clean",
+        None,
+        None,
+        1.2,
+        0.8,
+        510.25,
+    )
+    assert json.loads(rows[0][11])["schema"] == "jerboa.market_health.ui.v1"
+
+    assert rows[1][0] == "XLF"
+    assert rows[1][1:11] == (
+        55.0,
+        58.0,
+        49.0,
+        47.0,
+        "DMG",
+        43.10,
+        45.25,
+        1.9,
+        1.1,
+        44.5,
+    )
+
+
+def test_write_from_file(tmp_path: Path) -> None:
+    db = tmp_path / "market_health_alerts.v1.sqlite"
+    ui_path = tmp_path / "market_health.ui.v1.json"
+    ui_path.write_text(json.dumps(_ui_doc()), encoding="utf-8")
+    run_id = start_run(db_path=db, mode="dry-run", trigger_name="manual")
+
+    row_ids = write_held_position_snapshots_from_file(
+        db_path=db,
+        run_id=run_id,
+        ui_path=ui_path,
+    )
+
+    assert row_ids == [1, 2]
+    assert count_rows(db, "symbol_snapshots") == 2


### PR DESCRIPTION
## Summary

Adds the M43 held-position snapshot collector.

This introduces:

- `market_health/alert_snapshots.py`
- `tests/test_alert_snapshots.py`
- UI-contract/artifact-based held-position normalization
- merge of position rows with matching sector/dashboard rows
- writing held-symbol snapshots through `alert_store.add_symbol_snapshot`
- deterministic fixture tests using temp SQLite databases

## Scope

This PR intentionally does not add alert detectors, Telegram delivery, refresh runner behavior, or systemd units. Those are separate M43 issues.

## Testing

- `.venv-ci/bin/python -m py_compile market_health/alert_snapshots.py tests/test_alert_snapshots.py`
- `.venv-ci/bin/python -m pytest tests/test_alert_snapshots.py tests/test_alert_store.py -q`
- `.venv-ci/bin/ruff format --check market_health/alert_snapshots.py tests/test_alert_snapshots.py`
- `.venv-ci/bin/ruff check market_health/alert_snapshots.py tests/test_alert_snapshots.py`

Closes #322