### PR TITLE
Expose forecast pre-quant audit fields

### DIFF
--- a/market_health/forecast_checks_c_crowding.py
+++ b/market_health/forecast_checks_c_crowding.py
@@ -236,7 +236,7 @@ def c4_flow_pressure(
                 "strong_oi_threshold": strong_oi,
                 "flow_status": fs,
             },
-            source_quality="direct",
+            source_quality="real",
             fallback_used=False,
         )
 

--- a/market_health/forecast_types.py
+++ b/market_health/forecast_types.py
@@ -28,6 +28,116 @@ class ForecastCheck:
     fallback_used: bool = False
 
 
+def _canonical_source_quality(value: str) -> str:
+    text = str(value or "").strip().lower()
+    if text == "direct":
+        return "real"
+    if text in {"real", "proxy", "neutral", "disabled"}:
+        return text
+    return "proxy"
+
+
+def _json_safe(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, dict):
+        return {str(k): _json_safe(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(v) for v in value]
+    return str(value)
+
+
+def _first_numeric_metric(metrics: Dict[str, Any]) -> float | None:
+    ignored = {
+        "H",
+        "horizon",
+        "horizon_days",
+        "horizon_scale",
+        "window",
+        "lookback",
+    }
+    preferred_markers = (
+        "u",
+        "z",
+        "slope",
+        "ratio",
+        "pct",
+        "percent",
+        "share",
+        "rank",
+        "freq",
+        "corr",
+        "dispersion",
+        "width",
+        "atr",
+        "iv",
+        "distance",
+        "momentum",
+        "change",
+        "value",
+        "raw",
+        "score_input",
+    )
+
+    for key, value in metrics.items():
+        key_text = str(key)
+        key_l = key_text.lower()
+        if key_text in ignored or key_l in {x.lower() for x in ignored}:
+            continue
+        if not isinstance(value, (int, float)):
+            continue
+        if any(marker in key_l for marker in preferred_markers):
+            return float(value)
+
+    for key, value in metrics.items():
+        key_text = str(key)
+        key_l = key_text.lower()
+        if key_text in ignored or key_l in {x.lower() for x in ignored}:
+            continue
+        if isinstance(value, (int, float)):
+            return float(value)
+
+    return None
+
+
+def _audit_cutoffs(metrics: Dict[str, Any]) -> Dict[str, Any]:
+    markers = (
+        "cutoff",
+        "threshold",
+        "strong",
+        "weak",
+        "warn",
+        "hot",
+        "warm",
+        "ok",
+        "min",
+        "max",
+    )
+    out: Dict[str, Any] = {}
+    for key, value in metrics.items():
+        key_text = str(key).lower()
+        if any(marker in key_text for marker in markers):
+            out[str(key)] = _json_safe(value)
+    return out
+
+
+def _audit_fields(check: ForecastCheck) -> Dict[str, Any]:
+    raw_inputs = _json_safe(dict(check.metrics or {}))
+    source_quality = _canonical_source_quality(check.source_quality)
+
+    return {
+        "source_quality": source_quality,
+        "fallback_used": bool(check.fallback_used),
+        "raw_inputs": raw_inputs,
+        "u": _first_numeric_metric(dict(check.metrics or {})),
+        "cutoffs": _audit_cutoffs(dict(check.metrics or {})),
+        "orientation": str(
+            (check.metrics or {}).get("orientation") or "higher_score_is_better"
+        ),
+        "margin_to_flip": (check.metrics or {}).get("margin_to_flip"),
+    }
+
+
 def cap_score(x: int) -> int:
     """Clamp to {0,1,2}."""
     return 0 if x < 0 else 2 if x > 2 else x
@@ -75,6 +185,8 @@ def category_dict(checks: List[ForecastCheck], *, horizon_days: int) -> Dict[str
         metrics["horizon_days"] = H
         metrics["horizon_scale"] = float(H**0.5)
 
+        audit = _audit_fields(c)
+
         out["checks"].append(
             {
                 "label": c.label,
@@ -82,8 +194,13 @@ def category_dict(checks: List[ForecastCheck], *, horizon_days: int) -> Dict[str
                 "score": int(c.score),
                 "horizon_days": H,
                 "metrics": metrics,
-                "source_quality": c.source_quality,
-                "fallback_used": bool(c.fallback_used),
+                "source_quality": audit["source_quality"],
+                "fallback_used": audit["fallback_used"],
+                "raw_inputs": audit["raw_inputs"],
+                "u": audit["u"],
+                "cutoffs": audit["cutoffs"],
+                "orientation": audit["orientation"],
+                "margin_to_flip": audit["margin_to_flip"],
             }
         )
 

--- a/scripts/validate_forecast_scores_v1.py
+++ b/scripts/validate_forecast_scores_v1.py
@@ -141,10 +141,10 @@ def validate(doc: Dict[str, Any]) -> List[str]:
                         )
 
                     sq = chk.get("source_quality")
-                    if sq not in ("direct", "proxy", "neutral"):
+                    if sq not in ("real", "proxy", "neutral", "disabled"):
                         _err(
                             errors,
-                            f"scores[{sym}][{h}].categories[{code}].checks[{i}].source_quality must be one of direct/proxy/neutral",
+                            f"scores[{sym}][{h}].categories[{code}].checks[{i}].source_quality must be one of real/proxy/neutral/disabled",
                         )
 
                     fb = chk.get("fallback_used")
@@ -152,6 +152,52 @@ def validate(doc: Dict[str, Any]) -> List[str]:
                         _err(
                             errors,
                             f"scores[{sym}][{h}].categories[{code}].checks[{i}].fallback_used must be bool",
+                        )
+
+                    if not isinstance(chk.get("raw_inputs"), dict):
+                        _err(
+                            errors,
+                            f"scores[{sym}][{h}].categories[{code}].checks[{i}].raw_inputs must be object",
+                        )
+
+                    if "u" not in chk:
+                        _err(
+                            errors,
+                            f"scores[{sym}][{h}].categories[{code}].checks[{i}].u must be present",
+                        )
+                    elif chk.get("u") is not None and not isinstance(
+                        chk.get("u"), (int, float)
+                    ):
+                        _err(
+                            errors,
+                            f"scores[{sym}][{h}].categories[{code}].checks[{i}].u must be number or null",
+                        )
+
+                    if not isinstance(chk.get("cutoffs"), dict):
+                        _err(
+                            errors,
+                            f"scores[{sym}][{h}].categories[{code}].checks[{i}].cutoffs must be object",
+                        )
+
+                    if not isinstance(chk.get("orientation"), str) or not chk.get(
+                        "orientation"
+                    ):
+                        _err(
+                            errors,
+                            f"scores[{sym}][{h}].categories[{code}].checks[{i}].orientation must be non-empty string",
+                        )
+
+                    if "margin_to_flip" not in chk:
+                        _err(
+                            errors,
+                            f"scores[{sym}][{h}].categories[{code}].checks[{i}].margin_to_flip must be present",
+                        )
+                    elif chk.get("margin_to_flip") is not None and not isinstance(
+                        chk.get("margin_to_flip"), (int, float)
+                    ):
+                        _err(
+                            errors,
+                            f"scores[{sym}][{h}].categories[{code}].checks[{i}].margin_to_flip must be number or null",
                         )
 
             diag = payload.get("diagnostics")
@@ -164,9 +210,72 @@ def validate(doc: Dict[str, Any]) -> List[str]:
     return errors
 
 
+def _horizon_payload(
+    scores: Dict[str, Any], symbol: str, horizon: int
+) -> Dict[str, Any]:
+    by_symbol = scores.get(symbol)
+    if not isinstance(by_symbol, dict):
+        raise SystemExit(f"ERR: symbol not found: {symbol}")
+
+    payload = by_symbol.get(horizon)
+    if payload is None:
+        payload = by_symbol.get(str(horizon))
+    if not isinstance(payload, dict):
+        raise SystemExit(f"ERR: horizon not found for {symbol}: {horizon}")
+
+    return payload
+
+
+def print_audit(doc: Dict[str, Any], *, symbol: str, horizons: List[int]) -> None:
+    scores = doc.get("scores")
+    if not isinstance(scores, dict):
+        raise SystemExit("ERR: scores must be an object before audit can print")
+
+    for horizon in horizons:
+        payload = _horizon_payload(scores, symbol, horizon)
+        cats = payload.get("categories")
+        if not isinstance(cats, dict):
+            raise SystemExit(f"ERR: categories missing for {symbol} H{horizon}")
+
+        print(f"forecast-audit symbol={symbol} horizon={horizon}")
+        for code in ["A", "B", "C", "D", "E"]:
+            cat = cats.get(code)
+            if not isinstance(cat, dict):
+                continue
+            checks = cat.get("checks")
+            if not isinstance(checks, list):
+                continue
+            for idx, chk in enumerate(checks, start=1):
+                if not isinstance(chk, dict):
+                    continue
+                print(
+                    " "
+                    f"{code}{idx} "
+                    f"label={chk.get('label')} "
+                    f"score={chk.get('score')} "
+                    f"source_quality={chk.get('source_quality')} "
+                    f"fallback_used={chk.get('fallback_used')} "
+                    f"u={chk.get('u')} "
+                    f"orientation={chk.get('orientation')} "
+                    f"margin_to_flip={chk.get('margin_to_flip')} "
+                    f"cutoffs={json.dumps(chk.get('cutoffs', {}), sort_keys=True)} "
+                    f"raw_inputs={json.dumps(chk.get('raw_inputs', {}), sort_keys=True)}"
+                )
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description="Validate forecast_scores.v1.json")
     ap.add_argument("--path", required=True, help="Path to forecast_scores.v1.json")
+    ap.add_argument(
+        "--audit-symbol",
+        default="",
+        help="Print per-check pre-quant audit fields for this symbol",
+    )
+    ap.add_argument(
+        "--audit-horizons",
+        default="",
+        help="Comma-separated horizon pair/list for --audit-symbol, e.g. 1,5",
+    )
     args = ap.parse_args()
 
     p = Path(args.path)
@@ -183,6 +292,17 @@ def main() -> int:
         return 1
 
     print("OK: forecast_scores.v1 valid")
+
+    if args.audit_symbol:
+        horizons = [
+            int(x.strip())
+            for x in str(args.audit_horizons or "").split(",")
+            if x.strip()
+        ]
+        if not horizons:
+            horizons = [1, 5]
+        print_audit(doc, symbol=args.audit_symbol, horizons=horizons)
+
     return 0
 
 

--- a/tests/test_forecast_prequant_audit_fields.py
+++ b/tests/test_forecast_prequant_audit_fields.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from market_health.forecast_features import OHLCV
+from market_health.forecast_score_provider import compute_forecast_universe
+
+
+VALIDATOR = Path("scripts/validate_forecast_scores_v1.py")
+
+
+def _ohlcv_trend(n: int = 80) -> OHLCV:
+    close = [100.0 + (i * 0.25) for i in range(n)]
+    high = [c + 1.0 for c in close]
+    low = [c - 1.0 for c in close]
+    vol = [1_000_000.0 for _ in close]
+    return OHLCV(close=close, high=high, low=low, volume=vol)
+
+
+def test_forecast_checks_emit_prequant_audit_fields() -> None:
+    series = _ohlcv_trend()
+    scores = compute_forecast_universe(
+        universe={"SPY": series, "XLK": series, "XLF": series},
+        spy=series,
+        horizons_trading_days=(1, 5),
+    )
+
+    check = scores["SPY"][1]["categories"]["A"]["checks"][0]
+
+    assert check["source_quality"] in {"real", "proxy", "neutral", "disabled"}
+    assert isinstance(check["fallback_used"], bool)
+    assert isinstance(check["raw_inputs"], dict)
+    assert "u" in check
+    assert check["u"] is None or isinstance(check["u"], (int, float))
+    assert isinstance(check["cutoffs"], dict)
+    assert isinstance(check["orientation"], str)
+    assert check["orientation"]
+    assert "margin_to_flip" in check
+
+
+def test_validate_forecast_scores_prints_symbol_horizon_audit(tmp_path: Path) -> None:
+    series = _ohlcv_trend()
+    scores = compute_forecast_universe(
+        universe={"SPY": series, "XLK": series, "XLF": series},
+        spy=series,
+        horizons_trading_days=(1, 5),
+    )
+
+    doc = {
+        "schema": "forecast_scores.v1",
+        "asof": "2026-05-02T00:00:00Z",
+        "horizons_trading_days": [1, 5],
+        "scores": scores,
+    }
+    p = tmp_path / "forecast_scores.v1.json"
+    p.write_text(json.dumps(doc), encoding="utf-8")
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(VALIDATOR),
+            "--path",
+            str(p),
+            "--audit-symbol",
+            "SPY",
+            "--audit-horizons",
+            "1,5",
+        ],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    assert "OK: forecast_scores.v1 valid" in proc.stdout
+    assert "forecast-audit symbol=SPY horizon=1" in proc.stdout
+    assert "forecast-audit symbol=SPY horizon=5" in proc.stdout
+    assert "source_quality=" in proc.stdout
+    assert "fallback_used=" in proc.stdout
+    assert "raw_inputs=" in proc.stdout
+    assert "margin_to_flip=" in proc.stdout


### PR DESCRIPTION
## Summary

Adds per-check forecast audit fields to generated forecast score payloads.

Each serialized forecast check now includes:

- source_quality
- fallback_used
- raw_inputs
- u
- cutoffs
- orientation
- margin_to_flip

Also adds a terminal audit mode to `scripts/validate_forecast_scores_v1.py` for inspecting one symbol across selected horizons.

No recommendation logic is changed.

## Testing

- `.venv-ci/bin/python -m pytest tests/test_forecast_prequant_audit_fields.py tests/test_forecast_checks_v1.py tests/test_horizon_required_payload_v1.py tests/test_validate_global_broad_market_forecasts.py tests/test_offline_compute_scores.py -q`
- `.venv-ci/bin/python -m pytest tests/test_golden_fixtures_v1.py tests/test_ui_contract_v1.py tests/test_ui_contract_required_fields_v1.py tests/test_horizon_required_payload_v1.py tests/test_forecast_prequant_audit_fields.py -q`
- `.venv-ci/bin/python -m py_compile market_health/forecast_types.py market_health/forecast_checks_c_crowding.py scripts/validate_forecast_scores_v1.py tests/test_forecast_prequant_audit_fields.py`
- `.venv-ci/bin/ruff format --check market_health/forecast_types.py market_health/forecast_checks_c_crowding.py scripts/validate_forecast_scores_v1.py tests/test_forecast_prequant_audit_fields.py`
- `.venv-ci/bin/ruff check market_health/forecast_types.py market_health/forecast_checks_c_crowding.py scripts/validate_forecast_scores_v1.py tests/test_forecast_prequant_audit_fields.py`