### PR TITLE
Set Schwab OAuth example URLs

### DIFF
--- a/docs/examples/schwab_oauth.json.example
+++ b/docs/examples/schwab_oauth.json.example
@@ -2,7 +2,7 @@
   "client_id": "REPLACE_ME",
   "client_secret": "REPLACE_ME",
   "redirect_uri": "http://127.0.0.1:8080/callback",
-  "auth_url": "REPLACE_WITH_PROVIDER_AUTH_URL",
-  "token_url": "REPLACE_WITH_PROVIDER_TOKEN_URL",
+  "auth_url": "https://api.schwabapi.com/v1/oauth/authorize",
+  "token_url": "https://api.schwabapi.com/v1/oauth/token",
   "scope": ""
 }

--- a/tests/test_schwab_oauth_example.py
+++ b/tests/test_schwab_oauth_example.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+EXAMPLE = Path("docs/examples/schwab_oauth.json.example")
+
+
+def test_schwab_oauth_example_has_default_provider_urls() -> None:
+    data = json.loads(EXAMPLE.read_text(encoding="utf-8"))
+
+    assert data["client_id"] == "REPLACE_ME"
+    assert data["client_secret"] == "REPLACE_ME"
+    assert data["auth_url"] == "https://api.schwabapi.com/v1/oauth/authorize"
+    assert data["token_url"] == "https://api.schwabapi.com/v1/oauth/token"
+    assert data["redirect_uri"]


### PR DESCRIPTION
## Summary

Updates the Schwab OAuth example config with the standard Schwab OAuth authorize and token endpoint URLs.

This makes `scripts/schwab_oauth_cli.py --init-config` create a more useful local config template, so operator status only reports the credentials as missing instead of also reporting provider URLs as missing.

## Testing

- `.venv-ci/bin/python -m pytest tests/test_schwab_oauth_example.py tests/test_schwab_oauth_cli_status.py tests/test_schwab_oauth_cli_init_config.py -q`
- `.venv-ci/bin/python -m py_compile tests/test_schwab_oauth_example.py`
- `.venv-ci/bin/ruff format --check tests/test_schwab_oauth_example.py`
- `.venv-ci/bin/ruff check tests/test_schwab_oauth_example.py`