### PR TITLE
Add forecast upstream input inventory

### DIFF
--- a/market_health/forecast_input_inventory.py
+++ b/market_health/forecast_input_inventory.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+_FORECAST_INPUT_INVENTORY: list[dict[str, Any]] = [
+    {
+        "check": "A1",
+        "label": "Catalyst Window",
+        "dependency": "calendar/event provider",
+        "current_handling": "proxy intentionally",
+        "source_quality_when_missing": "proxy",
+        "missing_behavior": "uses deterministic fallback calendar context",
+    },
+    {
+        "check": "A2",
+        "label": "Macro Calendar Pressure",
+        "dependency": "VIX / volatility regime feed",
+        "current_handling": "neutral intentionally",
+        "source_quality_when_missing": "neutral",
+        "missing_behavior": "neutral_check when VIX features are unavailable",
+    },
+    {
+        "check": "A3",
+        "label": "Earnings Cluster",
+        "dependency": "earnings/calendar provider",
+        "current_handling": "proxy intentionally",
+        "source_quality_when_missing": "proxy",
+        "missing_behavior": "uses deterministic fallback calendar context",
+    },
+    {
+        "check": "A4",
+        "label": "Policy / Regulation Risk",
+        "dependency": "policy/calendar provider",
+        "current_handling": "proxy intentionally",
+        "source_quality_when_missing": "proxy",
+        "missing_behavior": "uses deterministic fallback calendar context",
+    },
+    {
+        "check": "A5",
+        "label": "Headline Shock Proxy",
+        "dependency": "news/headline feed",
+        "current_handling": "proxy intentionally",
+        "source_quality_when_missing": "proxy",
+        "missing_behavior": "uses ATR, Bollinger width, and extension proxies",
+    },
+    {
+        "check": "C4",
+        "label": "Flow Pressure",
+        "dependency": "flow.v1 provider cache",
+        "current_handling": "proxy intentionally",
+        "source_quality_when_missing": "proxy",
+        "missing_behavior": "uses volume proxy when flow.v1 is missing or incomplete",
+    },
+    {
+        "check": "D1",
+        "label": "Volatility Trend",
+        "dependency": "iv.v1 provider cache",
+        "current_handling": "proxy intentionally",
+        "source_quality_when_missing": "proxy",
+        "missing_behavior": "uses ATR/Bollinger proxies when symbol IV is missing",
+    },
+    {
+        "check": "E2",
+        "label": "VIX Outlook",
+        "dependency": "VIX / volatility regime feed",
+        "current_handling": "neutral intentionally",
+        "source_quality_when_missing": "neutral",
+        "missing_behavior": "neutral_check when VIX features are unavailable",
+    },
+    {
+        "check": "E5",
+        "label": "Cross-Regime Pressure",
+        "dependency": "defensive/cyclical universe regime context",
+        "current_handling": "neutral intentionally",
+        "source_quality_when_missing": "neutral",
+        "missing_behavior": "neutral_check when defensive/cyclical coverage is insufficient",
+    },
+    {
+        "check": "E6",
+        "label": "Driver Alignment",
+        "dependency": "VIX outlook and local RS context",
+        "current_handling": "proxy intentionally",
+        "source_quality_when_missing": "proxy",
+        "missing_behavior": "uses E2 score and local RS proxy",
+    },
+]
+
+
+def forecast_input_inventory() -> list[dict[str, Any]]:
+    return deepcopy(_FORECAST_INPUT_INVENTORY)
+
+
+def forecast_input_inventory_by_check() -> dict[str, dict[str, Any]]:
+    return {str(row["check"]): row for row in forecast_input_inventory()}

--- a/scripts/export_forecast_scores_v1.py
+++ b/scripts/export_forecast_scores_v1.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from market_health.forecast_features import OHLCV
+from market_health.forecast_input_inventory import forecast_input_inventory
 from market_health.forecast_score_provider import compute_forecast_universe
 from market_health.universe import INVERSE_SYMBOLS, get_default_scoring_symbols
 
@@ -539,6 +540,7 @@ def main() -> int:
             "sources": sources,
             "cache_dir": str(cache_dir),
             "symbols": len(scores),
+            "forecast_input_inventory": forecast_input_inventory(),
         },
     }
 

--- a/scripts/validate_forecast_scores_v1.py
+++ b/scripts/validate_forecast_scores_v1.py
@@ -7,6 +7,8 @@ import re as _re
 from pathlib import Path
 from typing import Any, Dict, List, Union
 
+from market_health.forecast_input_inventory import forecast_input_inventory
+
 
 def _err(errors: List[str], msg: str) -> None:
     errors.append(msg)
@@ -276,6 +278,11 @@ def main() -> int:
         default="",
         help="Comma-separated horizon pair/list for --audit-symbol, e.g. 1,5",
     )
+    ap.add_argument(
+        "--input-inventory",
+        action="store_true",
+        help="Print upstream forecast input inventory",
+    )
     args = ap.parse_args()
 
     p = Path(args.path)
@@ -302,6 +309,18 @@ def main() -> int:
         if not horizons:
             horizons = [1, 5]
         print_audit(doc, symbol=args.audit_symbol, horizons=horizons)
+
+    if args.input_inventory:
+        print("forecast-input-inventory")
+        for row in forecast_input_inventory():
+            print(
+                f" {row['check']} "
+                f"label={row['label']} "
+                f"dependency={row['dependency']} "
+                f"current_handling={row['current_handling']} "
+                f"source_quality_when_missing={row['source_quality_when_missing']} "
+                f"missing_behavior={row['missing_behavior']}"
+            )
 
     return 0
 

--- a/tests/test_forecast_input_inventory.py
+++ b/tests/test_forecast_input_inventory.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from market_health.forecast_features import OHLCV
+from market_health.forecast_input_inventory import forecast_input_inventory
+from market_health.forecast_score_provider import compute_forecast_universe
+
+
+VALIDATOR = Path("scripts/validate_forecast_scores_v1.py")
+
+
+def _series() -> OHLCV:
+    close = [100.0 + i * 0.25 for i in range(90)]
+    return OHLCV(
+        close=close,
+        high=[c + 1.0 for c in close],
+        low=[c - 1.0 for c in close],
+        volume=[1_000_000.0 for _ in close],
+    )
+
+
+def test_inventory_covers_known_upstream_dependencies() -> None:
+    rows = forecast_input_inventory()
+    by_check = {row["check"]: row for row in rows}
+
+    for check in ["A2", "C4", "D1", "E2", "E5", "E6"]:
+        assert check in by_check
+
+    allowed = {
+        "implement now",
+        "proxy intentionally",
+        "neutral intentionally",
+        "disable until available",
+    }
+
+    for row in rows:
+        assert row["current_handling"] in allowed
+        assert row["source_quality_when_missing"] in {
+            "real",
+            "proxy",
+            "neutral",
+            "disabled",
+        }
+        assert row["dependency"]
+        assert row["missing_behavior"]
+
+
+def test_validator_prints_input_inventory(tmp_path: Path) -> None:
+    series = _series()
+    scores = compute_forecast_universe(
+        universe={"SPY": series, "XLK": series, "XLF": series},
+        spy=series,
+        horizons_trading_days=(1, 5),
+    )
+    doc = {
+        "schema": "forecast_scores.v1",
+        "asof": "2026-05-02T00:00:00Z",
+        "horizons_trading_days": [1, 5],
+        "scores": scores,
+    }
+    p = tmp_path / "forecast_scores.v1.json"
+    p.write_text(json.dumps(doc), encoding="utf-8")
+
+    proc = subprocess.run(
+        [sys.executable, str(VALIDATOR), "--path", str(p), "--input-inventory"],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    assert "forecast-input-inventory" in proc.stdout
+    assert "A2" in proc.stdout
+    assert "C4" in proc.stdout
+    assert "D1" in proc.stdout
+    assert "VIX" in proc.stdout
+    assert "flow.v1" in proc.stdout
+    assert "iv.v1" in proc.stdout


### PR DESCRIPTION
## Summary

Adds a machine-readable upstream forecast input inventory for checks that depend on VIX, IV, flow, calendar/event, or regime-context inputs.

The inventory classifies missing dependency handling as:

- proxy intentionally
- neutral intentionally
- implement now
- disable until available

This is surfaced in two places:

- `forecast_scores.v1.json` under `inputs.forecast_input_inventory`
- `scripts/validate_forecast_scores_v1.py --input-inventory`

No recommendation logic is changed.

## Testing

- `.venv-ci/bin/python -m pytest tests/test_forecast_input_inventory.py tests/test_forecast_prequant_audit_fields.py tests/test_forecast_source_quality_explicit.py tests/test_forecast_checks_v1.py tests/test_m43_forecast_wrapper.py -q`
- `.venv-ci/bin/python -m py_compile market_health/forecast_input_inventory.py scripts/export_forecast_scores_v1.py scripts/validate_forecast_scores_v1.py tests/test_forecast_input_inventory.py`
- `.venv-ci/bin/ruff format --check market_health/forecast_input_inventory.py scripts/export_forecast_scores_v1.py scripts/validate_forecast_scores_v1.py tests/test_forecast_input_inventory.py`
- `.venv-ci/bin/ruff check market_health/forecast_input_inventory.py scripts/export_forecast_scores_v1.py scripts/validate_forecast_scores_v1.py tests/test_forecast_input_inventory.py`