### PR TITLE
Make forecast source quality explicit

### DIFF
--- a/market_health/forecast_checks_a_announcements.py
+++ b/market_health/forecast_checks_a_announcements.py
@@ -27,6 +27,8 @@ def make_check(label, meaning, score, metrics):
         meaning=str(meaning),
         metrics=(metrics or {}),
         score=sc,
+        source_quality="proxy",
+        fallback_used=False,
     )
 
 
@@ -185,6 +187,8 @@ def a2_macro_calendar_pressure(
             "danger_rank_threshold": danger_rank,
             "warn_slope_threshold": warn_slope,
         },
+        source_quality="proxy",
+        fallback_used=False,
     )
 
 
@@ -241,6 +245,8 @@ def a3_earnings_cluster(
             "earnings_symbols_in_window": calendar.get("earnings_symbols_in_window"),
             "danger_count_threshold": danger_count,
         },
+        source_quality="proxy",
+        fallback_used=False,
     )
 
 
@@ -278,6 +284,8 @@ def a4_policy_reg_risk(
             "horizon_scale": h_scale,
             "policy_decision_in_window": policy_risk,
         },
+        source_quality="proxy",
+        fallback_used=False,
     )
 
 
@@ -327,6 +335,8 @@ def a5_headline_shock_proxy(
             "warn_atr_threshold": warn_atr,
             "danger_atr_threshold": danger_atr,
         },
+        source_quality="proxy",
+        fallback_used=False,
     )
 
 
@@ -378,4 +388,6 @@ def a6_narrative_momentum(
             "strong_reversal_max": strong_reversal_max,
             "ok_reversal_max": ok_reversal_max,
         },
+        source_quality="proxy",
+        fallback_used=False,
     )

--- a/market_health/forecast_checks_b_backdrop.py
+++ b/market_health/forecast_checks_b_backdrop.py
@@ -113,6 +113,8 @@ def b1_trend_persistence(
             "strong_slope_threshold": strong_slope,
             "ok_slope_threshold": ok_slope,
         },
+        source_quality="proxy",
+        fallback_used=False,
     )
 
 
@@ -162,6 +164,8 @@ def b2_follow_through_setup(
             "strong_clv_threshold": strong_clv,
             "ok_clv_threshold": ok_clv,
         },
+        source_quality="proxy",
+        fallback_used=False,
     )
 
 
@@ -204,6 +208,8 @@ def b3_rs_momentum(
             "ok_rs_threshold": ok_rs,
             "max_good_z_threshold": max_good_z,
         },
+        source_quality="proxy",
+        fallback_used=False,
     )
 
 
@@ -249,6 +255,8 @@ def b4_support_cushion(
             "strong_cushion_threshold": strong_cushion,
             "ok_cushion_threshold": ok_cushion,
         },
+        source_quality="proxy",
+        fallback_used=False,
     )
 
 
@@ -309,6 +317,8 @@ def b5_participation_trend(
             "ok_rs_threshold": ok_rs,
             "early_rs_floor_threshold": early_rs_floor,
         },
+        source_quality="proxy",
+        fallback_used=False,
     )
 
 
@@ -362,4 +372,6 @@ def b6_acceleration_vs_exhaustion(
             "ok_ext_max_threshold": ok_ext_max,
             "clean_vol_max_threshold": clean_vol_max,
         },
+        source_quality="proxy",
+        fallback_used=False,
     )

--- a/market_health/forecast_checks_c_crowding.py
+++ b/market_health/forecast_checks_c_crowding.py
@@ -82,6 +82,8 @@ def c1_extension_risk(*, horizon_days: int, ext_z_20: Optional[float]) -> Foreca
             "warn_z_threshold": warn_z,
             "danger_z_threshold": danger_z,
         },
+        source_quality="proxy",
+        fallback_used=False,
     )
 
 
@@ -129,6 +131,8 @@ def c2_volume_climax_risk(
             "danger_vol_threshold": danger_vol,
             "weak_clv_threshold": weak_clv,
         },
+        source_quality="proxy",
+        fallback_used=False,
     )
 
 
@@ -179,6 +183,8 @@ def c3_breadth_thinning(
             "warn_ratio_threshold": warn_ratio,
             "danger_ratio_threshold": danger_ratio,
         },
+        source_quality="proxy",
+        fallback_used=False,
     )
 
 
@@ -336,6 +342,8 @@ def c5_positioning_asymmetry(
             "warn_freq_threshold": warn_freq,
             "danger_freq_threshold": danger_freq,
         },
+        source_quality="proxy",
+        fallback_used=False,
     )
 
 
@@ -388,4 +396,6 @@ def c6_correlation_crowding(
             "thin_disp": thin_disp,
             "soft_thin_disp": soft_thin_disp,
         },
+        source_quality="proxy",
+        fallback_used=False,
     )

--- a/market_health/forecast_checks_d_danger.py
+++ b/market_health/forecast_checks_d_danger.py
@@ -208,6 +208,8 @@ def d1_volatility_trend(
             "iv_elevated": iv_elevated,
             "note": note,
         },
+        source_quality="proxy",
+        fallback_used=False,
     )
 
 
@@ -275,6 +277,8 @@ def d2_tail_gap_risk(
             "warn_atr_h_threshold": warn_atr_h,
             "danger_atr_h_threshold": danger_atr_h,
         },
+        source_quality="proxy",
+        fallback_used=False,
     )
 
 
@@ -326,6 +330,8 @@ def d3_market_coupling_trend(
             "warned": warned,
             "rising": rising,
         },
+        source_quality="proxy",
+        fallback_used=False,
     )
 
 
@@ -403,6 +409,8 @@ def d4_liquidity_stress(
             "danger_negative_share_threshold": danger_neg_share,
             "warn_negative_share_threshold": warn_neg_share,
         },
+        source_quality="proxy",
+        fallback_used=False,
     )
 
 
@@ -451,6 +459,8 @@ def d5_drawdown_vulnerability(
             "strong_room_threshold": strong_room,
             "ok_room_threshold": ok_room,
         },
+        source_quality="proxy",
+        fallback_used=False,
     )
 
 
@@ -508,4 +518,6 @@ def d6_risk_reward_feasibility(
             "warn_corr_threshold": warn_corr,
             "high_atr_threshold": high_atr,
         },
+        source_quality="proxy",
+        fallback_used=False,
     )

--- a/market_health/forecast_checks_e_environment.py
+++ b/market_health/forecast_checks_e_environment.py
@@ -102,6 +102,8 @@ def e1_spy_outlook(
             "soft_bull_threshold": soft_bull,
             "clear_bear_threshold": clear_bear,
         },
+        source_quality="proxy",
+        fallback_used=False,
     )
 
 
@@ -156,6 +158,8 @@ def e2_vix_outlook(
             "danger_rank_threshold": danger_rank,
             "flat_or_worse_slope_threshold": flat_or_worse_slope,
         },
+        source_quality="proxy",
+        fallback_used=False,
     )
 
 
@@ -243,6 +247,8 @@ def e3_leadership_persistence(
             "ok_span_threshold": ok_span,
             "good_avg_rank_threshold": good_avg_rank,
         },
+        source_quality="proxy",
+        fallback_used=False,
     )
 
 
@@ -281,6 +287,8 @@ def e4_breadth_regime(
             "strong_dispersion_threshold": strong_dispersion,
             "ok_dispersion_threshold": ok_dispersion,
         },
+        source_quality="proxy",
+        fallback_used=False,
     )
 
 
@@ -384,6 +392,8 @@ def e5_cross_regime_pressure(
             "regime": regime,
             "is_defensive": is_def,
         },
+        source_quality="proxy",
+        fallback_used=False,
     )
 
 
@@ -466,4 +476,6 @@ def e6_driver_alignment(
             "mild_negative_threshold": mild_neg,
             "deep_negative_threshold": deep_neg,
         },
+        source_quality="proxy",
+        fallback_used=False,
     )

--- a/tests/test_forecast_source_quality_explicit.py
+++ b/tests/test_forecast_source_quality_explicit.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+def test_direct_forecast_checks_have_explicit_source_quality_and_fallback() -> None:
+    missing: list[str] = []
+
+    for path in sorted(Path("market_health").glob("forecast_checks_*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+
+            name = ""
+            if isinstance(node.func, ast.Name):
+                name = node.func.id
+            elif isinstance(node.func, ast.Attribute):
+                name = node.func.attr
+
+            if name != "ForecastCheck":
+                continue
+
+            keys = {kw.arg for kw in node.keywords if kw.arg}
+            if "source_quality" not in keys or "fallback_used" not in keys:
+                missing.append(f"{path}:{node.lineno}")
+
+    assert missing == []
+
+
+def test_forecast_source_quality_values_are_known() -> None:
+    allowed = {"real", "proxy", "neutral", "disabled", "direct"}
+    bad: list[str] = []
+
+    for path in sorted(Path("market_health").glob("forecast_checks_*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+
+            name = ""
+            if isinstance(node.func, ast.Name):
+                name = node.func.id
+            elif isinstance(node.func, ast.Attribute):
+                name = node.func.attr
+
+            if name != "ForecastCheck":
+                continue
+
+            for kw in node.keywords:
+                if kw.arg != "source_quality":
+                    continue
+                if isinstance(kw.value, ast.Constant) and isinstance(
+                    kw.value.value, str
+                ):
+                    if kw.value.value not in allowed:
+                        bad.append(f"{path}:{node.lineno}:{kw.value.value}")
+                else:
+                    bad.append(f"{path}:{node.lineno}:non-literal")
+
+    assert bad == []


### PR DESCRIPTION
## Summary

Makes forecast check source classification explicit at construction time.

This removes silent reliance on the `ForecastCheck` default for non-neutral checks by adding explicit:

- `source_quality="proxy"`
- `fallback_used=False`

to direct `ForecastCheck(...)` calls across A–E forecast checks.

Existing neutral checks continue to use `neutral_check(...)`, and the flow-backed check remains explicitly `real`.

Also adds a regression test that fails if a direct forecast check omits `source_quality` or `fallback_used`.

No recommendation logic is changed.

## Testing

- `.venv-ci/bin/python -m pytest tests/test_forecast_source_quality_explicit.py tests/test_forecast_prequant_audit_fields.py tests/test_forecast_checks_v1.py tests/test_horizon_required_payload_v1.py -q`
- `.venv-ci/bin/python -m py_compile market_health/forecast_checks_a_announcements.py market_health/forecast_checks_b_backdrop.py market_health/forecast_checks_c_crowding.py market_health/forecast_checks_d_danger.py market_health/forecast_checks_e_environment.py tests/test_forecast_source_quality_explicit.py`
- `.venv-ci/bin/ruff format --check market_health/forecast_checks_a_announcements.py market_health/forecast_checks_b_backdrop.py market_health/forecast_checks_c_crowding.py market_health/forecast_checks_d_danger.py market_health/forecast_checks_e_environment.py tests/test_forecast_source_quality_explicit.py`
- `.venv-ci/bin/ruff check market_health/forecast_checks_a_announcements.py market_health/forecast_checks_b_backdrop.py market_health/forecast_checks_c_crowding.py market_health/forecast_checks_d_danger.py market_health/forecast_checks_e_environment.py tests/test_forecast_source_quality_explicit.py`