### PR TITLE
Use calendar schedule for M43 alert timer

### DIFF
--- a/scripts/jerboa/systemd/user/jerboa-market-health-alert.timer
+++ b/scripts/jerboa/systemd/user/jerboa-market-health-alert.timer
@@ -2,8 +2,7 @@
 Description=Jerboa Market Health - run M43 alert service every 15 minutes
 
 [Timer]
-OnBootSec=5m
-OnUnitActiveSec=15m
+OnCalendar=*-*-* *:0/15:00
 Persistent=true
 Unit=jerboa-market-health-alert.service
 

--- a/tests/test_m43_systemd_templates.py
+++ b/tests/test_m43_systemd_templates.py
@@ -46,11 +46,11 @@ def test_alert_service_is_user_oneshot_with_timeout_and_journald_identifier() ->
 def test_alert_timer_runs_every_15_minutes_and_installs_to_timers_target() -> None:
     text = TIMER.read_text(encoding="utf-8")
 
-    assert "OnBootSec=5m" in text
-    assert "OnUnitActiveSec=15m" in text
+    assert "OnCalendar=*-*-* *:0/15:00" in text
     assert "Persistent=true" in text
     assert "Unit=jerboa-market-health-alert.service" in text
     assert "WantedBy=timers.target" in text
+    assert "OnUnitActiveSec=15m" not in text
 
 
 def test_service_and_timer_do_not_enable_themselves() -> None:


### PR DESCRIPTION
## Summary

Updates the M43 alert timer template to use an explicit calendar schedule.

The Pi user timer did not show a future trigger with the previous `OnUnitActiveSec=15m` template. The installed timer works correctly with:

- `OnCalendar=*-*-* *:0/15:00`
- `Persistent=true`

This makes the repo template match the verified working timer configuration.

## Testing

- `.venv-ci/bin/python -m pytest tests/test_m43_systemd_templates.py -q`
- `.venv-ci/bin/ruff format --check tests/test_m43_systemd_templates.py`
- `.venv-ci/bin/ruff check tests/test_m43_systemd_templates.py`

Note: `systemd-analyze` is not available in the Android Debian environment.