### PR TITLE
Add M43 Telegram notifier modes

### DIFF
--- a/market_health/telegram_notifier.py
+++ b/market_health/telegram_notifier.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import datetime as dt
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Mapping, Optional
+
+import requests
+
+from market_health.alert_detectors import AlertCandidate
+from market_health.alert_store import add_alert
+
+
+@dataclass(frozen=True)
+class TelegramConfig:
+    mode: str = "disabled"
+    bot_token: str = ""
+    chat_id: str = ""
+    api_base: str = "https://api.telegram.org"
+
+
+@dataclass(frozen=True)
+class TelegramDeliveryResult:
+    delivery_status: str
+    sent: bool
+    text: str
+    error_text: Optional[str] = None
+    delivered_at_utc: Optional[str] = None
+
+
+Sender = Callable[[str, Mapping[str, str], int], Any]
+
+
+def _utc_now_iso() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _clean_mode(value: str) -> str:
+    mode = str(value or "disabled").strip().lower()
+    if mode not in {"disabled", "dry-run", "test", "live"}:
+        return "disabled"
+    return mode
+
+
+def load_telegram_config(path: Path) -> TelegramConfig:
+    """Load Telegram config from a local secrets/config file.
+
+    The file is expected to live outside committed repo paths, for example
+    ~/.config/jerboa/telegram.json or a future M43-specific secrets file.
+    """
+
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return TelegramConfig(mode="disabled")
+    except Exception:
+        return TelegramConfig(mode="disabled")
+
+    if not isinstance(raw, dict):
+        return TelegramConfig(mode="disabled")
+
+    return TelegramConfig(
+        mode=_clean_mode(str(raw.get("mode", "disabled"))),
+        bot_token=str(raw.get("bot_token", "")).strip(),
+        chat_id=str(raw.get("chat_id", "")).strip(),
+        api_base=str(raw.get("api_base", "https://api.telegram.org")).strip()
+        or "https://api.telegram.org",
+    )
+
+
+def _default_sender(url: str, data: Mapping[str, str], timeout: int) -> Any:
+    return requests.post(url, data=dict(data), timeout=timeout)
+
+
+def format_alert_message(
+    candidate: AlertCandidate,
+    *,
+    test_prefix: bool = False,
+) -> str:
+    prefix = "TEST: " if test_prefix else ""
+    parts = [
+        f"{prefix}{candidate.title}",
+        candidate.message,
+    ]
+    if candidate.symbol:
+        parts.append(f"Symbol: {candidate.symbol}")
+    parts.append(f"Severity: {candidate.severity}")
+    parts.append(f"Type: {candidate.alert_type}")
+    return "\n".join(part for part in parts if part)
+
+
+def send_alert_candidate(
+    candidate: AlertCandidate,
+    *,
+    config: TelegramConfig,
+    sender: Sender = _default_sender,
+    timeout: int = 10,
+    now_utc: Optional[str] = None,
+) -> TelegramDeliveryResult:
+    mode = _clean_mode(config.mode)
+    text = format_alert_message(candidate, test_prefix=(mode == "test"))
+
+    if mode == "disabled":
+        return TelegramDeliveryResult(
+            delivery_status="disabled",
+            sent=False,
+            text=text,
+        )
+
+    if mode == "dry-run":
+        return TelegramDeliveryResult(
+            delivery_status="dry-run",
+            sent=False,
+            text=text,
+        )
+
+    if not config.bot_token or not config.chat_id:
+        return TelegramDeliveryResult(
+            delivery_status="error",
+            sent=False,
+            text=text,
+            error_text="missing telegram bot_token or chat_id",
+        )
+
+    url = f"{config.api_base.rstrip('/')}/bot{config.bot_token}/sendMessage"
+    try:
+        response = sender(
+            url,
+            {"chat_id": config.chat_id, "text": text},
+            timeout,
+        )
+        if hasattr(response, "raise_for_status"):
+            response.raise_for_status()
+    except Exception as exc:
+        return TelegramDeliveryResult(
+            delivery_status="error",
+            sent=False,
+            text=text,
+            error_text=str(exc),
+        )
+
+    return TelegramDeliveryResult(
+        delivery_status="sent",
+        sent=True,
+        text=text,
+        delivered_at_utc=now_utc or _utc_now_iso(),
+    )
+
+
+def send_and_record_alert_candidate(
+    *,
+    db_path: Path,
+    run_id: int,
+    candidate: AlertCandidate,
+    config: TelegramConfig,
+    sender: Sender = _default_sender,
+    timeout: int = 10,
+    ts_utc: Optional[str] = None,
+) -> TelegramDeliveryResult:
+    result = send_alert_candidate(
+        candidate,
+        config=config,
+        sender=sender,
+        timeout=timeout,
+        now_utc=ts_utc,
+    )
+
+    add_alert(
+        db_path=db_path,
+        run_id=run_id,
+        alert_key=candidate.alert_key,
+        alert_type=candidate.alert_type,
+        severity=candidate.severity,
+        symbol=candidate.symbol,
+        title=candidate.title,
+        message=candidate.message,
+        payload={
+            **candidate.payload,
+            "telegram_text": result.text,
+        },
+        ts_utc=ts_utc,
+        delivery_status=result.delivery_status,
+        delivered_at_utc=result.delivered_at_utc,
+        error_text=result.error_text,
+    )
+    return result

--- a/tests/test_telegram_notifier.py
+++ b/tests/test_telegram_notifier.py
@@ -1,0 +1,236 @@
+import json
+import sqlite3
+from pathlib import Path
+from unittest.mock import Mock
+
+from market_health.alert_detectors import AlertCandidate
+from market_health.alert_store import start_run
+from market_health.telegram_notifier import (
+    TelegramConfig,
+    format_alert_message,
+    load_telegram_config,
+    send_alert_candidate,
+    send_and_record_alert_candidate,
+)
+
+
+def _candidate() -> AlertCandidate:
+    return AlertCandidate(
+        alert_key="position_state:SPY:clean->DMG",
+        alert_type="position_state_changed",
+        severity="warning",
+        symbol="SPY",
+        title="SPY state changed",
+        message="SPY changed from clean to DMG.",
+        payload={"from": "clean", "to": "DMG"},
+    )
+
+
+def test_load_telegram_config_from_local_json(tmp_path: Path) -> None:
+    cfg_path = tmp_path / "telegram.json"
+    cfg_path.write_text(
+        json.dumps(
+            {
+                "mode": "test",
+                "bot_token": "token",
+                "chat_id": "chat",
+                "api_base": "https://example.invalid",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    cfg = load_telegram_config(cfg_path)
+
+    assert cfg == TelegramConfig(
+        mode="test",
+        bot_token="token",
+        chat_id="chat",
+        api_base="https://example.invalid",
+    )
+
+
+def test_load_telegram_config_defaults_to_disabled_when_missing() -> None:
+    cfg = load_telegram_config(Path("/tmp/does-not-exist-telegram-config.json"))
+
+    assert cfg.mode == "disabled"
+    assert cfg.bot_token == ""
+    assert cfg.chat_id == ""
+
+
+def test_format_alert_message_includes_test_prefix() -> None:
+    text = format_alert_message(_candidate(), test_prefix=True)
+
+    assert text.startswith("TEST: SPY state changed")
+    assert "SPY changed from clean to DMG." in text
+    assert "Symbol: SPY" in text
+    assert "Severity: warning" in text
+
+
+def test_disabled_mode_does_not_send() -> None:
+    sender = Mock()
+
+    result = send_alert_candidate(
+        _candidate(),
+        config=TelegramConfig(mode="disabled"),
+        sender=sender,
+    )
+
+    assert result.delivery_status == "disabled"
+    assert result.sent is False
+    sender.assert_not_called()
+
+
+def test_dry_run_mode_does_not_send() -> None:
+    sender = Mock()
+
+    result = send_alert_candidate(
+        _candidate(),
+        config=TelegramConfig(mode="dry-run", bot_token="token", chat_id="chat"),
+        sender=sender,
+    )
+
+    assert result.delivery_status == "dry-run"
+    assert result.sent is False
+    assert "SPY state changed" in result.text
+    sender.assert_not_called()
+
+
+def test_test_mode_sends_with_test_prefix() -> None:
+    sender = Mock()
+    response = Mock()
+    sender.return_value = response
+
+    result = send_alert_candidate(
+        _candidate(),
+        config=TelegramConfig(
+            mode="test",
+            bot_token="token",
+            chat_id="chat",
+            api_base="https://api.example",
+        ),
+        sender=sender,
+        now_utc="2026-05-01T15:00:00Z",
+    )
+
+    assert result.delivery_status == "sent"
+    assert result.sent is True
+    assert result.delivered_at_utc == "2026-05-01T15:00:00Z"
+    sender.assert_called_once()
+    url, data, timeout = sender.call_args.args
+    assert url == "https://api.example/bottoken/sendMessage"
+    assert data["chat_id"] == "chat"
+    assert data["text"].startswith("TEST: SPY state changed")
+    assert timeout == 10
+    response.raise_for_status.assert_called_once_with()
+
+
+def test_live_mode_sends_without_test_prefix() -> None:
+    sender = Mock()
+    response = Mock()
+    sender.return_value = response
+
+    result = send_alert_candidate(
+        _candidate(),
+        config=TelegramConfig(
+            mode="live",
+            bot_token="token",
+            chat_id="chat",
+            api_base="https://api.example",
+        ),
+        sender=sender,
+    )
+
+    assert result.delivery_status == "sent"
+    assert result.sent is True
+    data = sender.call_args.args[1]
+    assert data["text"].startswith("SPY state changed")
+    assert not data["text"].startswith("TEST:")
+
+
+def test_test_or_live_mode_requires_credentials() -> None:
+    sender = Mock()
+
+    result = send_alert_candidate(
+        _candidate(),
+        config=TelegramConfig(mode="live"),
+        sender=sender,
+    )
+
+    assert result.delivery_status == "error"
+    assert result.sent is False
+    assert result.error_text == "missing telegram bot_token or chat_id"
+    sender.assert_not_called()
+
+
+def test_send_error_is_returned_without_raising() -> None:
+    def sender(_url, _data, _timeout):
+        raise RuntimeError("network down")
+
+    result = send_alert_candidate(
+        _candidate(),
+        config=TelegramConfig(mode="live", bot_token="token", chat_id="chat"),
+        sender=sender,
+    )
+
+    assert result.delivery_status == "error"
+    assert result.sent is False
+    assert result.error_text == "network down"
+
+
+def test_send_and_record_alert_candidate_writes_sqlite_status(tmp_path: Path) -> None:
+    db = tmp_path / "market_health_alerts.v1.sqlite"
+    run_id = start_run(db_path=db, mode="dry-run", trigger_name="manual")
+
+    result = send_and_record_alert_candidate(
+        db_path=db,
+        run_id=run_id,
+        candidate=_candidate(),
+        config=TelegramConfig(mode="dry-run", bot_token="token", chat_id="chat"),
+        sender=Mock(),
+        ts_utc="2026-05-01T15:00:00Z",
+    )
+
+    assert result.delivery_status == "dry-run"
+
+    conn = sqlite3.connect(str(db))
+    row = conn.execute(
+        """
+        SELECT alert_key, delivery_status, delivered_at_utc, error_text, payload_json
+        FROM alerts
+        """
+    ).fetchone()
+    conn.close()
+
+    assert row[0] == "position_state:SPY:clean->DMG"
+    assert row[1] == "dry-run"
+    assert row[2] is None
+    assert row[3] is None
+    payload = json.loads(row[4])
+    assert payload["from"] == "clean"
+    assert "telegram_text" in payload
+
+
+def test_send_and_record_alert_candidate_records_send_error(tmp_path: Path) -> None:
+    db = tmp_path / "market_health_alerts.v1.sqlite"
+    run_id = start_run(db_path=db, mode="live", trigger_name="manual")
+
+    def sender(_url, _data, _timeout):
+        raise RuntimeError("network down")
+
+    result = send_and_record_alert_candidate(
+        db_path=db,
+        run_id=run_id,
+        candidate=_candidate(),
+        config=TelegramConfig(mode="live", bot_token="token", chat_id="chat"),
+        sender=sender,
+        ts_utc="2026-05-01T15:00:00Z",
+    )
+
+    assert result.delivery_status == "error"
+
+    conn = sqlite3.connect(str(db))
+    row = conn.execute("SELECT delivery_status, error_text FROM alerts").fetchone()
+    conn.close()
+
+    assert row == ("error", "network down")


### PR DESCRIPTION
## Summary

Adds the M43 Telegram notifier with safe rollout modes.

This introduces:

- `market_health/telegram_notifier.py`
- `tests/test_telegram_notifier.py`
- disabled mode
- dry-run mode
- test mode with TEST prefix
- live mode
- local JSON config loading
- injectable/mocked HTTP sender
- delivery result object
- SQLite alert-row recording through `alert_store.add_alert`
- send-error recording

## Scope

This PR intentionally does not add the run-once alert runner, systemd units, or live scheduling. Those are separate M43 issues.

## Testing

- `.venv-ci/bin/python -m py_compile market_health/telegram_notifier.py tests/test_telegram_notifier.py`
- `.venv-ci/bin/python -m pytest tests/test_telegram_notifier.py tests/test_telegram_notify_status_change_v0.py -q`
- `.venv-ci/bin/ruff format --check market_health/telegram_notifier.py tests/test_telegram_notifier.py`
- `.venv-ci/bin/ruff check market_health/telegram_notifier.py tests/test_telegram_notifier.py`

Secrets check only finds the existing placeholder example in `docs/examples/telegram.json.example`.

Closes #327