### PR TITLE
Add M43 alert status command

### DIFF
--- a/market_health/alert_status.py
+++ b/market_health/alert_status.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Optional, Sequence
+
+from market_health.alert_store import apply_migrations, connect
+
+SERVICE_NAME = "jerboa-market-health-alert.service"
+TIMER_NAME = "jerboa-market-health-alert.timer"
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    returncode: int
+    stdout: str = ""
+    stderr: str = ""
+
+
+CommandRunner = Callable[[Sequence[str]], CommandResult]
+
+
+def _default_command_runner(cmd: Sequence[str]) -> CommandResult:
+    try:
+        proc = subprocess.run(
+            list(cmd),
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+    except FileNotFoundError as exc:
+        return CommandResult(returncode=127, stderr=str(exc))
+    return CommandResult(
+        returncode=proc.returncode,
+        stdout=proc.stdout.strip(),
+        stderr=proc.stderr.strip(),
+    )
+
+
+def _db_size(db_path: Path) -> int:
+    return db_path.stat().st_size if db_path.exists() else 0
+
+
+def _one(conn, sql: str):
+    return conn.execute(sql).fetchone()
+
+
+def _sqlite_status(db_path: Path) -> dict:
+    status = {
+        "db_path": str(db_path),
+        "db_exists": db_path.exists(),
+        "db_size_bytes": _db_size(db_path),
+        "last_run": None,
+        "last_successful_run": None,
+        "last_failed_run": None,
+        "latest_positions_timestamp": None,
+        "latest_forecast_timestamp": None,
+        "latest_telegram_alert": None,
+        "latest_system_health_event": None,
+    }
+
+    if not db_path.exists():
+        return status
+
+    with connect(db_path) as conn:
+        apply_migrations(conn)
+
+        status["last_run"] = dict(
+            _one(
+                conn,
+                """
+                SELECT id, started_at_utc, finished_at_utc, status, mode, trigger_name, error_text
+                FROM runs
+                ORDER BY id DESC
+                LIMIT 1
+                """,
+            )
+            or {}
+        )
+        status["last_successful_run"] = dict(
+            _one(
+                conn,
+                """
+                SELECT id, started_at_utc, finished_at_utc, status, mode, trigger_name
+                FROM runs
+                WHERE status = 'success'
+                ORDER BY id DESC
+                LIMIT 1
+                """,
+            )
+            or {}
+        )
+        status["last_failed_run"] = dict(
+            _one(
+                conn,
+                """
+                SELECT id, started_at_utc, finished_at_utc, status, mode, trigger_name, error_text
+                FROM runs
+                WHERE status != 'success'
+                ORDER BY id DESC
+                LIMIT 1
+                """,
+            )
+            or {}
+        )
+        latest_positions = _one(
+            conn,
+            """
+            SELECT MAX(ts_utc) AS ts_utc
+            FROM symbol_snapshots
+            WHERE is_held = 1
+            """,
+        )
+        status["latest_positions_timestamp"] = (
+            latest_positions["ts_utc"] if latest_positions else None
+        )
+
+        latest_forecast = _one(
+            conn,
+            """
+            SELECT MAX(ts_utc) AS ts_utc
+            FROM symbol_snapshots
+            WHERE h1_score IS NOT NULL OR h5_score IS NOT NULL
+            """,
+        )
+        status["latest_forecast_timestamp"] = (
+            latest_forecast["ts_utc"] if latest_forecast else None
+        )
+
+        latest_alert = _one(
+            conn,
+            """
+            SELECT id, ts_utc, alert_key, alert_type, severity, symbol,
+                   delivery_status, delivered_at_utc, error_text
+            FROM alerts
+            ORDER BY id DESC
+            LIMIT 1
+            """,
+        )
+        status["latest_telegram_alert"] = dict(latest_alert or {})
+
+        latest_system = _one(
+            conn,
+            """
+            SELECT id, ts_utc, event_type, severity, message
+            FROM system_events
+            ORDER BY id DESC
+            LIMIT 1
+            """,
+        )
+        status["latest_system_health_event"] = dict(latest_system or {})
+
+    return status
+
+
+def _systemd_unit_status(
+    *,
+    unit_name: str,
+    runner: CommandRunner,
+) -> dict:
+    cat = runner(["systemctl", "--user", "cat", unit_name])
+    enabled = runner(["systemctl", "--user", "is-enabled", unit_name])
+    active = runner(["systemctl", "--user", "is-active", unit_name])
+
+    if cat.returncode == 127 or enabled.returncode == 127 or active.returncode == 127:
+        return {
+            "unit": unit_name,
+            "systemd_available": False,
+            "installed": None,
+            "enabled": None,
+            "active": None,
+        }
+
+    return {
+        "unit": unit_name,
+        "systemd_available": True,
+        "installed": cat.returncode == 0,
+        "enabled": enabled.stdout.strip() or "unknown",
+        "active": active.stdout.strip() or "unknown",
+    }
+
+
+def _git_commit(repo_path: Path, runner: CommandRunner) -> Optional[str]:
+    result = runner(["git", "-C", str(repo_path), "rev-parse", "--short", "HEAD"])
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def build_alert_status(
+    *,
+    db_path: Path,
+    repo_path: Path,
+    runner: CommandRunner = _default_command_runner,
+) -> dict:
+    return {
+        "service": _systemd_unit_status(unit_name=SERVICE_NAME, runner=runner),
+        "timer": _systemd_unit_status(unit_name=TIMER_NAME, runner=runner),
+        "database": _sqlite_status(db_path),
+        "git_commit": _git_commit(repo_path, runner),
+    }
+
+
+def _format_optional_run(run: Optional[dict]) -> str:
+    if not run:
+        return "none"
+    return (
+        f"id={run.get('id')} status={run.get('status')} "
+        f"started={run.get('started_at_utc')} finished={run.get('finished_at_utc')} "
+        f"mode={run.get('mode')} trigger={run.get('trigger_name')}"
+    )
+
+
+def format_status_text(status: dict) -> str:
+    db = status["database"]
+    service = status["service"]
+    timer = status["timer"]
+    latest_alert = db.get("latest_telegram_alert") or {}
+    latest_system = db.get("latest_system_health_event") or {}
+
+    lines = [
+        "m43-alert-status:",
+        f"  service: installed={service.get('installed')} enabled={service.get('enabled')} active={service.get('active')}",
+        f"  timer: installed={timer.get('installed')} enabled={timer.get('enabled')} active={timer.get('active')}",
+        f"  database: path={db.get('db_path')} exists={db.get('db_exists')} size_bytes={db.get('db_size_bytes')}",
+        f"  git_commit: {status.get('git_commit') or 'unknown'}",
+        f"  last_run: {_format_optional_run(db.get('last_run'))}",
+        f"  last_successful_run: {_format_optional_run(db.get('last_successful_run'))}",
+        f"  last_failed_run: {_format_optional_run(db.get('last_failed_run'))}",
+        f"  latest_positions_timestamp: {db.get('latest_positions_timestamp') or 'none'}",
+        f"  latest_forecast_timestamp: {db.get('latest_forecast_timestamp') or 'none'}",
+        (
+            "  latest_telegram_alert: "
+            f"id={latest_alert.get('id', 'none')} "
+            f"type={latest_alert.get('alert_type', 'none')} "
+            f"status={latest_alert.get('delivery_status', 'none')} "
+            f"ts={latest_alert.get('ts_utc', 'none')}"
+        ),
+        (
+            "  latest_system_health_event: "
+            f"id={latest_system.get('id', 'none')} "
+            f"type={latest_system.get('event_type', 'none')} "
+            f"severity={latest_system.get('severity', 'none')} "
+            f"ts={latest_system.get('ts_utc', 'none')}"
+        ),
+    ]
+    return "\n".join(lines)
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Show M43 alert-service status.")
+    parser.add_argument(
+        "--db",
+        type=Path,
+        default=Path.home() / ".cache/jerboa/market_health_alerts.v1.sqlite",
+        help="Path to alert SQLite database.",
+    )
+    parser.add_argument(
+        "--repo",
+        type=Path,
+        default=Path.cwd(),
+        help="Path to market-health-cli git checkout.",
+    )
+    parser.add_argument("--json", action="store_true", help="Print JSON status.")
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    status = build_alert_status(db_path=args.db, repo_path=args.repo)
+
+    if args.json:
+        print(json.dumps(status, indent=2, sort_keys=True))
+    else:
+        print(format_status_text(status))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/jerboa/bin/mh_alert_status
+++ b/scripts/jerboa/bin/mh_alert_status
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DB="${JERBOA_ALERT_DB:-$HOME/.cache/jerboa/market_health_alerts.v1.sqlite}"
+REPO="${JERBOA_MARKET_HEALTH_REPO:-$PWD}"
+
+exec python -m market_health.alert_status \
+  --db "$DB" \
+  --repo "$REPO" \
+  "$@"

--- a/tests/test_alert_status.py
+++ b/tests/test_alert_status.py
@@ -1,0 +1,207 @@
+import sqlite3
+from pathlib import Path
+
+from market_health.alert_status import (
+    CommandResult,
+    build_alert_status,
+    format_status_text,
+    main,
+)
+from market_health.alert_store import (
+    add_alert,
+    add_system_event,
+    add_symbol_snapshot,
+    finish_run,
+    start_run,
+)
+
+
+def _runner(cmd):
+    text = " ".join(cmd)
+    if "rev-parse" in text:
+        return CommandResult(0, "abc123")
+    if "cat jerboa-market-health-alert.service" in text:
+        return CommandResult(0, "[Service]")
+    if "cat jerboa-market-health-alert.timer" in text:
+        return CommandResult(0, "[Timer]")
+    if "is-enabled jerboa-market-health-alert.timer" in text:
+        return CommandResult(0, "enabled")
+    if "is-enabled jerboa-market-health-alert.service" in text:
+        return CommandResult(1, "static")
+    if "is-active jerboa-market-health-alert.timer" in text:
+        return CommandResult(0, "active")
+    if "is-active jerboa-market-health-alert.service" in text:
+        return CommandResult(3, "inactive")
+    return CommandResult(1, "")
+
+
+def test_build_alert_status_handles_missing_db(tmp_path: Path) -> None:
+    status = build_alert_status(
+        db_path=tmp_path / "missing.sqlite",
+        repo_path=tmp_path,
+        runner=_runner,
+    )
+
+    assert status["database"]["db_exists"] is False
+    assert status["database"]["db_size_bytes"] == 0
+    assert status["database"]["last_run"] is None
+    assert status["git_commit"] == "abc123"
+    assert status["service"]["installed"] is True
+    assert status["timer"]["enabled"] == "enabled"
+
+
+def test_build_alert_status_reads_sqlite_state(tmp_path: Path) -> None:
+    db = tmp_path / "alerts.sqlite"
+    run_id = start_run(
+        db_path=db,
+        mode="dry-run",
+        trigger_name="manual",
+        started_at_utc="2026-05-01T15:00:00Z",
+    )
+    add_symbol_snapshot(
+        db_path=db,
+        run_id=run_id,
+        symbol="SPY",
+        ts_utc="2026-05-01T15:01:00Z",
+        h1_score=66,
+        h5_score=61,
+    )
+    add_alert(
+        db_path=db,
+        run_id=run_id,
+        alert_key="position_state:SPY:clean->DMG",
+        alert_type="position_state_changed",
+        severity="warning",
+        title="SPY state changed",
+        message="SPY changed.",
+        ts_utc="2026-05-01T15:02:00Z",
+        delivery_status="dry-run",
+    )
+    add_system_event(
+        db_path=db,
+        run_id=run_id,
+        event_type="refresh_failed",
+        severity="error",
+        message="refresh failed",
+        ts_utc="2026-05-01T15:03:00Z",
+    )
+    finish_run(
+        db_path=db,
+        run_id=run_id,
+        status="success",
+        finished_at_utc="2026-05-01T15:04:00Z",
+    )
+
+    status = build_alert_status(db_path=db, repo_path=tmp_path, runner=_runner)
+
+    assert status["database"]["db_exists"] is True
+    assert status["database"]["last_run"]["status"] == "success"
+    assert status["database"]["last_successful_run"]["id"] == run_id
+    assert status["database"]["last_failed_run"] == {}
+    assert status["database"]["latest_positions_timestamp"] == "2026-05-01T15:01:00Z"
+    assert status["database"]["latest_forecast_timestamp"] == "2026-05-01T15:01:00Z"
+    assert status["database"]["latest_telegram_alert"]["delivery_status"] == "dry-run"
+    assert (
+        status["database"]["latest_system_health_event"]["event_type"]
+        == "refresh_failed"
+    )
+
+
+def test_build_alert_status_reads_last_failed_run(tmp_path: Path) -> None:
+    db = tmp_path / "alerts.sqlite"
+    run_id = start_run(
+        db_path=db,
+        mode="disabled",
+        trigger_name="manual",
+        started_at_utc="2026-05-01T15:00:00Z",
+    )
+    finish_run(
+        db_path=db,
+        run_id=run_id,
+        status="failed",
+        finished_at_utc="2026-05-01T15:01:00Z",
+        error_text="refresh failed",
+    )
+
+    status = build_alert_status(db_path=db, repo_path=tmp_path, runner=_runner)
+
+    assert status["database"]["last_failed_run"]["id"] == run_id
+    assert status["database"]["last_failed_run"]["error_text"] == "refresh failed"
+
+
+def test_status_text_contains_operator_fields(tmp_path: Path) -> None:
+    status = build_alert_status(
+        db_path=tmp_path / "missing.sqlite",
+        repo_path=tmp_path,
+        runner=_runner,
+    )
+
+    text = format_status_text(status)
+
+    assert "m43-alert-status:" in text
+    assert "service:" in text
+    assert "timer:" in text
+    assert "database:" in text
+    assert "git_commit:" in text
+    assert "last_run:" in text
+    assert "latest_telegram_alert:" in text
+    assert "latest_system_health_event:" in text
+
+
+def test_systemd_unavailable_is_graceful(tmp_path: Path) -> None:
+    def runner(_cmd):
+        return CommandResult(127, "", "systemctl not found")
+
+    status = build_alert_status(
+        db_path=tmp_path / "missing.sqlite",
+        repo_path=tmp_path,
+        runner=runner,
+    )
+
+    assert status["service"]["systemd_available"] is False
+    assert status["timer"]["systemd_available"] is False
+
+
+def test_main_prints_json_status_for_missing_db(tmp_path: Path, capsys) -> None:
+    code = main(
+        [
+            "--db",
+            str(tmp_path / "missing.sqlite"),
+            "--repo",
+            str(tmp_path),
+            "--json",
+        ]
+    )
+
+    out = capsys.readouterr().out
+    assert code == 0
+    assert '"database"' in out
+    assert '"db_exists": false' in out
+
+
+def test_wrapper_script_exists_and_calls_module() -> None:
+    p = Path("scripts/jerboa/bin/mh_alert_status")
+    text = p.read_text(encoding="utf-8")
+
+    assert text.startswith("#!/usr/bin/env bash")
+    assert "python -m market_health.alert_status" in text
+    assert "JERBOA_ALERT_DB" in text
+    assert "JERBOA_MARKET_HEALTH_REPO" in text
+
+
+def test_status_does_not_create_missing_db(tmp_path: Path) -> None:
+    db = tmp_path / "missing.sqlite"
+
+    build_alert_status(db_path=db, repo_path=tmp_path, runner=_runner)
+
+    assert not db.exists()
+
+
+def test_sqlite_status_handles_existing_empty_db(tmp_path: Path) -> None:
+    db = tmp_path / "empty.sqlite"
+    sqlite3.connect(str(db)).close()
+
+    status = build_alert_status(db_path=db, repo_path=tmp_path, runner=_runner)
+
+    assert status["database"]["db_exists"] is True
+    assert status["database"]["last_run"] == {}


### PR DESCRIPTION
## Summary

Adds an operator status command for the M43 Raspberry Pi alert service.

This introduces:

- `market_health/alert_status.py`
- `scripts/jerboa/bin/mh_alert_status`
- `tests/test_alert_status.py`

The command reports:

- systemd service status
- systemd timer status
- database path, existence, and size
- current git commit
- last run
- last successful run
- last failed run
- latest positions timestamp
- latest forecast timestamp
- latest Telegram alert status
- latest system-health event

It fails gracefully when systemd is unavailable and does not create a missing database just to inspect status.

## Testing

- `.venv-ci/bin/python -m py_compile market_health/alert_status.py tests/test_alert_status.py`
- `.venv-ci/bin/python -m pytest tests/test_alert_status.py -q`
- `bash -n scripts/jerboa/bin/mh_alert_status`
- `.venv-ci/bin/ruff format --check market_health/alert_status.py tests/test_alert_status.py`
- `.venv-ci/bin/ruff check market_health/alert_status.py tests/test_alert_status.py`

Closes #331