### PR TITLE
Make M43 status wrapper repo-aware

### DIFF
--- a/scripts/jerboa/bin/mh_alert_status
+++ b/scripts/jerboa/bin/mh_alert_status
@@ -2,9 +2,20 @@
 set -euo pipefail
 
 DB="${JERBOA_ALERT_DB:-$HOME/.cache/jerboa/market_health_alerts.v1.sqlite}"
-REPO="${JERBOA_MARKET_HEALTH_REPO:-$PWD}"
+REPO="${JERBOA_MARKET_HEALTH_REPO:-$HOME/market-health-cli}"
 
-exec python -m market_health.alert_status \
+cd "$REPO"
+
+PYTHON="${JERBOA_MARKET_HEALTH_PYTHON:-}"
+if [ -z "$PYTHON" ]; then
+  if [ -x "$REPO/.venv/bin/python" ]; then
+    PYTHON="$REPO/.venv/bin/python"
+  else
+    PYTHON="python"
+  fi
+fi
+
+exec "$PYTHON" -m market_health.alert_status \
   --db "$DB" \
   --repo "$REPO" \
   "$@"

--- a/tests/test_alert_status.py
+++ b/tests/test_alert_status.py
@@ -184,7 +184,10 @@ def test_wrapper_script_exists_and_calls_module() -> None:
     text = p.read_text(encoding="utf-8")
 
     assert text.startswith("#!/usr/bin/env bash")
-    assert "python -m market_health.alert_status" in text
+    assert '"$PYTHON" -m market_health.alert_status' in text
+    assert "JERBOA_MARKET_HEALTH_PYTHON" in text
+    assert "$REPO/.venv/bin/python" in text
+    assert 'cd "$REPO"' in text
     assert "JERBOA_ALERT_DB" in text
     assert "JERBOA_MARKET_HEALTH_REPO" in text
 


### PR DESCRIPTION
## Summary

Updates the `mh_alert_status` wrapper to work from any current directory.

Behavior:

- defaults repo path to `$HOME/market-health-cli`
- changes into the repo before running the Python module
- honors `JERBOA_MARKET_HEALTH_PYTHON` when set
- otherwise uses `$REPO/.venv/bin/python` if present
- falls back to `python`

This fixes Raspberry Pi operator checks where `mh_alert_status` was run from `$HOME` instead of the repo checkout.

## Testing

- `.venv-ci/bin/python -m pytest tests/test_alert_status.py -q`
- `bash -n scripts/jerboa/bin/mh_alert_status`
- `.venv-ci/bin/ruff format --check tests/test_alert_status.py`
- `.venv-ci/bin/ruff check tests/test_alert_status.py`