### PR TITLE
Show cache artifact timestamps in M43 status

### DIFF
--- a/market_health/alert_status.py
+++ b/market_health/alert_status.py
@@ -48,6 +48,26 @@ def _one(conn, sql: str):
     return conn.execute(sql).fetchone()
 
 
+def _json_timestamp(path: Path, keys: tuple[str, ...]) -> str | None:
+    if not path.exists():
+        return None
+
+    try:
+        obj = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+
+    if not isinstance(obj, dict):
+        return None
+
+    for key in keys:
+        value = obj.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+
+    return None
+
+
 def _sqlite_status(db_path: Path) -> dict:
     status = {
         "db_path": str(db_path),
@@ -116,6 +136,8 @@ def _sqlite_status(db_path: Path) -> dict:
         )
         status["latest_positions_timestamp"] = (
             latest_positions["ts_utc"] if latest_positions else None
+        ) or _json_timestamp(
+            db_path.parent / "positions.v1.json", ("asof", "generated_at")
         )
 
         latest_forecast = _one(
@@ -128,6 +150,9 @@ def _sqlite_status(db_path: Path) -> dict:
         )
         status["latest_forecast_timestamp"] = (
             latest_forecast["ts_utc"] if latest_forecast else None
+        ) or _json_timestamp(
+            db_path.parent / "forecast_scores.v1.json",
+            ("generated_at", "asof", "snapshot_asof", "source_asof"),
         )
 
         latest_alert = _one(

--- a/tests/test_alert_status.py
+++ b/tests/test_alert_status.py
@@ -208,3 +208,29 @@ def test_sqlite_status_handles_existing_empty_db(tmp_path: Path) -> None:
 
     assert status["database"]["db_exists"] is True
     assert status["database"]["last_run"] == {}
+
+
+def test_sqlite_status_uses_cache_artifact_timestamps_when_snapshots_missing(
+    tmp_path: Path,
+) -> None:
+    from market_health.alert_status import _sqlite_status
+    from market_health.alert_store import apply_migrations, connect
+
+    db_path = tmp_path / "market_health_alerts.v1.sqlite"
+
+    with connect(db_path) as conn:
+        apply_migrations(conn)
+
+    (tmp_path / "positions.v1.json").write_text(
+        '{"schema":"positions.v1","asof":"2026-05-01T15:00:00Z"}\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "forecast_scores.v1.json").write_text(
+        '{"schema":"forecast_scores.v1","generated_at":"2026-05-01T16:00:00Z"}\n',
+        encoding="utf-8",
+    )
+
+    status = _sqlite_status(db_path)
+
+    assert status["latest_positions_timestamp"] == "2026-05-01T15:00:00Z"
+    assert status["latest_forecast_timestamp"] == "2026-05-01T16:00:00Z"


### PR DESCRIPTION
## Summary

Updates `mh_alert_status` to fall back to cache artifact timestamps when SQLite snapshot rows do not contain held/forecast timestamps.

This makes the operator status command show useful freshness data from:

- `positions.v1.json`
- `forecast_scores.v1.json`

instead of reporting `none` when the artifacts exist and refresh successfully.

## Testing

- `.venv-ci/bin/python -m pytest tests/test_alert_status.py -q`
- `.venv-ci/bin/python -m py_compile market_health/alert_status.py tests/test_alert_status.py`
- `.venv-ci/bin/ruff format --check market_health/alert_status.py tests/test_alert_status.py`
- `.venv-ci/bin/ruff check market_health/alert_status.py tests/test_alert_status.py`