### PR TITLE
Add forecast blend diagnostics

### DIFF
--- a/market_health/forecast_recommendations.py
+++ b/market_health/forecast_recommendations.py
@@ -71,6 +71,7 @@ def _component_snapshot(
     if not isinstance(meta, dict):
         return {}
     cur = meta.get("current_utility")
+    blend_diagnostic = meta.get("utility_blend_diagnostic")
     return {
         "c": cur,
         "current": cur,
@@ -78,6 +79,10 @@ def _component_snapshot(
         "h5": meta.get("h5_utility"),
         "blend": meta.get("utility"),
         "blended": meta.get("utility"),
+        "utility_weights": meta.get("utility_weights"),
+        "blend_diagnostic": blend_diagnostic
+        if isinstance(blend_diagnostic, dict)
+        else {},
     }
 
 

--- a/market_health/recommendations_engine.py
+++ b/market_health/recommendations_engine.py
@@ -167,6 +167,47 @@ def _forecast_utility(payload: Any, current_utility: Any = None) -> float | None
     return max(0.0, min(1.0, anchored))
 
 
+def _blend_utility_diagnostic(
+    *,
+    parts: Dict[str, Any],
+    weights: Dict[str, float],
+    blended: float,
+) -> Dict[str, Any]:
+    order = ("c", "h1", "h5")
+    present = {k: parts.get(k) for k in order if isinstance(parts.get(k), (int, float))}
+    denominator = sum(float(weights[k]) for k in present)
+
+    components: Dict[str, Dict[str, Any]] = {}
+    for key in order:
+        value = parts.get(key)
+        is_present = isinstance(value, (int, float))
+        base_weight = float(weights.get(key, 0.0))
+        effective_weight = (
+            base_weight / denominator if is_present and denominator > 0 else 0.0
+        )
+        numeric_value = float(value) if is_present else None
+        contribution = (
+            effective_weight * numeric_value if numeric_value is not None else 0.0
+        )
+        components[key] = {
+            "present": is_present,
+            "value": numeric_value,
+            "base_weight": base_weight,
+            "effective_weight": effective_weight,
+            "contribution": contribution,
+        }
+
+    return {
+        "formula": "blend=sum(effective_weight(component)*utility(component)) over present c,h1,h5 components",
+        "component_order": list(order),
+        "raw_weights": {k: float(weights.get(k, 0.0)) for k in order},
+        "present_components": [k for k in order if k in present],
+        "denominator": denominator,
+        "components": components,
+        "blended_utility": float(blended),
+    }
+
+
 def blended_utility_from_scores(
     rows: Iterable[Dict[str, Any]],
     *,
@@ -213,6 +254,11 @@ def blended_utility_from_scores(
                 "h1_utility": h1_util,
                 "h5_utility": h5_util,
                 "utility_weights": dict(weights),
+                "utility_blend_diagnostic": _blend_utility_diagnostic(
+                    parts=parts,
+                    weights=weights,
+                    blended=blended,
+                ),
             }
         )
     return out

--- a/tests/test_forecast_blend_diagnostics.py
+++ b/tests/test_forecast_blend_diagnostics.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from typing import Any
+
+from market_health.recommendations_engine import blended_utility_from_scores
+
+
+def _score_row(symbol: str, scores: list[int]) -> dict[str, Any]:
+    categories = {}
+    for code, score in zip(("A", "B", "C", "D", "E"), scores):
+        categories[code] = {"checks": [{"score": score}]}
+    return {"symbol": symbol, "categories": categories}
+
+
+def test_blend_diagnostic_explains_default_c_h1_h5_contributions() -> None:
+    rows = [_score_row("SPY", [2, 1, 1, 1, 1])]  # C/current utility = 6/10 = 0.60
+    forecast_scores = {
+        "SPY": {
+            1: {"forecast_score": 0.70},  # anchored H1 = 0.80
+            5: {"forecast_score": 0.40},  # anchored H5 = 0.50
+        }
+    }
+
+    out = blended_utility_from_scores(
+        rows,
+        forecast_scores=forecast_scores,
+        forecast_horizons=(1, 5),
+    )
+
+    meta = out["SPY"]
+    diag = meta["utility_blend_diagnostic"]
+    components = diag["components"]
+
+    assert round(meta["current_utility"], 6) == 0.6
+    assert round(meta["h1_utility"], 6) == 0.8
+    assert round(meta["h5_utility"], 6) == 0.5
+    assert round(meta["utility"], 6) == 0.625
+
+    assert diag["present_components"] == ["c", "h1", "h5"]
+    assert diag["raw_weights"] == {"c": 0.5, "h1": 0.25, "h5": 0.25}
+    assert round(components["c"]["contribution"], 6) == 0.3
+    assert round(components["h1"]["contribution"], 6) == 0.2
+    assert round(components["h5"]["contribution"], 6) == 0.125
+
+
+def test_blend_diagnostic_shows_missing_horizon_weight_renormalization() -> None:
+    rows = [_score_row("SPY", [2, 1, 1, 1, 1])]  # C/current utility = 0.60
+    forecast_scores = {
+        "SPY": {
+            1: {"forecast_score": 0.70},  # anchored H1 = 0.80
+        }
+    }
+
+    out = blended_utility_from_scores(
+        rows,
+        forecast_scores=forecast_scores,
+        forecast_horizons=(1, 5),
+    )
+
+    diag = out["SPY"]["utility_blend_diagnostic"]
+    components = diag["components"]
+
+    assert diag["present_components"] == ["c", "h1"]
+    assert round(diag["denominator"], 6) == 0.75
+    assert components["h5"]["present"] is False
+    assert components["h5"]["effective_weight"] == 0.0
+    assert round(components["c"]["effective_weight"], 6) == 0.666667
+    assert round(components["h1"]["effective_weight"], 6) == 0.333333
+    assert round(out["SPY"]["utility"], 6) == 0.666667
+
+
+def test_custom_utility_weights_are_normalized_and_explained() -> None:
+    rows = [_score_row("SPY", [2, 1, 1, 1, 1])]
+    forecast_scores = {
+        "SPY": {
+            1: {"forecast_score": 0.70},
+            5: {"forecast_score": 0.40},
+        }
+    }
+
+    out = blended_utility_from_scores(
+        rows,
+        forecast_scores=forecast_scores,
+        utility_weights={"c": 2, "h1": 1, "h5": 1},
+        forecast_horizons=(1, 5),
+    )
+
+    diag = out["SPY"]["utility_blend_diagnostic"]
+    assert diag["raw_weights"] == {"c": 0.5, "h1": 0.25, "h5": 0.25}
+    assert round(diag["blended_utility"], 6) == 0.625


### PR DESCRIPTION
## Summary

Adds diagnostics for the existing forecast blend math without changing recommendation logic or weights.

The blend diagnostic records:

- component order: C, H1, H5
- normalized raw weights
- present components
- denominator used for weight renormalization
- per-component value
- per-component base weight
- per-component effective weight
- per-component contribution
- final blended utility

This makes the current C/H1/H5 blend auditable and shows how missing horizon data renormalizes the remaining component weights.

No weight changes are included.

## Testing

- `.venv-ci/bin/python -m pytest tests/test_forecast_blend_diagnostics.py tests/test_forecast_recommendations_pm10.py tests/test_forecast_recommendations_pm11.py tests/test_forecast_recommendations_pm12.py tests/test_dashboard_etf_triscore_pm19.py -q`
- `.venv-ci/bin/python -m py_compile market_health/recommendations_engine.py market_health/forecast_recommendations.py tests/test_forecast_blend_diagnostics.py`
- `.venv-ci/bin/ruff format --check market_health/recommendations_engine.py market_health/forecast_recommendations.py tests/test_forecast_blend_diagnostics.py`
- `.venv-ci/bin/ruff check market_health/recommendations_engine.py market_health/forecast_recommendations.py tests/test_forecast_blend_diagnostics.py`