### PR TITLE
Store Schwab OAuth token cache

### DIFF
--- a/scripts/schwab_oauth_walkthrough.py
+++ b/scripts/schwab_oauth_walkthrough.py
@@ -16,8 +16,8 @@ from typing import Any, Dict
 import getpass
 
 
-def _sanitize_for_disk(obj):
-    """Drop secrets before writing JSON to disk."""
+def _sanitize_for_display(obj):
+    """Return a redacted copy suitable for logs/stdout."""
     if not isinstance(obj, dict):
         return obj
     out = dict(obj)
@@ -28,7 +28,8 @@ def _sanitize_for_disk(obj):
         "refresh_token",
         "id_token",
     ):
-        out.pop(k, None)
+        if k in out:
+            out[k] = "***"
     return out
 
 
@@ -49,7 +50,7 @@ def _read_json(p: Path) -> Dict[str, Any]:
 def _write_json_secure(p: Path, obj: Dict[str, Any]) -> None:
     p.parent.mkdir(parents=True, exist_ok=True)
     tmp = p.with_suffix(p.suffix + ".tmp")
-    tmp.write_text("token exchange complete (tokens not stored)\n", encoding="utf-8")
+    tmp.write_text(json.dumps(obj, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     os.replace(tmp, p)
     try:
         os.chmod(p, 0o600)
@@ -196,14 +197,9 @@ def main() -> int:
             pass
 
     token_path = Path(os.path.expanduser(args.token))
-    tok_disk = {
-        "expires_at": tok.get("expires_at"),
-        "expires_in": tok.get("expires_in"),
-        "token_type": tok.get("token_type"),
-        "scope": tok.get("scope"),
-    }
+    tok_disk = dict(tok)
     _write_json_secure(token_path, tok_disk)
-    print(f"OK: wrote token marker -> {token_path} (tokens not stored)")
+    print(f"OK: wrote token cache -> {token_path} (0600; secrets not printed)")
     return 0
 
 

--- a/tests/test_schwab_oauth_walkthrough.py
+++ b/tests/test_schwab_oauth_walkthrough.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+
+SCRIPT = Path("scripts/schwab_oauth_walkthrough.py")
+
+
+def test_walkthrough_writes_actual_token_cache_not_marker_only() -> None:
+    text = SCRIPT.read_text(encoding="utf-8")
+
+    assert "token exchange complete (tokens not stored)" not in text
+    assert "tok_disk = dict(tok)" in text
+    assert "json.dumps(obj" in text
+    assert "os.chmod(p, 0o600)" in text
+    assert "secrets not printed" in text
+
+
+def test_walkthrough_redacts_tokens_for_display_helpers() -> None:
+    text = SCRIPT.read_text(encoding="utf-8")
+
+    assert "def _sanitize_for_display" in text
+    assert '"access_token"' in text
+    assert '"refresh_token"' in text
+    assert 'out[k] = "***"' in text


### PR DESCRIPTION
## Summary

Fixes the Schwab OAuth walkthrough so it writes the actual token cache required by `scripts/schwab_live_refresh.sh`.

Previously the walkthrough wrote only a marker file saying tokens were not stored. The live refresh path requires `access_token` and `refresh_token` in `~/.cache/jerboa/schwab.token.json`.

This update:

- writes the token response JSON to the token cache
- keeps token cache permissions at `0600`
- avoids printing token values
- keeps a redaction helper for safe display behavior

## Testing

- `.venv-ci/bin/python -m pytest tests/test_schwab_oauth_walkthrough.py -q`
- `.venv-ci/bin/python -m py_compile scripts/schwab_oauth_walkthrough.py tests/test_schwab_oauth_walkthrough.py`
- `.venv-ci/bin/ruff format --check tests/test_schwab_oauth_walkthrough.py`
- `.venv-ci/bin/ruff check tests/test_schwab_oauth_walkthrough.py`