### PR TITLE
Add M43 alert cooldown suppression

### DIFF
--- a/market_health/alert_cooldowns.py
+++ b/market_health/alert_cooldowns.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Optional, Tuple
+
+from market_health.alert_detectors import AlertCandidate
+from market_health.alert_store import apply_migrations, connect
+
+
+@dataclass(frozen=True)
+class AlertHistoryEvent:
+    alert_key: str
+    severity: str
+    ts_utc: str
+    alert_type: str = ""
+
+
+@dataclass(frozen=True)
+class AlertCooldownConfig:
+    default_cooldown_minutes: int = 60
+    critical_cooldown_minutes: int = 15
+    system_health_cooldown_minutes: int = 15
+
+
+@dataclass(frozen=True)
+class AlertCooldownDecision:
+    candidate: AlertCandidate
+    allowed: bool
+    reason: str = ""
+    matched_event: Optional[AlertHistoryEvent] = None
+
+
+def _parse_utc(value: str) -> dt.datetime:
+    text = str(value).strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    parsed = dt.datetime.fromisoformat(text)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.timezone.utc)
+    return parsed.astimezone(dt.timezone.utc)
+
+
+def _cooldown_minutes(
+    candidate: AlertCandidate,
+    config: AlertCooldownConfig,
+) -> int:
+    severity = candidate.severity.lower()
+    alert_type = candidate.alert_type.lower()
+
+    if severity in {"critical", "error"}:
+        return config.critical_cooldown_minutes
+    if alert_type.startswith("system") or alert_type.startswith("health"):
+        return config.system_health_cooldown_minutes
+    return config.default_cooldown_minutes
+
+
+def apply_alert_cooldowns(
+    *,
+    candidates: Iterable[AlertCandidate],
+    history: Iterable[AlertHistoryEvent],
+    now_utc: str,
+    config: AlertCooldownConfig = AlertCooldownConfig(),
+) -> Tuple[List[AlertCandidate], List[AlertCooldownDecision]]:
+    """Return allowed candidates plus suppression decisions.
+
+    Suppression key is `alert_key`.
+
+    Rules:
+    - no same-key history => allow
+    - same key but changed severity => allow
+    - same key and same severity inside cooldown => suppress
+    - critical/system-health candidates can use shorter cooldown windows
+    """
+
+    now = _parse_utc(now_utc)
+    history_by_key: dict[str, list[AlertHistoryEvent]] = {}
+    for event in history:
+        history_by_key.setdefault(event.alert_key, []).append(event)
+
+    allowed: List[AlertCandidate] = []
+    suppressed: List[AlertCooldownDecision] = []
+
+    for candidate in candidates:
+        events = history_by_key.get(candidate.alert_key, [])
+        if not events:
+            allowed.append(candidate)
+            continue
+
+        recent_event = max(events, key=lambda event: _parse_utc(event.ts_utc))
+
+        if recent_event.severity.lower() != candidate.severity.lower():
+            allowed.append(candidate)
+            continue
+
+        elapsed = now - _parse_utc(recent_event.ts_utc)
+        cooldown = dt.timedelta(minutes=_cooldown_minutes(candidate, config))
+
+        if elapsed < cooldown:
+            suppressed.append(
+                AlertCooldownDecision(
+                    candidate=candidate,
+                    allowed=False,
+                    reason=(
+                        "cooldown:"
+                        f"{int(elapsed.total_seconds() // 60)}m"
+                        f"<{int(cooldown.total_seconds() // 60)}m"
+                    ),
+                    matched_event=recent_event,
+                )
+            )
+        else:
+            allowed.append(candidate)
+
+    return allowed, suppressed
+
+
+def read_alert_history_from_store(
+    *,
+    db_path: Path,
+    limit: int = 1000,
+) -> List[AlertHistoryEvent]:
+    """Read prior alert delivery/cooldown state from the M43 alert store."""
+
+    with connect(db_path) as conn:
+        apply_migrations(conn)
+        rows = conn.execute(
+            """
+            SELECT alert_key, severity, ts_utc, alert_type
+            FROM alerts
+            ORDER BY id DESC
+            LIMIT ?
+            """,
+            (int(limit),),
+        ).fetchall()
+
+    return [
+        AlertHistoryEvent(
+            alert_key=str(row["alert_key"]),
+            severity=str(row["severity"]),
+            ts_utc=str(row["ts_utc"]),
+            alert_type=str(row["alert_type"] or ""),
+        )
+        for row in rows
+    ]

--- a/tests/test_alert_cooldowns.py
+++ b/tests/test_alert_cooldowns.py
@@ -1,0 +1,223 @@
+from pathlib import Path
+
+from market_health.alert_cooldowns import (
+    AlertCooldownConfig,
+    AlertHistoryEvent,
+    apply_alert_cooldowns,
+    read_alert_history_from_store,
+)
+from market_health.alert_detectors import AlertCandidate
+from market_health.alert_store import add_alert, start_run
+
+
+def _candidate(
+    *,
+    key: str = "position_state:SPY:clean->DMG",
+    severity: str = "warning",
+    alert_type: str = "position_state_changed",
+) -> AlertCandidate:
+    return AlertCandidate(
+        alert_key=key,
+        alert_type=alert_type,
+        severity=severity,
+        symbol="SPY",
+        title="SPY state changed",
+        message="SPY state changed.",
+        payload={"symbol": "SPY"},
+    )
+
+
+def test_alert_cooldown_suppresses_repeated_identical_alert() -> None:
+    candidate = _candidate()
+    history = [
+        AlertHistoryEvent(
+            alert_key=candidate.alert_key,
+            severity="warning",
+            ts_utc="2026-05-01T15:00:00Z",
+            alert_type=candidate.alert_type,
+        )
+    ]
+
+    allowed, suppressed = apply_alert_cooldowns(
+        candidates=[candidate],
+        history=history,
+        now_utc="2026-05-01T15:10:00Z",
+    )
+
+    assert allowed == []
+    assert len(suppressed) == 1
+    assert suppressed[0].candidate == candidate
+    assert suppressed[0].matched_event == history[0]
+    assert suppressed[0].reason == "cooldown:10m<60m"
+
+
+def test_alert_cooldown_allows_after_default_window() -> None:
+    candidate = _candidate()
+    history = [
+        AlertHistoryEvent(
+            alert_key=candidate.alert_key,
+            severity="warning",
+            ts_utc="2026-05-01T14:00:00Z",
+            alert_type=candidate.alert_type,
+        )
+    ]
+
+    allowed, suppressed = apply_alert_cooldowns(
+        candidates=[candidate],
+        history=history,
+        now_utc="2026-05-01T15:01:00Z",
+    )
+
+    assert allowed == [candidate]
+    assert suppressed == []
+
+
+def test_alert_cooldown_allows_when_severity_changes() -> None:
+    candidate = _candidate(severity="critical")
+    history = [
+        AlertHistoryEvent(
+            alert_key=candidate.alert_key,
+            severity="warning",
+            ts_utc="2026-05-01T15:00:00Z",
+            alert_type=candidate.alert_type,
+        )
+    ]
+
+    allowed, suppressed = apply_alert_cooldowns(
+        candidates=[candidate],
+        history=history,
+        now_utc="2026-05-01T15:05:00Z",
+    )
+
+    assert allowed == [candidate]
+    assert suppressed == []
+
+
+def test_alert_cooldown_uses_shorter_critical_window() -> None:
+    candidate = _candidate(severity="critical")
+    history = [
+        AlertHistoryEvent(
+            alert_key=candidate.alert_key,
+            severity="critical",
+            ts_utc="2026-05-01T15:00:00Z",
+            alert_type=candidate.alert_type,
+        )
+    ]
+
+    allowed, suppressed = apply_alert_cooldowns(
+        candidates=[candidate],
+        history=history,
+        now_utc="2026-05-01T15:16:00Z",
+        config=AlertCooldownConfig(
+            default_cooldown_minutes=60,
+            critical_cooldown_minutes=15,
+        ),
+    )
+
+    assert allowed == [candidate]
+    assert suppressed == []
+
+
+def test_alert_cooldown_suppresses_critical_inside_short_window() -> None:
+    candidate = _candidate(severity="critical")
+    history = [
+        AlertHistoryEvent(
+            alert_key=candidate.alert_key,
+            severity="critical",
+            ts_utc="2026-05-01T15:00:00Z",
+            alert_type=candidate.alert_type,
+        )
+    ]
+
+    allowed, suppressed = apply_alert_cooldowns(
+        candidates=[candidate],
+        history=history,
+        now_utc="2026-05-01T15:05:00Z",
+        config=AlertCooldownConfig(
+            default_cooldown_minutes=60,
+            critical_cooldown_minutes=15,
+        ),
+    )
+
+    assert allowed == []
+    assert len(suppressed) == 1
+    assert suppressed[0].reason == "cooldown:5m<15m"
+
+
+def test_alert_cooldown_uses_shorter_system_health_window() -> None:
+    candidate = _candidate(
+        key="system_health:refresh_failed",
+        severity="warning",
+        alert_type="system_health",
+    )
+    history = [
+        AlertHistoryEvent(
+            alert_key=candidate.alert_key,
+            severity="warning",
+            ts_utc="2026-05-01T15:00:00Z",
+            alert_type=candidate.alert_type,
+        )
+    ]
+
+    allowed, suppressed = apply_alert_cooldowns(
+        candidates=[candidate],
+        history=history,
+        now_utc="2026-05-01T15:20:00Z",
+        config=AlertCooldownConfig(
+            default_cooldown_minutes=60,
+            system_health_cooldown_minutes=15,
+        ),
+    )
+
+    assert allowed == [candidate]
+    assert suppressed == []
+
+
+def test_alert_history_can_be_read_from_sqlite_store(tmp_path: Path) -> None:
+    db = tmp_path / "market_health_alerts.v1.sqlite"
+    run_id = start_run(db_path=db, mode="dry-run", trigger_name="manual")
+
+    add_alert(
+        db_path=db,
+        run_id=run_id,
+        alert_key="position_state:SPY:clean->DMG",
+        alert_type="position_state_changed",
+        severity="warning",
+        symbol="SPY",
+        title="SPY state changed",
+        message="SPY changed to DMG.",
+        ts_utc="2026-05-01T15:00:00Z",
+    )
+
+    history = read_alert_history_from_store(db_path=db)
+
+    assert history == [
+        AlertHistoryEvent(
+            alert_key="position_state:SPY:clean->DMG",
+            severity="warning",
+            ts_utc="2026-05-01T15:00:00Z",
+            alert_type="position_state_changed",
+        )
+    ]
+
+
+def test_alert_cooldown_multiple_candidates_mixed_allowed_and_suppressed() -> None:
+    repeated = _candidate(key="position_state:SPY:clean->DMG")
+    new = _candidate(key="position_state:XLF:clean->BRK")
+    history = [
+        AlertHistoryEvent(
+            alert_key=repeated.alert_key,
+            severity="warning",
+            ts_utc="2026-05-01T15:00:00Z",
+            alert_type=repeated.alert_type,
+        )
+    ]
+
+    allowed, suppressed = apply_alert_cooldowns(
+        candidates=[repeated, new],
+        history=history,
+        now_utc="2026-05-01T15:10:00Z",
+    )
+
+    assert allowed == [new]
+    assert [d.candidate for d in suppressed] == [repeated]


### PR DESCRIPTION
## Summary

Adds M43 alert cooldown and duplicate suppression support.

This introduces:

- `market_health/alert_cooldowns.py`
- `tests/test_alert_cooldowns.py`
- cooldown keys based on `AlertCandidate.alert_key`
- repeated identical alert suppression
- severity-change bypass
- shorter critical alert cooldown
- shorter system-health alert cooldown
- SQLite alert-history reader for later runner integration
- deterministic tests using temp SQLite databases

## Scope

This PR intentionally does not add Telegram delivery, refresh runner behavior, or systemd units. Those are separate M43 issues.

## Testing

- `.venv-ci/bin/python -m py_compile market_health/alert_cooldowns.py tests/test_alert_cooldowns.py`
- `.venv-ci/bin/python -m pytest tests/test_alert_cooldowns.py tests/test_cooldown_policy.py -q`
- `.venv-ci/bin/ruff format --check market_health/alert_cooldowns.py tests/test_alert_cooldowns.py`
- `.venv-ci/bin/ruff check market_health/alert_cooldowns.py tests/test_alert_cooldowns.py`

Closes #326