### PR TITLE
Show current M43 system errors separately

### DIFF
--- a/market_health/alert_status.py
+++ b/market_health/alert_status.py
@@ -80,6 +80,7 @@ def _sqlite_status(db_path: Path) -> dict:
         "latest_forecast_timestamp": None,
         "latest_telegram_alert": None,
         "latest_system_health_event": None,
+        "latest_system_error_after_success": None,
     }
 
     if not db_path.exists():
@@ -178,6 +179,29 @@ def _sqlite_status(db_path: Path) -> dict:
         )
         status["latest_system_health_event"] = dict(latest_system or {})
 
+        latest_system_error_after_success = _one(
+            conn,
+            """
+            SELECT id, ts_utc, event_type, severity, message
+            FROM system_events
+            WHERE severity IN ('error', 'critical')
+              AND ts_utc > COALESCE(
+                (
+                  SELECT MAX(finished_at_utc)
+                  FROM runs
+                  WHERE status = 'success'
+                    AND finished_at_utc IS NOT NULL
+                ),
+                ''
+              )
+            ORDER BY id DESC
+            LIMIT 1
+            """,
+        )
+        status["latest_system_error_after_success"] = dict(
+            latest_system_error_after_success or {}
+        )
+
     return status
 
 
@@ -245,6 +269,7 @@ def format_status_text(status: dict) -> str:
     timer = status["timer"]
     latest_alert = db.get("latest_telegram_alert") or {}
     latest_system = db.get("latest_system_health_event") or {}
+    latest_system_error = db.get("latest_system_error_after_success") or {}
 
     lines = [
         "m43-alert-status:",
@@ -270,6 +295,13 @@ def format_status_text(status: dict) -> str:
             f"type={latest_system.get('event_type', 'none')} "
             f"severity={latest_system.get('severity', 'none')} "
             f"ts={latest_system.get('ts_utc', 'none')}"
+        ),
+        (
+            "  latest_system_error_after_success: "
+            f"id={latest_system_error.get('id', 'none')} "
+            f"type={latest_system_error.get('event_type', 'none')} "
+            f"severity={latest_system_error.get('severity', 'none')} "
+            f"ts={latest_system_error.get('ts_utc', 'none')}"
         ),
     ]
     return "\n".join(lines)

--- a/tests/test_alert_status.py
+++ b/tests/test_alert_status.py
@@ -234,3 +234,66 @@ def test_sqlite_status_uses_cache_artifact_timestamps_when_snapshots_missing(
 
     assert status["latest_positions_timestamp"] == "2026-05-01T15:00:00Z"
     assert status["latest_forecast_timestamp"] == "2026-05-01T16:00:00Z"
+
+
+def test_sqlite_status_reports_only_system_errors_after_latest_success(
+    tmp_path: Path,
+) -> None:
+    from market_health.alert_status import _sqlite_status
+    from market_health.alert_store import apply_migrations, connect
+
+    db_path = tmp_path / "market_health_alerts.v1.sqlite"
+
+    with connect(db_path) as conn:
+        apply_migrations(conn)
+        conn.execute(
+            """
+            INSERT INTO runs (
+                started_at_utc, finished_at_utc, status, mode, trigger_name
+            )
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                "2026-05-01T10:00:00Z",
+                "2026-05-01T10:01:00Z",
+                "failed",
+                "dry-run",
+                "manual",
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO system_events (
+                run_id, ts_utc, event_type, severity, message, payload_json
+            )
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                1,
+                "2026-05-01T10:00:30Z",
+                "runner_failed",
+                "error",
+                "old failure",
+                "{}",
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO runs (
+                started_at_utc, finished_at_utc, status, mode, trigger_name
+            )
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                "2026-05-01T11:00:00Z",
+                "2026-05-01T11:01:00Z",
+                "success",
+                "test",
+                "manual",
+            ),
+        )
+
+    status = _sqlite_status(db_path)
+
+    assert status["latest_system_health_event"]["event_type"] == "runner_failed"
+    assert status["latest_system_error_after_success"] == {}


### PR DESCRIPTION
## Summary

Updates `mh_alert_status` to separate historical system health events from current unresolved system errors.

The status output now includes:

- `latest_system_health_event`: latest event of any severity
- `latest_system_error_after_success`: latest error/critical event after the most recent successful run

This avoids making old historical errors look like the current service state after later successful runs.

## Testing

- `.venv-ci/bin/python -m pytest tests/test_alert_status.py -q`
- `.venv-ci/bin/python -m py_compile market_health/alert_status.py tests/test_alert_status.py`
- `.venv-ci/bin/ruff format --check market_health/alert_status.py tests/test_alert_status.py`
- `.venv-ci/bin/ruff check market_health/alert_status.py tests/test_alert_status.py`