### PR TITLE
Treat recent live positions as fresh

### DIFF
--- a/scripts/export_recommendations_v1.py
+++ b/scripts/export_recommendations_v1.py
@@ -116,12 +116,21 @@ def _is_market_session_fresh(value: Any, max_age_minutes: int = 15):
     if dt is None:
         return False
 
+    if max_age_minutes <= 0:
+        return True
+
     now_utc = datetime.now(timezone.utc)
     ttl_seconds = max_age_minutes * 60
 
     def _within_ttl() -> bool:
         age = (now_utc - dt).total_seconds()
         return 0 <= age <= ttl_seconds
+
+    # Live broker/cache inputs that were just refreshed should be accepted
+    # regardless of market-session timing. Session-aware logic below is only
+    # needed for accepting the last completed market session outside intraday TTL.
+    if _within_ttl():
+        return True
 
     try:
         from zoneinfo import ZoneInfo

--- a/tests/test_export_recommendations_positions_freshness.py
+++ b/tests/test_export_recommendations_positions_freshness.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import ModuleType
+
+
+SCRIPT = Path("scripts/export_recommendations_v1.py")
+
+
+def load_export_recommendations_module() -> ModuleType:
+    name = "export_recommendations_v1_for_freshness_test"
+    spec = importlib.util.spec_from_file_location(name, SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_market_session_fresh_accepts_recent_timestamp_outside_session() -> None:
+    module = load_export_recommendations_module()
+    recent = datetime.now(timezone.utc) - timedelta(minutes=3)
+
+    assert module._is_market_session_fresh(recent.isoformat(), max_age_minutes=15)
+
+
+def test_market_session_fresh_treats_nonpositive_max_age_as_disabled() -> None:
+    module = load_export_recommendations_module()
+    old = datetime.now(timezone.utc) - timedelta(days=365)
+
+    assert module._is_market_session_fresh(old.isoformat(), max_age_minutes=0)


### PR DESCRIPTION
## Summary

Fixes recommendation freshness gating for live broker positions.

Previously, `export_recommendations_v1.py` could mark positions as stale outside normal market-session logic even when the live Schwab positions cache had just refreshed. This made recommendations emit `stale_positions_cache` despite positions being only a few minutes old.

This update:

- treats timestamps within `max_positions_age_minutes` as fresh regardless of market-session timing
- treats non-positive max age as disabled
- preserves the existing session-aware fallback for last-completed-session behavior

## Testing

- `.venv-ci/bin/python -m pytest tests/test_export_recommendations_positions_freshness.py -q`
- `.venv-ci/bin/python -m py_compile scripts/export_recommendations_v1.py tests/test_export_recommendations_positions_freshness.py`
- `.venv-ci/bin/ruff format --check tests/test_export_recommendations_positions_freshness.py`
- `.venv-ci/bin/ruff check scripts/export_recommendations_v1.py tests/test_export_recommendations_positions_freshness.py`