### PR TITLE
Make Schwab OAuth walkthrough handle first-run setup

### DIFF
--- a/scripts/schwab_oauth_walkthrough.py
+++ b/scripts/schwab_oauth_walkthrough.py
@@ -16,6 +16,11 @@ from typing import Any, Dict
 import getpass
 
 
+DEFAULT_REDIRECT_URI = "http://127.0.0.1:8080/callback"
+DEFAULT_AUTH_URL = "https://api.schwabapi.com/v1/oauth/authorize"
+DEFAULT_TOKEN_URL = "https://api.schwabapi.com/v1/oauth/token"
+
+
 def _sanitize_for_display(obj):
     """Return a redacted copy suitable for logs/stdout."""
     if not isinstance(obj, dict):
@@ -47,6 +52,44 @@ def _read_json(p: Path) -> Dict[str, Any]:
     return json.loads(p.read_text(encoding="utf-8"))
 
 
+def _looks_like_placeholder(value: object) -> bool:
+    text = str(value or "").strip().lower()
+    if not text:
+        return True
+
+    placeholder_markers = (
+        "replace",
+        "your_",
+        "your-",
+        "todo",
+        "example",
+        "placeholder",
+        "changeme",
+        "change_me",
+        "<",
+        ">",
+    )
+    return any(marker in text for marker in placeholder_markers)
+
+
+def _prompt_text(prompt: str) -> str:
+    try:
+        with open("/dev/tty", "r+", encoding="utf-8") as tty:
+            tty.write(prompt)
+            tty.flush()
+            return tty.readline().strip()
+    except OSError:
+        return input(prompt).strip()
+
+
+def _prompt_secret(prompt: str) -> str:
+    try:
+        with open("/dev/tty", "r+", encoding="utf-8") as tty:
+            return getpass.getpass(prompt, stream=tty).strip()
+    except OSError:
+        return getpass.getpass(prompt).strip()
+
+
 def _write_json_secure(p: Path, obj: Dict[str, Any]) -> None:
     p.parent.mkdir(parents=True, exist_ok=True)
     tmp = p.with_suffix(p.suffix + ".tmp")
@@ -68,16 +111,45 @@ def _chmod_dir_private(p: Path) -> None:
 
 def load_cfg(path: str) -> Cfg:
     p = Path(os.path.expanduser(path))
-    d = _read_json(p)
-    d["client_secret"] = (
-        d.get("client_secret")
-        or os.environ.get("SCHWAB_CLIENT_SECRET")
-        or getpass.getpass("SCHWAB_CLIENT_SECRET: ")
-    )
-    need = ["client_id", "redirect_uri", "auth_url", "token_url"]
-    missing = [k for k in need if not d.get(k)]
+    if p.exists():
+        d = _read_json(p)
+    else:
+        d = {}
+
+    changed = False
+
+    if _looks_like_placeholder(d.get("client_id")):
+        env_client_id = os.environ.get("SCHWAB_CLIENT_ID", "").strip()
+        d["client_id"] = env_client_id or _prompt_text("SCHWAB_CLIENT_ID: ")
+        changed = True
+
+    if _looks_like_placeholder(d.get("client_secret")):
+        env_client_secret = os.environ.get("SCHWAB_CLIENT_SECRET", "").strip()
+        d["client_secret"] = env_client_secret or _prompt_secret(
+            "SCHWAB_CLIENT_SECRET: "
+        )
+        changed = True
+
+    defaults = {
+        "redirect_uri": DEFAULT_REDIRECT_URI,
+        "auth_url": DEFAULT_AUTH_URL,
+        "token_url": DEFAULT_TOKEN_URL,
+        "scope": "",
+    }
+    for key, default in defaults.items():
+        if _looks_like_placeholder(d.get(key)):
+            d[key] = default
+            changed = True
+
+    need = ["client_id", "client_secret", "redirect_uri", "auth_url", "token_url"]
+    missing = [k for k in need if _looks_like_placeholder(d.get(k))]
     if missing:
         raise SystemExit(f"ERR: missing keys in {p}: {', '.join(missing)}")
+
+    if changed or not p.exists():
+        _write_json_secure(p, d)
+        print(f"OK: wrote OAuth config -> {p} (0600; secrets not printed)")
+
     return Cfg(
         client_id=str(d["client_id"]),
         client_secret=str(d["client_secret"]),
@@ -144,7 +216,7 @@ def token_is_fresh(tok: Dict[str, Any], leeway: int = 60) -> bool:
 
 def main() -> int:
     ap = argparse.ArgumentParser(
-        description="Schwab OAuth walkthrough: print auth URL, paste redirect URL, save token cache"
+        description="Schwab OAuth walkthrough: first-run setup, browser authorization, token cache"
     )
     ap.add_argument(
         "--config",
@@ -174,7 +246,7 @@ def main() -> int:
     )
 
     try:
-        redirect_url = input("Redirect URL: ").strip()
+        redirect_url = _prompt_text("Redirect URL: ")
     except KeyboardInterrupt:
         print("\nCanceled. No changes made.")
         return 130

--- a/tests/test_schwab_oauth_walkthrough_first_run.py
+++ b/tests/test_schwab_oauth_walkthrough_first_run.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+SCRIPT = Path("scripts/schwab_oauth_walkthrough.py")
+
+
+def load_walkthrough_module() -> ModuleType:
+    name = "schwab_oauth_walkthrough"
+    spec = importlib.util.spec_from_file_location(name, SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_load_cfg_creates_first_run_config_without_printing_secrets(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    module = load_walkthrough_module()
+    config = tmp_path / "schwab_oauth.json"
+
+    monkeypatch.setattr(module, "_prompt_text", lambda prompt: "CLIENT_ID_VALUE")
+    monkeypatch.setattr(module, "_prompt_secret", lambda prompt: "CLIENT_SECRET_VALUE")
+
+    cfg = module.load_cfg(str(config))
+    captured = capsys.readouterr()
+
+    assert cfg.client_id == "CLIENT_ID_VALUE"
+    assert cfg.client_secret == "CLIENT_SECRET_VALUE"
+    assert cfg.redirect_uri == "http://127.0.0.1:8080/callback"
+    assert cfg.auth_url == "https://api.schwabapi.com/v1/oauth/authorize"
+    assert cfg.token_url == "https://api.schwabapi.com/v1/oauth/token"
+    assert "secrets not printed" in captured.out
+    assert "CLIENT_SECRET_VALUE" not in captured.out
+    assert oct(config.stat().st_mode & 0o777) == "0o600"
+
+    data = json.loads(config.read_text(encoding="utf-8"))
+    assert data["client_id"] == "CLIENT_ID_VALUE"
+    assert data["client_secret"] == "CLIENT_SECRET_VALUE"
+
+
+def test_load_cfg_replaces_template_placeholders(tmp_path: Path, monkeypatch) -> None:
+    module = load_walkthrough_module()
+    config = tmp_path / "schwab_oauth.json"
+    config.write_text(
+        json.dumps(
+            {
+                "client_id": "REPLACE_ME",
+                "client_secret": "REPLACE_ME",
+                "redirect_uri": "http://127.0.0.1:8080/callback",
+                "auth_url": "https://api.schwabapi.com/v1/oauth/authorize",
+                "token_url": "https://api.schwabapi.com/v1/oauth/token",
+                "scope": "",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(module, "_prompt_text", lambda prompt: "CLIENT_ID_VALUE")
+    monkeypatch.setattr(module, "_prompt_secret", lambda prompt: "CLIENT_SECRET_VALUE")
+
+    cfg = module.load_cfg(str(config))
+
+    assert cfg.client_id == "CLIENT_ID_VALUE"
+    assert cfg.client_secret == "CLIENT_SECRET_VALUE"
+    assert cfg.auth_url == "https://api.schwabapi.com/v1/oauth/authorize"
+    assert cfg.token_url == "https://api.schwabapi.com/v1/oauth/token"
+
+
+def test_load_cfg_can_use_environment_credentials(tmp_path: Path, monkeypatch) -> None:
+    module = load_walkthrough_module()
+    config = tmp_path / "schwab_oauth.json"
+
+    monkeypatch.setenv("SCHWAB_CLIENT_ID", "ENV_CLIENT_ID")
+    monkeypatch.setenv("SCHWAB_CLIENT_SECRET", "ENV_CLIENT_SECRET")
+
+    cfg = module.load_cfg(str(config))
+
+    assert cfg.client_id == "ENV_CLIENT_ID"
+    assert cfg.client_secret == "ENV_CLIENT_SECRET"


### PR DESCRIPTION
## Summary

Updates the Schwab OAuth walkthrough so first-run setup is self-guided.

The walkthrough now:

- detects missing or placeholder Schwab OAuth config values
- prompts locally for `client_id` and `client_secret`
- supports `SCHWAB_CLIENT_ID` and `SCHWAB_CLIENT_SECRET` environment variables
- fills standard Schwab OAuth URLs and redirect URI defaults
- writes `~/.config/jerboa/schwab_oauth.json` with `0600`
- avoids printing secrets
- continues into the browser OAuth authorization flow and token-cache write

This removes the need for operators to manually edit the config file before running the walkthrough.

## Testing

- `.venv-ci/bin/python -m pytest tests/test_schwab_oauth_walkthrough_first_run.py tests/test_schwab_oauth_walkthrough.py -q`
- `.venv-ci/bin/python -m py_compile scripts/schwab_oauth_walkthrough.py tests/test_schwab_oauth_walkthrough_first_run.py`
- `.venv-ci/bin/ruff format --check scripts/schwab_oauth_walkthrough.py tests/test_schwab_oauth_walkthrough_first_run.py`
- `.venv-ci/bin/ruff check scripts/schwab_oauth_walkthrough.py tests/test_schwab_oauth_walkthrough_first_run.py`