### PR TITLE
Add safe Schwab OAuth status output

### DIFF
--- a/scripts/schwab_oauth_cli.py
+++ b/scripts/schwab_oauth_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import sys
 
@@ -24,6 +25,22 @@ from market_health.brokers.schwab_oauth import (
     refresh_access_token,
     token_is_fresh,
 )
+
+
+def _config_status(path: str) -> tuple[bool, list[str]]:
+    cfg_path = os.path.expanduser(path)
+    if not os.path.exists(cfg_path):
+        return False, ["missing_file"]
+
+    try:
+        with open(cfg_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except Exception:
+        return True, ["unreadable_json"]
+
+    required = ["client_id", "client_secret", "redirect_uri", "auth_url", "token_url"]
+    missing = [key for key in required if not str(data.get(key, "")).strip()]
+    return True, missing
 
 
 def main() -> int:
@@ -56,13 +73,22 @@ def main() -> int:
     tok_path = os.path.expanduser(args.token)
 
     if args.status:
+        cfg_exists, cfg_missing = _config_status(cfg_path)
+        print(f"CONFIG: {cfg_path}")
+        print(f"config_exists={cfg_exists}")
+        print("config_missing=" + ",".join(cfg_missing))
+
         tok = load_token(tok_path)
-        if not tok:
-            print(f"NO TOKEN: {tok_path}")
-            return 0
-        fresh = token_is_fresh(tok)
         print(f"TOKEN: {tok_path}")
+        if not tok:
+            print("token_exists=False")
+            return 0
+
+        fresh = token_is_fresh(tok)
+        print("token_exists=True")
         print(f"fresh={fresh} expires_at={tok.get('expires_at', '?')}")
+        print(f"has_access_token={bool(str(tok.get('access_token', '')).strip())}")
+        print(f"has_refresh_token={bool(str(tok.get('refresh_token', '')).strip())}")
         return 0
 
     try:

--- a/tests/test_schwab_oauth_cli_status.py
+++ b/tests/test_schwab_oauth_cli_status.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+SCRIPT = Path("scripts/schwab_oauth_cli.py")
+
+
+def run_status(config: Path, token: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--config",
+            str(config),
+            "--token",
+            str(token),
+            "--status",
+        ],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+
+def test_status_reports_missing_config_and_token_without_error(tmp_path: Path) -> None:
+    config = tmp_path / "missing_config.json"
+    token = tmp_path / "missing_token.json"
+
+    proc = run_status(config, token)
+
+    assert proc.returncode == 0
+    assert f"CONFIG: {config}" in proc.stdout
+    assert "config_exists=False" in proc.stdout
+    assert "config_missing=missing_file" in proc.stdout
+    assert f"TOKEN: {token}" in proc.stdout
+    assert "token_exists=False" in proc.stdout
+
+
+def test_status_reports_presence_without_printing_secret_values(tmp_path: Path) -> None:
+    config = tmp_path / "schwab_oauth.json"
+    token = tmp_path / "schwab.token.json"
+
+    config.write_text(
+        json.dumps(
+            {
+                "client_id": "CLIENT_VALUE_SHOULD_NOT_PRINT",
+                "client_secret": "SECRET_VALUE_SHOULD_NOT_PRINT",
+                "redirect_uri": "https://127.0.0.1/callback",
+                "auth_url": "https://auth.example/authorize",
+                "token_url": "https://auth.example/token",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    token.write_text(
+        json.dumps(
+            {
+                "access_token": "ACCESS_VALUE_SHOULD_NOT_PRINT",
+                "refresh_token": "REFRESH_VALUE_SHOULD_NOT_PRINT",
+                "expires_at": 9999999999,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    proc = run_status(config, token)
+
+    assert proc.returncode == 0
+    assert "config_exists=True" in proc.stdout
+    assert "config_missing=" in proc.stdout
+    assert "token_exists=True" in proc.stdout
+    assert "has_access_token=True" in proc.stdout
+    assert "has_refresh_token=True" in proc.stdout
+    assert "CLIENT_VALUE_SHOULD_NOT_PRINT" not in proc.stdout
+    assert "SECRET_VALUE_SHOULD_NOT_PRINT" not in proc.stdout
+    assert "ACCESS_VALUE_SHOULD_NOT_PRINT" not in proc.stdout
+    assert "REFRESH_VALUE_SHOULD_NOT_PRINT" not in proc.stdout


### PR DESCRIPTION
## Summary

Adds safe, explicit status output to the Schwab OAuth CLI.

The `--status` command now reports:

- expected config path
- whether config exists
- missing config keys
- expected token path
- whether token exists
- token freshness metadata
- whether access and refresh tokens are present

It does not print client secrets, access tokens, or refresh tokens.

## Testing

- `.venv-ci/bin/python -m pytest tests/test_schwab_oauth_cli_status.py -q`
- `.venv-ci/bin/python -m py_compile scripts/schwab_oauth_cli.py tests/test_schwab_oauth_cli_status.py`
- `.venv-ci/bin/ruff format --check tests/test_schwab_oauth_cli_status.py`
- `.venv-ci/bin/ruff check scripts/schwab_oauth_cli.py tests/test_schwab_oauth_cli_status.py`