### PR TITLE
Detect M43 position state changes

### DIFF
--- a/market_health/alert_detectors.py
+++ b/market_health/alert_detectors.py
@@ -100,3 +100,83 @@ def detect_position_inventory_changes(
         )
 
     return alerts
+
+
+def _normalize_state_tokens(value: Optional[str]) -> Set[str]:
+    if value is None:
+        return set()
+
+    text = str(value).strip()
+    if not text:
+        return set()
+
+    parts = text.replace(",", " ").replace("|", " ").replace(";", " ").split()
+    tokens: Set[str] = set()
+    for part in parts:
+        token = part.strip().upper()
+        if not token or token in {"-", "—", "CLEAN", "OK", "NONE", "NULL", "N/A"}:
+            continue
+        tokens.add(token)
+    return tokens
+
+
+def detect_position_state_changes(
+    *,
+    previous_states: Dict[str, Optional[str]],
+    current_states: Dict[str, Optional[str]],
+) -> List[AlertCandidate]:
+    """Detect meaningful state transitions for symbols present in both snapshots."""
+
+    previous_by_symbol = {
+        str(symbol).strip().upper(): state
+        for symbol, state in previous_states.items()
+        if str(symbol).strip()
+    }
+    current_by_symbol = {
+        str(symbol).strip().upper(): state
+        for symbol, state in current_states.items()
+        if str(symbol).strip()
+    }
+
+    alerts: List[AlertCandidate] = []
+    for symbol in sorted(set(previous_by_symbol) & set(current_by_symbol)):
+        previous_tokens = _normalize_state_tokens(previous_by_symbol[symbol])
+        current_tokens = _normalize_state_tokens(current_by_symbol[symbol])
+
+        if previous_tokens == current_tokens:
+            continue
+
+        added = sorted(current_tokens - previous_tokens)
+        removed = sorted(previous_tokens - current_tokens)
+
+        if current_tokens and not previous_tokens:
+            severity = "warning"
+        elif not current_tokens and previous_tokens:
+            severity = "info"
+        elif added:
+            severity = "warning"
+        else:
+            severity = "info"
+
+        previous_label = ",".join(sorted(previous_tokens)) or "clean"
+        current_label = ",".join(sorted(current_tokens)) or "clean"
+
+        alerts.append(
+            AlertCandidate(
+                alert_key=f"position_state:{symbol}:{previous_label}->{current_label}",
+                alert_type="position_state_changed",
+                severity=severity,
+                symbol=symbol,
+                title=f"{symbol} state changed: {previous_label} -> {current_label}",
+                message=f"{symbol} state changed from {previous_label} to {current_label}.",
+                payload={
+                    "symbol": symbol,
+                    "previous_state": previous_label,
+                    "current_state": current_label,
+                    "added_tags": added,
+                    "removed_tags": removed,
+                },
+            )
+        )
+
+    return alerts

--- a/tests/test_alert_detectors.py
+++ b/tests/test_alert_detectors.py
@@ -1,4 +1,7 @@
-from market_health.alert_detectors import detect_position_inventory_changes
+from market_health.alert_detectors import (
+    detect_position_inventory_changes,
+    detect_position_state_changes,
+)
 
 
 def test_position_inventory_suppresses_first_run_alert_storm() -> None:
@@ -91,3 +94,89 @@ def test_position_inventory_equal_sets_have_no_alerts() -> None:
     )
 
     assert alerts == []
+
+
+def test_position_state_detects_clean_to_dmg() -> None:
+    alerts = detect_position_state_changes(
+        previous_states={"SPY": "clean"},
+        current_states={"SPY": "DMG"},
+    )
+
+    assert len(alerts) == 1
+    assert alerts[0].alert_type == "position_state_changed"
+    assert alerts[0].severity == "warning"
+    assert alerts[0].symbol == "SPY"
+    assert alerts[0].payload["previous_state"] == "clean"
+    assert alerts[0].payload["current_state"] == "DMG"
+    assert alerts[0].payload["added_tags"] == ["DMG"]
+    assert alerts[0].payload["removed_tags"] == []
+
+
+def test_position_state_detects_dmg_to_dmg_rcl() -> None:
+    alerts = detect_position_state_changes(
+        previous_states={"SPY": "DMG"},
+        current_states={"SPY": "DMG,RCL"},
+    )
+
+    assert len(alerts) == 1
+    assert alerts[0].severity == "warning"
+    assert alerts[0].payload["previous_state"] == "DMG"
+    assert alerts[0].payload["current_state"] == "DMG,RCL"
+    assert alerts[0].payload["added_tags"] == ["RCL"]
+    assert alerts[0].payload["removed_tags"] == []
+
+
+def test_position_state_detects_brk_and_oh_brk() -> None:
+    alerts = detect_position_state_changes(
+        previous_states={"SPY": "clean", "XLF": "DMG"},
+        current_states={"SPY": "BRK", "XLF": "OH,BRK"},
+    )
+
+    assert [a.symbol for a in alerts] == ["SPY", "XLF"]
+    assert alerts[0].payload["added_tags"] == ["BRK"]
+    assert alerts[1].payload["added_tags"] == ["BRK", "OH"]
+    assert all(a.severity == "warning" for a in alerts)
+
+
+def test_position_state_detects_rcl_disappears() -> None:
+    alerts = detect_position_state_changes(
+        previous_states={"SPY": "DMG,RCL"},
+        current_states={"SPY": "DMG"},
+    )
+
+    assert len(alerts) == 1
+    assert alerts[0].severity == "info"
+    assert alerts[0].payload["added_tags"] == []
+    assert alerts[0].payload["removed_tags"] == ["RCL"]
+
+
+def test_position_state_detects_damaged_to_clean() -> None:
+    alerts = detect_position_state_changes(
+        previous_states={"SPY": "DMG,BRK"},
+        current_states={"SPY": "clean"},
+    )
+
+    assert len(alerts) == 1
+    assert alerts[0].severity == "info"
+    assert alerts[0].payload["previous_state"] == "BRK,DMG"
+    assert alerts[0].payload["current_state"] == "clean"
+    assert alerts[0].payload["removed_tags"] == ["BRK", "DMG"]
+
+
+def test_position_state_ignores_formatting_only_changes() -> None:
+    alerts = detect_position_state_changes(
+        previous_states={"spy": "DMG, RCL", "xlf": "clean"},
+        current_states={"SPY": "RCL DMG", "XLF": "OK"},
+    )
+
+    assert alerts == []
+
+
+def test_position_state_ignores_symbols_not_present_in_both_snapshots() -> None:
+    alerts = detect_position_state_changes(
+        previous_states={"SPY": "DMG", "XLF": "BRK"},
+        current_states={"SPY": "DMG,RCL", "XLK": "DMG"},
+    )
+
+    assert len(alerts) == 1
+    assert alerts[0].symbol == "SPY"


### PR DESCRIPTION
## Summary

Adds M43 held-position state-change detection.

This extends the alert detector module with:

- structured state-transition alerts
- clean -> DMG detection
- DMG -> DMG,RCL detection
- BRK / OH,BRK tag detection
- RCL disappearing detection
- damaged -> clean recovery detection
- formatting-only state normalization/no-op behavior
- ignoring symbols that are not present in both snapshots

## Scope

This PR intentionally does not add Telegram delivery, cooldown persistence, forecast-warning alerts, refresh runner behavior, or systemd units. Those are separate M43 issues.

## Testing

- `.venv-ci/bin/python -m pytest tests/test_alert_detectors.py -q`
- `.venv-ci/bin/ruff format --check market_health/alert_detectors.py tests/test_alert_detectors.py`
- `.venv-ci/bin/ruff check market_health/alert_detectors.py tests/test_alert_detectors.py`

Closes #324