### PR TITLE
Add M43 alert systemd templates

### DIFF
--- a/scripts/jerboa/bin/jerboa-market-health-alert-run-once
+++ b/scripts/jerboa/bin/jerboa-market-health-alert-run-once
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DB="${JERBOA_ALERT_DB:-$HOME/.cache/jerboa/market_health_alerts.v1.sqlite}"
+UI="${JERBOA_MARKET_HEALTH_UI:-$HOME/.cache/jerboa/market_health.ui.v1.json}"
+TELEGRAM_CONFIG="${JERBOA_TELEGRAM_CONFIG:-$HOME/.config/jerboa/telegram.json}"
+TELEGRAM_MODE="${JERBOA_ALERT_TELEGRAM_MODE:-disabled}"
+
+exec python -m market_health.alert_runner \
+  --db "$DB" \
+  --ui "$UI" \
+  --telegram-config "$TELEGRAM_CONFIG" \
+  --telegram-mode "$TELEGRAM_MODE" \
+  --trigger-name systemd-timer

--- a/scripts/jerboa/systemd/user/jerboa-market-health-alert.service
+++ b/scripts/jerboa/systemd/user/jerboa-market-health-alert.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=Jerboa Market Health - M43 alert run-once service
+Documentation=https://github.com/chrisdudley-dev/market-health-cli
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=%h/bin/jerboa-market-health-alert-run-once
+TimeoutStartSec=10min
+
+# Logs go to journald by default for user services.
+SyslogIdentifier=jerboa-market-health-alert
+
+# Be gentle to the Pi.
+Nice=10
+IOSchedulingClass=best-effort
+IOSchedulingPriority=6
+
+# Safe hardening. The service still writes under $HOME.
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectSystem=strict
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes

--- a/scripts/jerboa/systemd/user/jerboa-market-health-alert.timer
+++ b/scripts/jerboa/systemd/user/jerboa-market-health-alert.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Jerboa Market Health - run M43 alert service every 15 minutes
+
+[Timer]
+OnBootSec=5m
+OnUnitActiveSec=15m
+Persistent=true
+Unit=jerboa-market-health-alert.service
+
+[Install]
+WantedBy=timers.target

--- a/tests/test_m43_systemd_templates.py
+++ b/tests/test_m43_systemd_templates.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BIN = ROOT / "scripts/jerboa/bin/jerboa-market-health-alert-run-once"
+SERVICE = ROOT / "scripts/jerboa/systemd/user/jerboa-market-health-alert.service"
+TIMER = ROOT / "scripts/jerboa/systemd/user/jerboa-market-health-alert.timer"
+
+
+def test_alert_run_once_wrapper_exists_and_calls_python_runner() -> None:
+    text = BIN.read_text(encoding="utf-8")
+
+    assert text.startswith("#!/usr/bin/env bash")
+    assert "set -euo pipefail" in text
+    assert "python -m market_health.alert_runner" in text
+    assert "--trigger-name systemd-timer" in text
+    assert "JERBOA_ALERT_DB" in text
+    assert "JERBOA_MARKET_HEALTH_UI" in text
+    assert "JERBOA_TELEGRAM_CONFIG" in text
+    assert "JERBOA_ALERT_TELEGRAM_MODE" in text
+
+
+def test_alert_service_is_user_oneshot_with_timeout_and_journald_identifier() -> None:
+    text = SERVICE.read_text(encoding="utf-8")
+
+    assert "Type=oneshot" in text
+    assert "ExecStart=%h/bin/jerboa-market-health-alert-run-once" in text
+    assert "TimeoutStartSec=10min" in text
+    assert "SyslogIdentifier=jerboa-market-health-alert" in text
+    assert "Nice=10" in text
+    assert "NoNewPrivileges=yes" in text
+    assert "PrivateTmp=yes" in text
+    assert "ProtectSystem=strict" in text
+
+
+def test_alert_timer_runs_every_15_minutes_and_installs_to_timers_target() -> None:
+    text = TIMER.read_text(encoding="utf-8")
+
+    assert "OnBootSec=5m" in text
+    assert "OnUnitActiveSec=15m" in text
+    assert "Persistent=true" in text
+    assert "Unit=jerboa-market-health-alert.service" in text
+    assert "WantedBy=timers.target" in text
+
+
+def test_service_and_timer_do_not_enable_themselves() -> None:
+    service_text = SERVICE.read_text(encoding="utf-8")
+    timer_text = TIMER.read_text(encoding="utf-8")
+
+    assert "systemctl --user enable" not in service_text
+    assert "systemctl --user enable" not in timer_text
+    assert "systemctl --user start" not in service_text
+    assert "systemctl --user start" not in timer_text


### PR DESCRIPTION
## Summary

Adds M43 user-level systemd templates for the Raspberry Pi alert service.

This introduces:

- `scripts/jerboa/bin/jerboa-market-health-alert-run-once`
- `scripts/jerboa/systemd/user/jerboa-market-health-alert.service`
- `scripts/jerboa/systemd/user/jerboa-market-health-alert.timer`
- `tests/test_m43_systemd_templates.py`

The service is a run-once `Type=oneshot` user service. The timer triggers every 15 minutes. The service logs to journald and uses Pi-friendly systemd hardening.

## Scope

This PR adds templates only. It does not install, enable, or start the timer on the Raspberry Pi.

## Testing

- `.venv-ci/bin/python -m py_compile tests/test_m43_systemd_templates.py`
- `.venv-ci/bin/python -m pytest tests/test_m43_systemd_templates.py tests/test_alert_runner.py -q`
- `bash -n scripts/jerboa/bin/jerboa-market-health-alert-run-once`
- `.venv-ci/bin/ruff format --check tests/test_m43_systemd_templates.py`
- `.venv-ci/bin/ruff check tests/test_m43_systemd_templates.py`

Closes #330