### PR TITLE
Detect M43 position inventory changes

### DIFF
--- a/market_health/alert_detectors.py
+++ b/market_health/alert_detectors.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Optional, Set
+
+
+@dataclass(frozen=True)
+class AlertCandidate:
+    alert_key: str
+    alert_type: str
+    severity: str
+    title: str
+    message: str
+    symbol: Optional[str] = None
+    payload: Dict[str, Any] = field(default_factory=dict)
+
+
+def _normalize_symbols(symbols: Iterable[str]) -> Set[str]:
+    out: Set[str] = set()
+    for symbol in symbols:
+        text = str(symbol).strip().upper()
+        if text:
+            out.add(text)
+    return out
+
+
+def detect_position_inventory_changes(
+    *,
+    previous_symbols: Iterable[str],
+    current_symbols: Iterable[str],
+    suppress_first_run: bool = True,
+) -> List[AlertCandidate]:
+    """Detect held-position inventory changes between snapshots.
+
+    This detector is intentionally pure and does not send notifications. The
+    later runner/cooldown layer will decide whether candidates are stored,
+    suppressed, or delivered.
+    """
+
+    previous = _normalize_symbols(previous_symbols)
+    current = _normalize_symbols(current_symbols)
+
+    if suppress_first_run and not previous:
+        return []
+
+    added = sorted(current - previous)
+    removed = sorted(previous - current)
+
+    alerts: List[AlertCandidate] = []
+
+    for symbol in added:
+        alerts.append(
+            AlertCandidate(
+                alert_key=f"position_inventory:added:{symbol}",
+                alert_type="position_added",
+                severity="info",
+                symbol=symbol,
+                title=f"New held position detected: {symbol}",
+                message=f"{symbol} is present in the current held-position snapshot but was not present in the previous snapshot.",
+                payload={
+                    "symbol": symbol,
+                    "previous_symbols": sorted(previous),
+                    "current_symbols": sorted(current),
+                },
+            )
+        )
+
+    for symbol in removed:
+        alerts.append(
+            AlertCandidate(
+                alert_key=f"position_inventory:removed:{symbol}",
+                alert_type="position_removed",
+                severity="warning",
+                symbol=symbol,
+                title=f"Held position removed: {symbol}",
+                message=f"{symbol} was present in the previous held-position snapshot but is missing from the current snapshot.",
+                payload={
+                    "symbol": symbol,
+                    "previous_symbols": sorted(previous),
+                    "current_symbols": sorted(current),
+                },
+            )
+        )
+
+    if added or removed:
+        alerts.append(
+            AlertCandidate(
+                alert_key="position_inventory:symbol_set_changed",
+                alert_type="position_symbol_set_changed",
+                severity="info" if added and not removed else "warning",
+                title="Held position symbol set changed",
+                message="The held-position symbol set changed between snapshots.",
+                payload={
+                    "added": added,
+                    "removed": removed,
+                    "previous_symbols": sorted(previous),
+                    "current_symbols": sorted(current),
+                },
+            )
+        )
+
+    return alerts

--- a/tests/test_alert_detectors.py
+++ b/tests/test_alert_detectors.py
@@ -1,0 +1,93 @@
+from market_health.alert_detectors import detect_position_inventory_changes
+
+
+def test_position_inventory_suppresses_first_run_alert_storm() -> None:
+    alerts = detect_position_inventory_changes(
+        previous_symbols=[],
+        current_symbols=["SPY", "XLF"],
+    )
+
+    assert alerts == []
+
+
+def test_position_inventory_can_disable_first_run_suppression() -> None:
+    alerts = detect_position_inventory_changes(
+        previous_symbols=[],
+        current_symbols=["SPY"],
+        suppress_first_run=False,
+    )
+
+    assert [a.alert_type for a in alerts] == [
+        "position_added",
+        "position_symbol_set_changed",
+    ]
+    assert alerts[0].symbol == "SPY"
+
+
+def test_position_inventory_detects_new_held_position() -> None:
+    alerts = detect_position_inventory_changes(
+        previous_symbols=["SPY", "XLF"],
+        current_symbols=["SPY", "XLF", "XLK"],
+    )
+
+    assert [a.alert_type for a in alerts] == [
+        "position_added",
+        "position_symbol_set_changed",
+    ]
+    assert alerts[0].alert_key == "position_inventory:added:XLK"
+    assert alerts[0].severity == "info"
+    assert alerts[0].symbol == "XLK"
+    assert alerts[0].payload["previous_symbols"] == ["SPY", "XLF"]
+    assert alerts[0].payload["current_symbols"] == ["SPY", "XLF", "XLK"]
+
+    summary = alerts[1]
+    assert summary.alert_type == "position_symbol_set_changed"
+    assert summary.payload["added"] == ["XLK"]
+    assert summary.payload["removed"] == []
+
+
+def test_position_inventory_detects_removed_held_position() -> None:
+    alerts = detect_position_inventory_changes(
+        previous_symbols=["SPY", "XLF"],
+        current_symbols=["SPY"],
+    )
+
+    assert [a.alert_type for a in alerts] == [
+        "position_removed",
+        "position_symbol_set_changed",
+    ]
+    assert alerts[0].alert_key == "position_inventory:removed:XLF"
+    assert alerts[0].severity == "warning"
+    assert alerts[0].symbol == "XLF"
+
+    summary = alerts[1]
+    assert summary.alert_type == "position_symbol_set_changed"
+    assert summary.severity == "warning"
+    assert summary.payload["added"] == []
+    assert summary.payload["removed"] == ["XLF"]
+
+
+def test_position_inventory_detects_add_and_remove_together() -> None:
+    alerts = detect_position_inventory_changes(
+        previous_symbols=["SPY", "XLF"],
+        current_symbols=["SPY", "XLK"],
+    )
+
+    assert [a.alert_type for a in alerts] == [
+        "position_added",
+        "position_removed",
+        "position_symbol_set_changed",
+    ]
+    assert alerts[0].symbol == "XLK"
+    assert alerts[1].symbol == "XLF"
+    assert alerts[2].payload["added"] == ["XLK"]
+    assert alerts[2].payload["removed"] == ["XLF"]
+
+
+def test_position_inventory_equal_sets_have_no_alerts() -> None:
+    alerts = detect_position_inventory_changes(
+        previous_symbols=["spy", " xlf ", "SPY"],
+        current_symbols=["XLF", "SPY"],
+    )
+
+    assert alerts == []


### PR DESCRIPTION
## Summary

Adds the first M43 alert detector for held-position inventory changes.

This introduces:

- `market_health/alert_detectors.py`
- `tests/test_alert_detectors.py`
- structured `AlertCandidate`
- detection for newly held positions
- detection for removed held positions
- symbol-set changed summary alert
- first-run alert-storm suppression
- deterministic pure-function tests

## Scope

This PR intentionally does not add Telegram delivery, cooldown persistence, state-change alerts, forecast-warning alerts, refresh runner behavior, or systemd units. Those are separate M43 issues.

## Testing

- `.venv-ci/bin/python -m py_compile market_health/alert_detectors.py tests/test_alert_detectors.py`
- `.venv-ci/bin/python -m pytest tests/test_alert_detectors.py -q`
- `.venv-ci/bin/ruff format --check market_health/alert_detectors.py tests/test_alert_detectors.py`
- `.venv-ci/bin/ruff check market_health/alert_detectors.py tests/test_alert_detectors.py`

Closes #323