### PR TITLE
Make M43 user service Pi-compatible

### DIFF
--- a/scripts/jerboa/bin/jerboa-market-health-alert-run-once
+++ b/scripts/jerboa/bin/jerboa-market-health-alert-run-once
@@ -18,10 +18,17 @@ if [ -z "$PYTHON" ]; then
   fi
 fi
 
+EXTRA_ARGS=()
+if [ -n "${JERBOA_ALERT_RUNNER_ARGS:-}" ]; then
+  # shellcheck disable=SC2206
+  EXTRA_ARGS=($JERBOA_ALERT_RUNNER_ARGS)
+fi
+
 exec "$PYTHON" -m market_health.alert_runner \
   --db "$DB" \
   --ui "$UI" \
   --telegram-config "$TELEGRAM_CONFIG" \
   --telegram-mode "$TELEGRAM_MODE" \
   --trigger-name systemd-timer \
+  "${EXTRA_ARGS[@]}" \
   "$@"

--- a/scripts/jerboa/systemd/user/jerboa-market-health-alert.service
+++ b/scripts/jerboa/systemd/user/jerboa-market-health-alert.service
@@ -17,10 +17,8 @@ Nice=10
 IOSchedulingClass=best-effort
 IOSchedulingPriority=6
 
-# Safe hardening. The service still writes under $HOME.
+# User-service-compatible hardening.
+# Avoid root-only sandboxing directives here; some Raspberry Pi user managers
+# fail before ExecStart with status=218/CAPABILITIES.
 NoNewPrivileges=yes
 PrivateTmp=yes
-ProtectSystem=strict
-ProtectKernelTunables=yes
-ProtectKernelModules=yes
-ProtectControlGroups=yes

--- a/tests/test_m43_systemd_templates.py
+++ b/tests/test_m43_systemd_templates.py
@@ -22,6 +22,8 @@ def test_alert_run_once_wrapper_exists_and_calls_python_runner() -> None:
     assert "JERBOA_MARKET_HEALTH_UI" in text
     assert "JERBOA_TELEGRAM_CONFIG" in text
     assert "JERBOA_ALERT_TELEGRAM_MODE" in text
+    assert "JERBOA_ALERT_RUNNER_ARGS" in text
+    assert '"${EXTRA_ARGS[@]}"' in text
     assert '"$@"' in text
 
 
@@ -35,7 +37,10 @@ def test_alert_service_is_user_oneshot_with_timeout_and_journald_identifier() ->
     assert "Nice=10" in text
     assert "NoNewPrivileges=yes" in text
     assert "PrivateTmp=yes" in text
-    assert "ProtectSystem=strict" in text
+    assert "ProtectSystem=strict" not in text
+    assert "ProtectKernelTunables=yes" not in text
+    assert "ProtectKernelModules=yes" not in text
+    assert "ProtectControlGroups=yes" not in text
 
 
 def test_alert_timer_runs_every_15_minutes_and_installs_to_timers_target() -> None:


### PR DESCRIPTION
## Summary

Makes the M43 user-level systemd service compatible with the Raspberry Pi user systemd manager.

This removes root-only sandboxing directives that caused the user service to fail before ExecStart with `status=218/CAPABILITIES`.

Also adds `JERBOA_ALERT_RUNNER_ARGS` support to the run-once wrapper so systemd smoke tests can pass runner flags such as `--no-refresh` without editing the unit file.

## Testing

- `.venv-ci/bin/python -m pytest tests/test_m43_systemd_templates.py tests/test_alert_runner.py -q`
- `bash -n scripts/jerboa/bin/jerboa-market-health-alert-run-once`
- `.venv-ci/bin/ruff format --check tests/test_m43_systemd_templates.py`
- `.venv-ci/bin/ruff check tests/test_m43_systemd_templates.py`