### PR TITLE
Prefer repo venv in recommendations refresh wrapper

### DIFF
--- a/scripts/jerboa/bin/jerboa-market-health-recommendations-refresh
+++ b/scripts/jerboa/bin/jerboa-market-health-recommendations-refresh
@@ -14,16 +14,25 @@ ROOT="$(cd "$(dirname "$SELF")/../../.." && pwd)"
 
 OUT="${HOME}/.cache/jerboa/recommendations.v1.json"
 
+PYTHON="${JERBOA_MARKET_HEALTH_PYTHON:-}"
+if [ -z "$PYTHON" ]; then
+  if [ -x "$ROOT/.venv/bin/python" ]; then
+    PYTHON="$ROOT/.venv/bin/python"
+  else
+    PYTHON="python3"
+  fi
+fi
+
 rc=0
 if [ "$QUIET" -eq 1 ]; then
-  PYTHONPATH="$ROOT" python3 "$ROOT/scripts/export_recommendations_v1.py" --forecast --quiet || rc=$?
+  PYTHONPATH="$ROOT" "$PYTHON" "$ROOT/scripts/export_recommendations_v1.py" --forecast --quiet || rc=$?
 else
-  PYTHONPATH="$ROOT" python3 "$ROOT/scripts/export_recommendations_v1.py" --forecast || rc=$?
+  PYTHONPATH="$ROOT" "$PYTHON" "$ROOT/scripts/export_recommendations_v1.py" --forecast || rc=$?
 fi
 
 # Validate if exporter succeeded and output exists
 if [ "$rc" -eq 0 ] && [ -f "$OUT" ]; then
-  PYTHONPATH="$ROOT" python3 "$ROOT/scripts/validate_recommendations_v1.py" --path "$OUT" >/dev/null || rc=$?
+  PYTHONPATH="$ROOT" "$PYTHON" "$ROOT/scripts/validate_recommendations_v1.py" --path "$OUT" >/dev/null || rc=$?
 fi
 
 if [ "$QUIET" -ne 1 ]; then

--- a/tests/test_m43_recommendations_wrapper.py
+++ b/tests/test_m43_recommendations_wrapper.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+
+WRAPPER = Path("scripts/jerboa/bin/jerboa-market-health-recommendations-refresh")
+
+
+def test_recommendations_wrapper_prefers_repo_venv_python() -> None:
+    text = WRAPPER.read_text(encoding="utf-8")
+
+    assert "JERBOA_MARKET_HEALTH_PYTHON" in text
+    assert "$ROOT/.venv/bin/python" in text
+    assert 'PYTHON="python3"' in text
+    assert 'PYTHONPATH="$ROOT" "$PYTHON"' in text
+    assert "export_recommendations_v1.py" in text
+    assert "validate_recommendations_v1.py" in text


### PR DESCRIPTION
## Summary

Updates the recommendations refresh wrapper to prefer the repository virtual environment when available.

Behavior:

- honors `JERBOA_MARKET_HEALTH_PYTHON` when set
- otherwise uses `$ROOT/.venv/bin/python` if present
- falls back to `python3`

This fixes Raspberry Pi runs where system Python does not have repo dependencies such as numpy.

## Testing

- `.venv-ci/bin/python -m pytest tests/test_m43_recommendations_wrapper.py -q`
- `bash -n scripts/jerboa/bin/jerboa-market-health-recommendations-refresh`
- `.venv-ci/bin/ruff format --check tests/test_m43_recommendations_wrapper.py`
- `.venv-ci/bin/ruff check tests/test_m43_recommendations_wrapper.py`