### PR TITLE
Make M43 alert wrapper repo-aware

### DIFF
--- a/scripts/jerboa/bin/jerboa-market-health-alert-run-once
+++ b/scripts/jerboa/bin/jerboa-market-health-alert-run-once
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+REPO="${JERBOA_MARKET_HEALTH_REPO:-$HOME/market-health-cli}"
 DB="${JERBOA_ALERT_DB:-$HOME/.cache/jerboa/market_health_alerts.v1.sqlite}"
 UI="${JERBOA_MARKET_HEALTH_UI:-$HOME/.cache/jerboa/market_health.ui.v1.json}"
 TELEGRAM_CONFIG="${JERBOA_TELEGRAM_CONFIG:-$HOME/.config/jerboa/telegram.json}"
 TELEGRAM_MODE="${JERBOA_ALERT_TELEGRAM_MODE:-disabled}"
+
+cd "$REPO"
 
 exec python -m market_health.alert_runner \
   --db "$DB" \

--- a/tests/test_m43_systemd_templates.py
+++ b/tests/test_m43_systemd_templates.py
@@ -14,6 +14,8 @@ def test_alert_run_once_wrapper_exists_and_calls_python_runner() -> None:
     assert "set -euo pipefail" in text
     assert "python -m market_health.alert_runner" in text
     assert "--trigger-name systemd-timer" in text
+    assert "JERBOA_MARKET_HEALTH_REPO" in text
+    assert 'cd "$REPO"' in text
     assert "JERBOA_ALERT_DB" in text
     assert "JERBOA_MARKET_HEALTH_UI" in text
     assert "JERBOA_TELEGRAM_CONFIG" in text


### PR DESCRIPTION
## Summary

Makes the M43 alert run-once wrapper change into the configured repository before running the Python module.

This adds support for:

- `JERBOA_MARKET_HEALTH_REPO`
- default repo path of `$HOME/market-health-cli`
- running `python -m market_health.alert_runner` from the checkout

This is needed for Raspberry Pi installs where command wrappers live in `$HOME/bin` but the Python package source lives in the repo checkout.

## Testing

- `.venv-ci/bin/python -m pytest tests/test_m43_systemd_templates.py tests/test_alert_runner.py -q`
- `bash -n scripts/jerboa/bin/jerboa-market-health-alert-run-once`
- `.venv-ci/bin/ruff format --check tests/test_m43_systemd_templates.py`
- `.venv-ci/bin/ruff check tests/test_m43_systemd_templates.py`