### PR TITLE
Add operator readiness to market health doctor

### DIFF
--- a/scripts/jerboa/doctor_market_health.sh
+++ b/scripts/jerboa/doctor_market_health.sh
@@ -17,6 +17,21 @@ ALERTDIR="${HOME}/.cache/jerboa/alerts"
 ENV_JSON="${HOME}/.cache/jerboa/environment.v1.json"
 SECT_JSON="${HOME}/.cache/jerboa/market_health.sectors.json"
 POS_JSON="${HOME}/.cache/jerboa/positions.v1.json"
+FORECAST_JSON="${HOME}/.cache/jerboa/forecast_scores.v1.json"
+REC_JSON="${HOME}/.cache/jerboa/recommendations.v1.json"
+UI_JSON="${HOME}/.cache/jerboa/market_health.ui.v1.json"
+ALERT_DB="${HOME}/.cache/jerboa/market_health_alerts.v1.sqlite"
+SCHWAB_CONFIG="${HOME}/.config/jerboa/schwab_oauth.json"
+SCHWAB_TOKEN="${HOME}/.cache/jerboa/schwab.token.json"
+
+PYTHON="${JERBOA_MARKET_HEALTH_PYTHON:-}"
+if [ -z "$PYTHON" ]; then
+  if [ -x "$REPO/.venv/bin/python" ]; then
+    PYTHON="$REPO/.venv/bin/python"
+  else
+    PYTHON="python3"
+  fi
+fi
 
 echo "== Repo root =="
 echo "$REPO"
@@ -67,7 +82,15 @@ journalctl --user -u jerboa-market-health-refresh-all.service -n 80 --no-pager 2
 
 echo
 echo "== Cache presence + timestamps =="
-ls -lh --time-style=long-iso "$ENV_JSON" "$SECT_JSON" "$POS_JSON" 2>/dev/null || true
+ls -lh --time-style=long-iso \
+  "$ENV_JSON" \
+  "$SECT_JSON" \
+  "$POS_JSON" \
+  "$FORECAST_JSON" \
+  "$REC_JSON" \
+  "$UI_JSON" \
+  "$ALERT_DB" \
+  2>/dev/null || true
 
 echo
 echo "== Last refresh-all state (state.json) =="
@@ -107,6 +130,61 @@ if [ -n "${latest:-}" ]; then
 else
   echo "none yet in $ALERTDIR"
 fi
+
+
+echo
+echo "== M43 alert status =="
+if [ -x "$BIN/mh_alert_status" ]; then
+  "$BIN/mh_alert_status" || true
+else
+  "$PYTHON" -m market_health.alert_status --db "$ALERT_DB" --repo "$REPO" || true
+fi
+
+echo
+echo "== M43 alert timer status =="
+systemctl --user is-enabled jerboa-market-health-alert.timer 2>/dev/null || true
+systemctl --user is-active  jerboa-market-health-alert.timer 2>/dev/null || true
+systemctl --user list-timers --all 2>/dev/null | grep -n 'jerboa-market-health-alert' || true
+
+echo
+echo "== Schwab OAuth status =="
+schwab_status="$("$PYTHON" "$REPO/scripts/schwab_oauth_cli.py" --status 2>/dev/null || true)"
+if [ -n "$schwab_status" ]; then
+  printf '%s\n' "$schwab_status"
+else
+  echo "Schwab status unavailable"
+fi
+
+echo
+echo "== Operator next action =="
+alert_timer_enabled="$(systemctl --user is-enabled jerboa-market-health-alert.timer 2>/dev/null || true)"
+alert_timer_active="$(systemctl --user is-active jerboa-market-health-alert.timer 2>/dev/null || true)"
+schwab_missing="$(printf '%s\n' "$schwab_status" | awk -F= '$1=="config_missing"{print $2; exit}')"
+token_exists="$(printf '%s\n' "$schwab_status" | awk -F= '$1=="token_exists"{print $2; exit}')"
+
+printed_next_action=0
+
+if [ -n "$schwab_missing" ] || [ "$token_exists" = "False" ]; then
+  echo "- Schwab live positions are not ready: complete local config/token setup, or continue using CSV/sample positions."
+  echo "  config: $SCHWAB_CONFIG"
+  echo "  token:  $SCHWAB_TOKEN"
+  printed_next_action=1
+fi
+
+if [ "$alert_timer_enabled" != "enabled" ] || [ "$alert_timer_active" != "active" ]; then
+  echo "- M43 alert timer is not active. Enable it only after Telegram mode and positions source are ready."
+  printed_next_action=1
+fi
+
+if [ ! -f "$UI_JSON" ]; then
+  echo "- UI artifact is missing. Run jerboa-market-health-refresh-all."
+  printed_next_action=1
+fi
+
+if [ "$printed_next_action" -eq 0 ]; then
+  echo "- No blocking readiness issue detected by this doctor snapshot."
+fi
+
 
 echo
 echo "DONE: doctor snapshot complete"

--- a/tests/test_m43_doctor_market_health.py
+++ b/tests/test_m43_doctor_market_health.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+
+DOCTOR = Path("scripts/jerboa/doctor_market_health.sh")
+
+
+def test_doctor_includes_operator_readiness_sections() -> None:
+    text = DOCTOR.read_text(encoding="utf-8")
+
+    assert "== M43 alert status ==" in text
+    assert "== M43 alert timer status ==" in text
+    assert "== Schwab OAuth status ==" in text
+    assert "== Operator next action ==" in text
+    assert "scripts/schwab_oauth_cli.py" in text
+    assert "mh_alert_status" in text
+    assert "jerboa-market-health-alert.timer" in text
+    assert "forecast_scores.v1.json" in text
+    assert "market_health.ui.v1.json" in text
+
+
+def test_doctor_prefers_repo_venv_python() -> None:
+    text = DOCTOR.read_text(encoding="utf-8")
+
+    assert "JERBOA_MARKET_HEALTH_PYTHON" in text
+    assert "$REPO/.venv/bin/python" in text
+    assert 'PYTHON="python3"' in text


### PR DESCRIPTION
## Summary

Extends the market-health doctor script with an operator-readiness snapshot.

Adds sections for:

- M43 alert status
- M43 alert timer status
- Schwab OAuth config/token status
- key cache artifacts including forecast, recommendations, UI, and alert DB
- a final “Operator next action” section

This gives a single terminal command that says what is currently blocking readiness instead of requiring several separate status checks.

## Testing

- `.venv-ci/bin/python -m pytest tests/test_m43_doctor_market_health.py -q`
- `bash -n scripts/jerboa/doctor_market_health.sh`
- `.venv-ci/bin/ruff format --check tests/test_m43_doctor_market_health.py`
- `.venv-ci/bin/ruff check tests/test_m43_doctor_market_health.py`