### PR TITLE
Add Schwab OAuth config initializer

### DIFF
--- a/scripts/schwab_oauth_cli.py
+++ b/scripts/schwab_oauth_cli.py
@@ -5,12 +5,16 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import shutil
 import sys
 
 # Allow running from repo checkout without installing the package
 from pathlib import Path as _Path
 
 _REPO_ROOT = _Path(__file__).resolve().parents[1]
+DEFAULT_EXAMPLE_CONFIG_PATH = (
+    _REPO_ROOT / "docs" / "examples" / "schwab_oauth.json.example"
+)
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
@@ -57,6 +61,16 @@ def main() -> int:
         "--status", action="store_true", help="Show token status (no network calls)"
     )
     ap.add_argument(
+        "--init-config",
+        action="store_true",
+        help="Create a local Schwab OAuth config template with 0600 permissions",
+    )
+    ap.add_argument(
+        "--force",
+        action="store_true",
+        help="Allow --init-config to overwrite an existing config file",
+    )
+    ap.add_argument(
         "--print-auth-url", action="store_true", help="Print the authorize URL"
     )
     ap.add_argument(
@@ -71,6 +85,31 @@ def main() -> int:
 
     cfg_path = os.path.expanduser(args.config)
     tok_path = os.path.expanduser(args.token)
+
+    if args.init_config:
+        dst = _Path(cfg_path)
+        if dst.exists() and not args.force:
+            print(f"ERR: config already exists: {dst}", file=sys.stderr)
+            print("Use --force to overwrite it.", file=sys.stderr)
+            return 2
+
+        if not DEFAULT_EXAMPLE_CONFIG_PATH.exists():
+            print(
+                f"ERR: example config missing: {DEFAULT_EXAMPLE_CONFIG_PATH}",
+                file=sys.stderr,
+            )
+            return 2
+
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(DEFAULT_EXAMPLE_CONFIG_PATH, dst)
+        try:
+            os.chmod(dst, 0o600)
+        except Exception:
+            pass
+
+        print(f"OK: wrote config template: {dst}")
+        print("Fill in client_id and client_secret locally; secrets were not printed.")
+        return 0
 
     if args.status:
         cfg_exists, cfg_missing = _config_status(cfg_path)

--- a/tests/test_schwab_oauth_cli_init_config.py
+++ b/tests/test_schwab_oauth_cli_init_config.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+SCRIPT = Path("scripts/schwab_oauth_cli.py")
+
+
+def test_init_config_writes_template_with_private_permissions(tmp_path: Path) -> None:
+    config = tmp_path / "schwab_oauth.json"
+    token = tmp_path / "schwab.token.json"
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--config",
+            str(config),
+            "--token",
+            str(token),
+            "--init-config",
+        ],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+    assert proc.returncode == 0
+    assert "OK: wrote config template" in proc.stdout
+    assert "secrets were not printed" in proc.stdout
+    assert config.exists()
+
+    text = config.read_text(encoding="utf-8")
+    assert "client_id" in text
+    assert "client_secret" in text
+    assert "token_url" in text
+    assert oct(config.stat().st_mode & 0o777) == "0o600"
+
+
+def test_init_config_refuses_to_overwrite_without_force(tmp_path: Path) -> None:
+    config = tmp_path / "schwab_oauth.json"
+    config.write_text('{"client_id":"keep"}\n', encoding="utf-8")
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--config",
+            str(config),
+            "--init-config",
+        ],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+    assert proc.returncode == 2
+    assert "config already exists" in proc.stderr
+    assert config.read_text(encoding="utf-8") == '{"client_id":"keep"}\n'


### PR DESCRIPTION
## Summary

Adds `--init-config` to the Schwab OAuth CLI.

This creates a local Schwab OAuth config template at the selected config path with `0600` permissions, using the repo example as the source.

Behavior:

- writes the template to `~/.config/jerboa/schwab_oauth.json` by default
- refuses to overwrite existing config unless `--force` is passed
- does not print secrets
- keeps setup terminal-only and inspectable via `--status`

## Testing

- `.venv-ci/bin/python -m pytest tests/test_schwab_oauth_cli_status.py tests/test_schwab_oauth_cli_init_config.py -q`
- `.venv-ci/bin/python -m py_compile scripts/schwab_oauth_cli.py tests/test_schwab_oauth_cli_init_config.py`
- `.venv-ci/bin/ruff format --check tests/test_schwab_oauth_cli_init_config.py`
- `.venv-ci/bin/ruff check scripts/schwab_oauth_cli.py tests/test_schwab_oauth_cli_init_config.py`