### PR TITLE
Forward extra args in M43 alert wrapper

### DIFF
--- a/scripts/jerboa/bin/jerboa-market-health-alert-run-once
+++ b/scripts/jerboa/bin/jerboa-market-health-alert-run-once
@@ -23,4 +23,5 @@ exec "$PYTHON" -m market_health.alert_runner \
   --ui "$UI" \
   --telegram-config "$TELEGRAM_CONFIG" \
   --telegram-mode "$TELEGRAM_MODE" \
-  --trigger-name systemd-timer
+  --trigger-name systemd-timer \
+  "$@"

--- a/tests/test_m43_systemd_templates.py
+++ b/tests/test_m43_systemd_templates.py
@@ -22,6 +22,7 @@ def test_alert_run_once_wrapper_exists_and_calls_python_runner() -> None:
     assert "JERBOA_MARKET_HEALTH_UI" in text
     assert "JERBOA_TELEGRAM_CONFIG" in text
     assert "JERBOA_ALERT_TELEGRAM_MODE" in text
+    assert '"$@"' in text
 
 
 def test_alert_service_is_user_oneshot_with_timeout_and_journald_identifier() -> None:


### PR DESCRIPTION
## Summary

Updates the M43 alert run-once wrapper to forward extra CLI arguments to `market_health.alert_runner`.

This allows operator smoke-test commands such as:

- `jerboa-market-health-alert-run-once --no-refresh`

without bypassing the wrapper.

## Testing

- `.venv-ci/bin/python -m pytest tests/test_m43_systemd_templates.py tests/test_alert_runner.py -q`
- `bash -n scripts/jerboa/bin/jerboa-market-health-alert-run-once`
- `.venv-ci/bin/ruff format --check tests/test_m43_systemd_templates.py`
- `.venv-ci/bin/ruff check tests/test_m43_systemd_templates.py`