### PR TITLE
Detect M43 forecast warnings

### DIFF
--- a/market_health/alert_detectors.py
+++ b/market_health/alert_detectors.py
@@ -180,3 +180,129 @@ def detect_position_state_changes(
         )
 
     return alerts
+
+
+def _score_band(value: Optional[float]) -> str:
+    if value is None:
+        return "unknown"
+    if value >= 70:
+        return "green"
+    if value >= 55:
+        return "yellow"
+    return "red"
+
+
+def _band_rank(band: str) -> int:
+    return {"unknown": 0, "red": 1, "yellow": 2, "green": 3}.get(band, 0)
+
+
+def _is_band_worse(previous: Optional[float], current: Optional[float]) -> bool:
+    return _band_rank(_score_band(current)) < _band_rank(_score_band(previous))
+
+
+def detect_forecast_warnings(
+    *,
+    symbol: str,
+    current_score: Optional[float],
+    h1_score: Optional[float],
+    h5_score: Optional[float],
+    previous_h1_score: Optional[float] = None,
+    previous_h5_score: Optional[float] = None,
+    current_drop_threshold: float = 5.0,
+    previous_drop_threshold: float = 7.0,
+) -> List[AlertCandidate]:
+    """Detect forecast deterioration for one held symbol."""
+
+    normalized_symbol = str(symbol).strip().upper()
+    if not normalized_symbol:
+        return []
+
+    alerts: List[AlertCandidate] = []
+
+    horizon_values = {
+        "H1": h1_score,
+        "H5": h5_score,
+    }
+    previous_values = {
+        "H1": previous_h1_score,
+        "H5": previous_h5_score,
+    }
+
+    for horizon, forecast_score in horizon_values.items():
+        if current_score is not None and forecast_score is not None:
+            drop = float(current_score) - float(forecast_score)
+            if drop >= current_drop_threshold:
+                alerts.append(
+                    AlertCandidate(
+                        alert_key=f"forecast_warning:{normalized_symbol}:{horizon}:below_current",
+                        alert_type="forecast_below_current",
+                        severity="warning",
+                        symbol=normalized_symbol,
+                        title=f"{normalized_symbol} {horizon} forecast below current score",
+                        message=(
+                            f"{normalized_symbol} {horizon} forecast is {drop:.1f} points "
+                            "below the current score."
+                        ),
+                        payload={
+                            "symbol": normalized_symbol,
+                            "horizon": horizon,
+                            "current_score": float(current_score),
+                            "forecast_score": float(forecast_score),
+                            "drop": drop,
+                            "threshold": float(current_drop_threshold),
+                        },
+                    )
+                )
+
+        previous_score = previous_values[horizon]
+        if previous_score is not None and forecast_score is not None:
+            weakening = float(previous_score) - float(forecast_score)
+            if weakening >= previous_drop_threshold:
+                alerts.append(
+                    AlertCandidate(
+                        alert_key=f"forecast_warning:{normalized_symbol}:{horizon}:weakened",
+                        alert_type="forecast_weakened",
+                        severity="warning",
+                        symbol=normalized_symbol,
+                        title=f"{normalized_symbol} {horizon} forecast weakened",
+                        message=(
+                            f"{normalized_symbol} {horizon} forecast weakened by "
+                            f"{weakening:.1f} points since the previous snapshot."
+                        ),
+                        payload={
+                            "symbol": normalized_symbol,
+                            "horizon": horizon,
+                            "previous_score": float(previous_score),
+                            "forecast_score": float(forecast_score),
+                            "weakening": weakening,
+                            "threshold": float(previous_drop_threshold),
+                        },
+                    )
+                )
+
+            if _is_band_worse(previous_score, forecast_score):
+                previous_band = _score_band(previous_score)
+                current_band = _score_band(forecast_score)
+                alerts.append(
+                    AlertCandidate(
+                        alert_key=f"forecast_warning:{normalized_symbol}:{horizon}:band_worse",
+                        alert_type="forecast_band_worsened",
+                        severity="warning",
+                        symbol=normalized_symbol,
+                        title=f"{normalized_symbol} {horizon} forecast band worsened",
+                        message=(
+                            f"{normalized_symbol} {horizon} forecast band worsened "
+                            f"from {previous_band} to {current_band}."
+                        ),
+                        payload={
+                            "symbol": normalized_symbol,
+                            "horizon": horizon,
+                            "previous_score": float(previous_score),
+                            "forecast_score": float(forecast_score),
+                            "previous_band": previous_band,
+                            "current_band": current_band,
+                        },
+                    )
+                )
+
+    return alerts

--- a/tests/test_alert_detectors.py
+++ b/tests/test_alert_detectors.py
@@ -180,3 +180,117 @@ def test_position_state_ignores_symbols_not_present_in_both_snapshots() -> None:
 
     assert len(alerts) == 1
     assert alerts[0].symbol == "SPY"
+
+
+def test_forecast_warning_detects_h1_and_h5_below_current() -> None:
+    from market_health.alert_detectors import detect_forecast_warnings
+
+    alerts = detect_forecast_warnings(
+        symbol="spy",
+        current_score=72,
+        h1_score=66,
+        h5_score=60,
+    )
+
+    assert [a.alert_type for a in alerts] == [
+        "forecast_below_current",
+        "forecast_below_current",
+    ]
+    assert [a.payload["horizon"] for a in alerts] == ["H1", "H5"]
+    assert alerts[0].symbol == "SPY"
+    assert alerts[0].payload["drop"] == 6.0
+    assert alerts[1].payload["drop"] == 12.0
+
+
+def test_forecast_warning_current_drop_threshold_is_configurable() -> None:
+    from market_health.alert_detectors import detect_forecast_warnings
+
+    alerts = detect_forecast_warnings(
+        symbol="SPY",
+        current_score=72,
+        h1_score=68,
+        h5_score=67,
+        current_drop_threshold=4,
+    )
+
+    assert [a.payload["horizon"] for a in alerts] == ["H1", "H5"]
+
+
+def test_forecast_warning_detects_previous_snapshot_weakening() -> None:
+    from market_health.alert_detectors import detect_forecast_warnings
+
+    alerts = detect_forecast_warnings(
+        symbol="SPY",
+        current_score=70,
+        h1_score=60,
+        h5_score=58,
+        previous_h1_score=68,
+        previous_h5_score=70,
+        previous_drop_threshold=7,
+    )
+
+    weakened = [a for a in alerts if a.alert_type == "forecast_weakened"]
+    assert [a.payload["horizon"] for a in weakened] == ["H1", "H5"]
+    assert weakened[0].payload["weakening"] == 8.0
+    assert weakened[1].payload["weakening"] == 12.0
+
+
+def test_forecast_warning_detects_band_worsening() -> None:
+    from market_health.alert_detectors import detect_forecast_warnings
+
+    alerts = detect_forecast_warnings(
+        symbol="SPY",
+        current_score=72,
+        h1_score=54,
+        h5_score=69,
+        previous_h1_score=56,
+        previous_h5_score=71,
+    )
+
+    band_alerts = [a for a in alerts if a.alert_type == "forecast_band_worsened"]
+    assert [a.payload["horizon"] for a in band_alerts] == ["H1", "H5"]
+    assert band_alerts[0].payload["previous_band"] == "yellow"
+    assert band_alerts[0].payload["current_band"] == "red"
+    assert band_alerts[1].payload["previous_band"] == "green"
+    assert band_alerts[1].payload["current_band"] == "yellow"
+
+
+def test_forecast_warning_no_alert_when_scores_are_stable() -> None:
+    from market_health.alert_detectors import detect_forecast_warnings
+
+    alerts = detect_forecast_warnings(
+        symbol="SPY",
+        current_score=70,
+        h1_score=68,
+        h5_score=66,
+        previous_h1_score=69,
+        previous_h5_score=67,
+    )
+
+    assert alerts == []
+
+
+def test_forecast_warning_ignores_missing_scores_and_blank_symbol() -> None:
+    from market_health.alert_detectors import detect_forecast_warnings
+
+    assert (
+        detect_forecast_warnings(
+            symbol="",
+            current_score=70,
+            h1_score=60,
+            h5_score=55,
+        )
+        == []
+    )
+
+    assert (
+        detect_forecast_warnings(
+            symbol="SPY",
+            current_score=None,
+            h1_score=None,
+            h5_score=60,
+            previous_h1_score=None,
+            previous_h5_score=None,
+        )
+        == []
+    )


### PR DESCRIPTION
## Summary

Adds M43 forecast-warning detection for held positions.

This extends the alert detector module with:

- H1/H5 below-current warning detection
- configurable current-score drop threshold
- configurable previous-snapshot weakening threshold
- H1/H5 previous-snapshot weakening detection
- H1/H5 band-worsening detection
- missing-score and blank-symbol no-op behavior
- deterministic pure-function tests

## Scope

This PR intentionally does not add Telegram delivery, cooldown persistence, refresh runner behavior, or systemd units. Those are separate M43 issues.

## Testing

- `.venv-ci/bin/python -m py_compile market_health/alert_detectors.py tests/test_alert_detectors.py`
- `.venv-ci/bin/python -m pytest tests/test_alert_detectors.py -q`
- `.venv-ci/bin/ruff format --check market_health/alert_detectors.py tests/test_alert_detectors.py`
- `.venv-ci/bin/ruff check market_health/alert_detectors.py tests/test_alert_detectors.py`

Closes #325