### PR TITLE
Show Schwab setup status from positions refresh

### DIFF
--- a/scripts/jerboa/bin/jerboa-market-health-positions-refresh
+++ b/scripts/jerboa/bin/jerboa-market-health-positions-refresh
@@ -61,7 +61,30 @@ chmod 700 "$POS_DIR" 2>/dev/null || true
 
 RAW_SCHWAB_JSON="${HOME}/.cache/jerboa/schwab_accounts.live.json"
 TOKEN_FILE="${HOME}/.cache/jerboa/schwab.token.json"
+SCHWAB_CONFIG_FILE="${HOME}/.config/jerboa/schwab_oauth.json"
 RAW_MAX_AGE_MINUTES="${JERBOA_SCHWAB_RAW_MAX_AGE_MINUTES:-15}"
+
+print_schwab_setup_hint() {
+  if [ "${JERBOA_POSITIONS_HIDE_SCHWAB_HINT:-0}" = "1" ]; then
+    return 0
+  fi
+
+  echo "Schwab live: not ready or not selected."
+  echo "Schwab OAuth status:"
+  hint_python="${JERBOA_MARKET_HEALTH_PYTHON:-}"
+  if [ -z "$hint_python" ]; then
+    if [ -x "$REPO_ROOT/.venv/bin/python" ]; then
+      hint_python="$REPO_ROOT/.venv/bin/python"
+    else
+      hint_python="python3"
+    fi
+  fi
+
+  "$hint_python" "$REPO_ROOT/scripts/schwab_oauth_cli.py" --status 2>/dev/null | sed 's/^/  /' || true
+  echo "To enable Schwab live positions, complete local config/token setup:"
+  echo "  config: $SCHWAB_CONFIG_FILE"
+  echo "  token:  $TOKEN_FILE"
+}
 
 if [ -z "$SCHWAB_JSON" ] && [ -z "$CSV" ] && [ "$OUT" = "$DEFAULT_OUT" ] && [ -f "$TOKEN_FILE" ]; then
   echo "Refreshing live Schwab data via token cache..."
@@ -135,6 +158,8 @@ if [ -n "$best" ]; then
   echo "Using ToS CSV: $best"
   exec "${REPO_ROOT}/scripts/cache/refresh_positions_cache.sh" --csv "$best" --out "$OUT"
 fi
+
+print_schwab_setup_hint
 
 if [ -s "$OUT" ]; then
   echo "Positions: keeping existing cache: $OUT"

--- a/tests/test_m43_positions_refresh_wrapper.py
+++ b/tests/test_m43_positions_refresh_wrapper.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+
+WRAPPER = Path("scripts/jerboa/bin/jerboa-market-health-positions-refresh")
+
+
+def test_positions_refresh_reports_safe_schwab_status_hint() -> None:
+    text = WRAPPER.read_text(encoding="utf-8")
+
+    assert "print_schwab_setup_hint" in text
+    assert "Schwab OAuth status:" in text
+    assert "scripts/schwab_oauth_cli.py" in text
+    assert "--status" in text
+    assert "JERBOA_POSITIONS_HIDE_SCHWAB_HINT" in text
+    assert "SCHWAB_CONFIG_FILE" in text
+    assert "TOKEN_FILE" in text


### PR DESCRIPTION
## Summary

Adds a safe Schwab setup hint to the positions refresh wrapper when no live Schwab token, cached Schwab JSON, or CSV source is available.

The hint runs `scripts/schwab_oauth_cli.py --status`, which reports config/token readiness without printing secrets.

Behavior:

- shows Schwab config/token status when positions refresh falls back to existing/no cache
- can be suppressed with `JERBOA_POSITIONS_HIDE_SCHWAB_HINT=1`
- continues preserving existing cache behavior

## Testing

- `.venv-ci/bin/python -m pytest tests/test_m43_positions_refresh_wrapper.py -q`
- `bash -n scripts/jerboa/bin/jerboa-market-health-positions-refresh`
- `.venv-ci/bin/ruff format --check tests/test_m43_positions_refresh_wrapper.py`
- `.venv-ci/bin/ruff check tests/test_m43_positions_refresh_wrapper.py`