### PR TITLE
Prefer repo venv in forecast refresh wrapper

### DIFF
--- a/scripts/jerboa/bin/jerboa-market-health-forecast-scores-refresh
+++ b/scripts/jerboa/bin/jerboa-market-health-forecast-scores-refresh
@@ -20,14 +20,23 @@ if [ -f "$SRC_DEFAULT" ]; then
   args+=(--source "$SRC_DEFAULT")
 fi
 
+PYTHON="${JERBOA_MARKET_HEALTH_PYTHON:-}"
+if [ -z "$PYTHON" ]; then
+  if [ -x "$ROOT/.venv/bin/python" ]; then
+    PYTHON="$ROOT/.venv/bin/python"
+  else
+    PYTHON="python3"
+  fi
+fi
+
 if [ "$QUIET" -eq 1 ]; then
-  PYTHONPATH="$ROOT" python3 "$ROOT/scripts/export_forecast_scores_v1.py" "${args[@]}" --quiet || rc=$?
+  PYTHONPATH="$ROOT" "$PYTHON" "$ROOT/scripts/export_forecast_scores_v1.py" "${args[@]}" --quiet || rc=$?
 else
-  PYTHONPATH="$ROOT" python3 "$ROOT/scripts/export_forecast_scores_v1.py" "${args[@]}" || rc=$?
+  PYTHONPATH="$ROOT" "$PYTHON" "$ROOT/scripts/export_forecast_scores_v1.py" "${args[@]}" || rc=$?
 fi
 
 if [ "$rc" -eq 0 ] && [ -f "$OUT" ]; then
-  PYTHONPATH="$ROOT" python3 "$ROOT/scripts/validate_forecast_scores_v1.py" --path "$OUT" >/dev/null || rc=$?
+  PYTHONPATH="$ROOT" "$PYTHON" "$ROOT/scripts/validate_forecast_scores_v1.py" --path "$OUT" >/dev/null || rc=$?
 fi
 
 if [ "$QUIET" -ne 1 ]; then

--- a/tests/test_m43_forecast_wrapper.py
+++ b/tests/test_m43_forecast_wrapper.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+
+WRAPPER = Path("scripts/jerboa/bin/jerboa-market-health-forecast-scores-refresh")
+
+
+def test_forecast_wrapper_prefers_repo_venv_python() -> None:
+    text = WRAPPER.read_text(encoding="utf-8")
+
+    assert "JERBOA_MARKET_HEALTH_PYTHON" in text
+    assert "$ROOT/.venv/bin/python" in text
+    assert 'PYTHON="python3"' in text
+    assert 'PYTHONPATH="$ROOT" "$PYTHON"' in text
+    assert "export_forecast_scores_v1.py" in text
+    assert "validate_forecast_scores_v1.py" in text


### PR DESCRIPTION
## Summary

Updates the forecast scores refresh wrapper to prefer the repository virtual environment when available.

Behavior:

- honors `JERBOA_MARKET_HEALTH_PYTHON` when set
- otherwise uses `$ROOT/.venv/bin/python` if present
- falls back to `python3`

This fixes Raspberry Pi runs where system Python does not have repo dependencies such as numpy.

## Testing

- `.venv-ci/bin/python -m pytest tests/test_m43_forecast_wrapper.py -q`
- `bash -n scripts/jerboa/bin/jerboa-market-health-forecast-scores-refresh`
- `.venv-ci/bin/ruff format --check tests/test_m43_forecast_wrapper.py`
- `.venv-ci/bin/ruff check tests/test_m43_forecast_wrapper.py`