### PR TITLE
Detect Schwab OAuth config placeholders

### DIFF
--- a/scripts/schwab_oauth_cli.py
+++ b/scripts/schwab_oauth_cli.py
@@ -31,6 +31,26 @@ from market_health.brokers.schwab_oauth import (
 )
 
 
+def _looks_like_placeholder(value: object) -> bool:
+    text = str(value or "").strip().lower()
+    if not text:
+        return True
+
+    placeholder_markers = (
+        "replace",
+        "your_",
+        "your-",
+        "todo",
+        "example",
+        "placeholder",
+        "changeme",
+        "change_me",
+        "<",
+        ">",
+    )
+    return any(marker in text for marker in placeholder_markers)
+
+
 def _config_status(path: str) -> tuple[bool, list[str]]:
     cfg_path = os.path.expanduser(path)
     if not os.path.exists(cfg_path):
@@ -43,7 +63,7 @@ def _config_status(path: str) -> tuple[bool, list[str]]:
         return True, ["unreadable_json"]
 
     required = ["client_id", "client_secret", "redirect_uri", "auth_url", "token_url"]
-    missing = [key for key in required if not str(data.get(key, "")).strip()]
+    missing = [key for key in required if _looks_like_placeholder(data.get(key))]
     return True, missing
 
 

--- a/tests/test_schwab_oauth_cli_status.py
+++ b/tests/test_schwab_oauth_cli_status.py
@@ -81,3 +81,30 @@ def test_status_reports_presence_without_printing_secret_values(tmp_path: Path) 
     assert "SECRET_VALUE_SHOULD_NOT_PRINT" not in proc.stdout
     assert "ACCESS_VALUE_SHOULD_NOT_PRINT" not in proc.stdout
     assert "REFRESH_VALUE_SHOULD_NOT_PRINT" not in proc.stdout
+
+
+def test_status_reports_placeholder_config_values_as_missing(tmp_path: Path) -> None:
+    config = tmp_path / "schwab_oauth.json"
+    token = tmp_path / "schwab.token.json"
+
+    config.write_text(
+        json.dumps(
+            {
+                "client_id": "REPLACE_WITH_CLIENT_ID",
+                "client_secret": "REPLACE_WITH_CLIENT_SECRET",
+                "redirect_uri": "https://127.0.0.1/callback",
+                "auth_url": "https://api.schwabapi.com/v1/oauth/authorize",
+                "token_url": "https://api.schwabapi.com/v1/oauth/token",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    proc = run_status(config, token)
+
+    assert proc.returncode == 0
+    assert "config_exists=True" in proc.stdout
+    assert "config_missing=client_id,client_secret" in proc.stdout
+    assert "REPLACE_WITH_CLIENT_ID" not in proc.stdout
+    assert "REPLACE_WITH_CLIENT_SECRET" not in proc.stdout


### PR DESCRIPTION
## Summary

Updates Schwab OAuth `--status` to treat template placeholder values as missing config.

This prevents a freshly initialized config template from appearing complete when `client_id` and `client_secret` still contain placeholder values.

The status output remains safe and does not print secret values.

## Testing

- `.venv-ci/bin/python -m pytest tests/test_schwab_oauth_cli_status.py tests/test_schwab_oauth_cli_init_config.py -q`
- `.venv-ci/bin/python -m py_compile scripts/schwab_oauth_cli.py tests/test_schwab_oauth_cli_status.py`
- `.venv-ci/bin/ruff format --check scripts/schwab_oauth_cli.py tests/test_schwab_oauth_cli_status.py`
- `.venv-ci/bin/ruff check scripts/schwab_oauth_cli.py tests/test_schwab_oauth_cli_status.py`