### PR TITLE
Prefer repo venv in M43 alert wrapper

### DIFF
--- a/scripts/jerboa/bin/jerboa-market-health-alert-run-once
+++ b/scripts/jerboa/bin/jerboa-market-health-alert-run-once
@@ -9,7 +9,16 @@ TELEGRAM_MODE="${JERBOA_ALERT_TELEGRAM_MODE:-disabled}"
 
 cd "$REPO"
 
-exec python -m market_health.alert_runner \
+PYTHON="${JERBOA_MARKET_HEALTH_PYTHON:-}"
+if [ -z "$PYTHON" ]; then
+  if [ -x "$REPO/.venv/bin/python" ]; then
+    PYTHON="$REPO/.venv/bin/python"
+  else
+    PYTHON="python"
+  fi
+fi
+
+exec "$PYTHON" -m market_health.alert_runner \
   --db "$DB" \
   --ui "$UI" \
   --telegram-config "$TELEGRAM_CONFIG" \

--- a/tests/test_m43_systemd_templates.py
+++ b/tests/test_m43_systemd_templates.py
@@ -12,7 +12,9 @@ def test_alert_run_once_wrapper_exists_and_calls_python_runner() -> None:
 
     assert text.startswith("#!/usr/bin/env bash")
     assert "set -euo pipefail" in text
-    assert "python -m market_health.alert_runner" in text
+    assert "JERBOA_MARKET_HEALTH_PYTHON" in text
+    assert "$REPO/.venv/bin/python" in text
+    assert '"$PYTHON" -m market_health.alert_runner' in text
     assert "--trigger-name systemd-timer" in text
     assert "JERBOA_MARKET_HEALTH_REPO" in text
     assert 'cd "$REPO"' in text


### PR DESCRIPTION
## Summary

Updates the M43 alert run-once wrapper to prefer the repository virtual environment when available.

Behavior:

- honors `JERBOA_MARKET_HEALTH_PYTHON` when set
- otherwise uses `$REPO/.venv/bin/python` if present
- falls back to `python`

This allows Raspberry Pi installs to keep dependencies isolated in a repo-local venv while still supporting explicit Python overrides.

## Testing

- `.venv-ci/bin/python -m pytest tests/test_m43_systemd_templates.py tests/test_alert_runner.py -q`
- `bash -n scripts/jerboa/bin/jerboa-market-health-alert-run-once`
- `.venv-ci/bin/ruff format --check tests/test_m43_systemd_templates.py`
- `.venv-ci/bin/ruff check tests/test_m43_systemd_templates.py`