### PR TITLE
Add held forecast divergence alerts

### DIFF
--- a/market_health/alert_detectors.py
+++ b/market_health/alert_detectors.py
@@ -200,12 +200,77 @@ def _is_band_worse(previous: Optional[float], current: Optional[float]) -> bool:
     return _band_rank(_score_band(current)) < _band_rank(_score_band(previous))
 
 
+def detect_held_forecast_divergence(
+    *,
+    symbol: str,
+    current_score: Optional[float],
+    h1_score: Optional[float],
+    h5_score: Optional[float],
+    blend_score: Optional[float] = None,
+    threshold: float = 5.0,
+) -> List[AlertCandidate]:
+    """Detect held-position forecast divergence: C is stronger than H1/H5/blend."""
+
+    normalized_symbol = str(symbol).strip().upper()
+    if not normalized_symbol or current_score is None:
+        return []
+
+    current = float(current_score)
+    targets = {
+        "H1": h1_score,
+        "H5": h5_score,
+        "blend": blend_score,
+    }
+
+    alerts: List[AlertCandidate] = []
+    for rule, target in targets.items():
+        if target is None:
+            continue
+
+        target_score = float(target)
+        drop = current - target_score
+        if drop < float(threshold):
+            continue
+
+        label = rule.upper() if rule != "blend" else "blend"
+        alerts.append(
+            AlertCandidate(
+                alert_key=f"held_forecast_divergence:{normalized_symbol}:{rule}",
+                alert_type="held_forecast_divergence",
+                severity="warning",
+                symbol=normalized_symbol,
+                title=f"{normalized_symbol} forecast divergence: C > {label}",
+                message=(
+                    f"{normalized_symbol} current score is {drop:.1f} points "
+                    f"above {label}."
+                ),
+                payload={
+                    "symbol": normalized_symbol,
+                    "triggered_rule": f"C>{label}",
+                    "current_score": current,
+                    "c_score": current,
+                    "h1_score": float(h1_score) if h1_score is not None else None,
+                    "h5_score": float(h5_score) if h5_score is not None else None,
+                    "blend_score": float(blend_score)
+                    if blend_score is not None
+                    else None,
+                    "comparison_score": target_score,
+                    "drop": drop,
+                    "threshold": float(threshold),
+                },
+            )
+        )
+
+    return alerts
+
+
 def detect_forecast_warnings(
     *,
     symbol: str,
     current_score: Optional[float],
     h1_score: Optional[float],
     h5_score: Optional[float],
+    blend_score: Optional[float] = None,
     previous_h1_score: Optional[float] = None,
     previous_h5_score: Optional[float] = None,
     current_drop_threshold: float = 5.0,
@@ -218,6 +283,16 @@ def detect_forecast_warnings(
         return []
 
     alerts: List[AlertCandidate] = []
+    alerts.extend(
+        detect_held_forecast_divergence(
+            symbol=normalized_symbol,
+            current_score=current_score,
+            h1_score=h1_score,
+            h5_score=h5_score,
+            blend_score=blend_score,
+            threshold=current_drop_threshold,
+        )
+    )
 
     horizon_values = {
         "H1": h1_score,
@@ -229,31 +304,6 @@ def detect_forecast_warnings(
     }
 
     for horizon, forecast_score in horizon_values.items():
-        if current_score is not None and forecast_score is not None:
-            drop = float(current_score) - float(forecast_score)
-            if drop >= current_drop_threshold:
-                alerts.append(
-                    AlertCandidate(
-                        alert_key=f"forecast_warning:{normalized_symbol}:{horizon}:below_current",
-                        alert_type="forecast_below_current",
-                        severity="warning",
-                        symbol=normalized_symbol,
-                        title=f"{normalized_symbol} {horizon} forecast below current score",
-                        message=(
-                            f"{normalized_symbol} {horizon} forecast is {drop:.1f} points "
-                            "below the current score."
-                        ),
-                        payload={
-                            "symbol": normalized_symbol,
-                            "horizon": horizon,
-                            "current_score": float(current_score),
-                            "forecast_score": float(forecast_score),
-                            "drop": drop,
-                            "threshold": float(current_drop_threshold),
-                        },
-                    )
-                )
-
         previous_score = previous_values[horizon]
         if previous_score is not None and forecast_score is not None:
             weakening = float(previous_score) - float(forecast_score)

--- a/market_health/alert_runner.py
+++ b/market_health/alert_runner.py
@@ -168,6 +168,7 @@ def _detect_alerts(
                 current_score=snapshot.current_score,
                 h1_score=snapshot.h1_score,
                 h5_score=snapshot.h5_score,
+                blend_score=getattr(snapshot, "blend_score", None),
                 previous_h1_score=prev.get("h1_score"),  # type: ignore[arg-type]
                 previous_h5_score=prev.get("h5_score"),  # type: ignore[arg-type]
                 current_drop_threshold=current_drop_threshold,

--- a/tests/test_alert_detectors.py
+++ b/tests/test_alert_detectors.py
@@ -193,10 +193,10 @@ def test_forecast_warning_detects_h1_and_h5_below_current() -> None:
     )
 
     assert [a.alert_type for a in alerts] == [
-        "forecast_below_current",
-        "forecast_below_current",
+        "held_forecast_divergence",
+        "held_forecast_divergence",
     ]
-    assert [a.payload["horizon"] for a in alerts] == ["H1", "H5"]
+    assert [a.payload["triggered_rule"] for a in alerts] == ["C>H1", "C>H5"]
     assert alerts[0].symbol == "SPY"
     assert alerts[0].payload["drop"] == 6.0
     assert alerts[1].payload["drop"] == 12.0
@@ -213,7 +213,7 @@ def test_forecast_warning_current_drop_threshold_is_configurable() -> None:
         current_drop_threshold=4,
     )
 
-    assert [a.payload["horizon"] for a in alerts] == ["H1", "H5"]
+    assert [a.payload["triggered_rule"] for a in alerts] == ["C>H1", "C>H5"]
 
 
 def test_forecast_warning_detects_previous_snapshot_weakening() -> None:
@@ -294,3 +294,38 @@ def test_forecast_warning_ignores_missing_scores_and_blank_symbol() -> None:
         )
         == []
     )
+
+
+def test_held_forecast_divergence_detects_blend_independently() -> None:
+    from market_health.alert_detectors import detect_held_forecast_divergence
+
+    alerts = detect_held_forecast_divergence(
+        symbol="SPY",
+        current_score=72,
+        h1_score=71,
+        h5_score=70,
+        blend_score=66,
+    )
+
+    assert len(alerts) == 1
+    assert alerts[0].alert_type == "held_forecast_divergence"
+    assert alerts[0].alert_key == "held_forecast_divergence:SPY:blend"
+    assert alerts[0].payload["triggered_rule"] == "C>blend"
+    assert alerts[0].payload["c_score"] == 72.0
+    assert alerts[0].payload["blend_score"] == 66.0
+    assert alerts[0].payload["threshold"] == 5.0
+
+
+def test_held_forecast_divergence_no_alert_when_below_threshold() -> None:
+    from market_health.alert_detectors import detect_held_forecast_divergence
+
+    alerts = detect_held_forecast_divergence(
+        symbol="SPY",
+        current_score=72,
+        h1_score=68,
+        h5_score=67.1,
+        blend_score=69,
+        threshold=5,
+    )
+
+    assert alerts == []

--- a/tests/test_alert_runner.py
+++ b/tests/test_alert_runner.py
@@ -8,7 +8,12 @@ from market_health.alert_store import count_rows
 
 
 def _write_ui(
-    path: Path, *, state: str = "clean", h1: float = 69.0, h5: float = 68.0
+    path: Path,
+    *,
+    state: str = "clean",
+    h1: float = 69.0,
+    h5: float = 68.0,
+    blend: float = 70.0,
 ) -> None:
     doc = {
         "schema": "jerboa.market_health.ui.v1",
@@ -22,7 +27,7 @@ def _write_ui(
                 {
                     "symbol": "SPY",
                     "C": 72.0,
-                    "Blend": 70.0,
+                    "Blend": blend,
                     "H1": h1,
                     "H5": h5,
                     "State": state,
@@ -107,7 +112,9 @@ def test_runner_detects_and_records_state_alert_on_second_run(tmp_path: Path) ->
     assert rows[0][2] == "dry-run"
 
 
-def test_runner_records_forecast_alert_and_suppresses_duplicate(tmp_path: Path) -> None:
+def test_runner_records_forecast_divergence_alert_and_suppresses_duplicate(
+    tmp_path: Path,
+) -> None:
     db = tmp_path / "alerts.sqlite"
     ui = tmp_path / "market_health.ui.v1.json"
 
@@ -129,7 +136,7 @@ def test_runner_records_forecast_alert_and_suppresses_duplicate(tmp_path: Path) 
     assert result2.suppressed_count == 1
     rows = _alert_rows(db)
     assert len(rows) == 1
-    assert rows[0][1] == "forecast_below_current"
+    assert rows[0][1] == "held_forecast_divergence"
 
 
 def test_runner_refresh_failure_returns_exit_code_2(tmp_path: Path) -> None:
@@ -205,3 +212,25 @@ def test_runner_main_supports_no_refresh_fixture_mode(tmp_path: Path) -> None:
     assert code == 0
     assert count_rows(db, "runs") == 1
     assert count_rows(db, "symbol_snapshots") == 1
+
+
+def test_runner_records_blend_divergence_alert(tmp_path: Path) -> None:
+    db = tmp_path / "alerts.sqlite"
+    ui = tmp_path / "market_health.ui.v1.json"
+
+    _write_ui(ui, state="clean", h1=71, h5=70, blend=66)
+    result = run_once_alert_service(
+        AlertRunnerConfig(
+            db_path=db,
+            ui_path=ui,
+            telegram_mode="dry-run",
+            no_refresh=True,
+        ),
+        now_utc="2026-05-01T15:00:00Z",
+    )
+
+    assert result.allowed_count == 1
+    rows = _alert_rows(db)
+    assert len(rows) == 1
+    assert rows[0][0] == "held_forecast_divergence:SPY:blend"
+    assert rows[0][1] == "held_forecast_divergence"


### PR DESCRIPTION
## Summary

Adds held-position forecast divergence alerts for cases where the current score is stronger than forecasted or blended scores.

For each held position, the detector now independently checks:

- C > H1 by configured margin
- C > H5 by configured margin
- C > blend by configured margin

Alert payloads include symbol, C, H1, H5, blend, threshold, drop, comparison score, and triggered rule.

This wires blend-score divergence into the alert runner and keeps cooldown behavior based on stable alert keys.

No recommendation logic is changed.

## Testing

- `.venv-ci/bin/python -m pytest tests/test_alert_detectors.py tests/test_alert_runner.py tests/test_alert_cooldowns.py tests/test_alert_snapshots.py tests/test_alert_store.py tests/test_telegram_notifier.py -q`
- `.venv-ci/bin/python -m py_compile market_health/alert_detectors.py market_health/alert_runner.py tests/test_alert_detectors.py tests/test_alert_runner.py`
- `.venv-ci/bin/ruff format --check market_health/alert_detectors.py market_health/alert_runner.py tests/test_alert_detectors.py tests/test_alert_runner.py`
- `.venv-ci/bin/ruff check market_health/alert_detectors.py market_health/alert_runner.py tests/test_alert_detectors.py tests/test_alert_runner.py`