### PR TITLE
Add held unhealthy floor alerts

### DIFF
--- a/market_health/alert_detectors.py
+++ b/market_health/alert_detectors.py
@@ -264,6 +264,75 @@ def detect_held_forecast_divergence(
     return alerts
 
 
+def _as_float_score(value: Optional[float]) -> Optional[float]:
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def detect_held_unhealthy_floor(
+    *,
+    symbol: str,
+    current_score: Optional[float],
+    h1_score: Optional[float],
+    h5_score: Optional[float],
+    blend_score: Optional[float] = None,
+    healthy_floor: float = 55.0,
+) -> List[AlertCandidate]:
+    """Detect held-position scores below the configured healthy floor."""
+
+    normalized_symbol = str(symbol).strip().upper()
+    if not normalized_symbol:
+        return []
+
+    floor = float(healthy_floor)
+    values = {
+        "C": _as_float_score(current_score),
+        "H1": _as_float_score(h1_score),
+        "H5": _as_float_score(h5_score),
+        "blend": _as_float_score(blend_score),
+    }
+    breached = [
+        field
+        for field, score in values.items()
+        if score is not None and float(score) < floor
+    ]
+
+    if not breached:
+        return []
+
+    key_suffix = "-".join(field.lower() for field in breached)
+    breach_text = ", ".join(
+        f"{field}={values[field]:.1f}"
+        for field in breached
+        if values[field] is not None
+    )
+
+    return [
+        AlertCandidate(
+            alert_key=f"held_unhealthy_floor:{normalized_symbol}:{key_suffix}",
+            alert_type="held_unhealthy_floor",
+            severity="warning",
+            symbol=normalized_symbol,
+            title=f"{normalized_symbol} below healthy floor",
+            message=(
+                f"{normalized_symbol} has held-position score fields below "
+                f"the healthy floor {floor:.1f}: {breach_text}."
+            ),
+            payload={
+                "symbol": normalized_symbol,
+                "current_score": values["C"],
+                "c_score": values["C"],
+                "h1_score": values["H1"],
+                "h5_score": values["H5"],
+                "blend_score": values["blend"],
+                "healthy_floor": floor,
+                "breached_fields": breached,
+            },
+        )
+    ]
+
+
 def detect_forecast_warnings(
     *,
     symbol: str,
@@ -271,6 +340,7 @@ def detect_forecast_warnings(
     h1_score: Optional[float],
     h5_score: Optional[float],
     blend_score: Optional[float] = None,
+    healthy_score_floor: float = 55.0,
     previous_h1_score: Optional[float] = None,
     previous_h5_score: Optional[float] = None,
     current_drop_threshold: float = 5.0,
@@ -291,6 +361,16 @@ def detect_forecast_warnings(
             h5_score=h5_score,
             blend_score=blend_score,
             threshold=current_drop_threshold,
+        )
+    )
+    alerts.extend(
+        detect_held_unhealthy_floor(
+            symbol=normalized_symbol,
+            current_score=current_score,
+            h1_score=h1_score,
+            h5_score=h5_score,
+            blend_score=blend_score,
+            healthy_floor=healthy_score_floor,
         )
     )
 

--- a/market_health/alert_runner.py
+++ b/market_health/alert_runner.py
@@ -52,6 +52,7 @@ class AlertRunnerConfig:
     git_commit: Optional[str] = None
     current_drop_threshold: float = 5.0
     previous_drop_threshold: float = 7.0
+    healthy_score_floor: float = 55.0
 
 
 @dataclass(frozen=True)
@@ -141,6 +142,7 @@ def _detect_alerts(
     current_snapshots: Sequence[HeldPositionSnapshot],
     current_drop_threshold: float,
     previous_drop_threshold: float,
+    healthy_score_floor: float,
 ) -> List[AlertCandidate]:
     current_symbols = [snapshot.symbol for snapshot in current_snapshots]
 
@@ -169,6 +171,7 @@ def _detect_alerts(
                 h1_score=snapshot.h1_score,
                 h5_score=snapshot.h5_score,
                 blend_score=getattr(snapshot, "blend_score", None),
+                healthy_score_floor=healthy_score_floor,
                 previous_h1_score=prev.get("h1_score"),  # type: ignore[arg-type]
                 previous_h5_score=prev.get("h5_score"),  # type: ignore[arg-type]
                 current_drop_threshold=current_drop_threshold,
@@ -242,6 +245,7 @@ def run_once_alert_service(
             current_snapshots=current_snapshots,
             current_drop_threshold=config.current_drop_threshold,
             previous_drop_threshold=config.previous_drop_threshold,
+            healthy_score_floor=config.healthy_score_floor,
         )
         history = read_alert_history_from_store(db_path=config.db_path)
         allowed, suppressed = apply_alert_cooldowns(
@@ -339,6 +343,13 @@ def build_arg_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--trigger-name", default="manual")
     parser.add_argument("--git-commit", default=None)
+    parser.add_argument(
+        "--healthy-score-floor",
+        type=float,
+        default=55.0,
+        help="Held-position healthy score floor for C/H1/H5/blend alerts.",
+    )
+
     return parser
 
 

--- a/tests/test_alert_detectors.py
+++ b/tests/test_alert_detectors.py
@@ -329,3 +329,43 @@ def test_held_forecast_divergence_no_alert_when_below_threshold() -> None:
     )
 
     assert alerts == []
+
+
+def test_held_unhealthy_floor_detects_rising_but_unhealthy_scores() -> None:
+    from market_health.alert_detectors import detect_held_unhealthy_floor
+
+    alerts = detect_held_unhealthy_floor(
+        symbol="SPY",
+        current_score=42,
+        h1_score=47,
+        h5_score=51,
+        blend_score=49,
+        healthy_floor=55,
+    )
+
+    assert len(alerts) == 1
+    alert = alerts[0]
+    assert alert.alert_type == "held_unhealthy_floor"
+    assert alert.alert_key == "held_unhealthy_floor:SPY:c-h1-h5-blend"
+    assert alert.payload["symbol"] == "SPY"
+    assert alert.payload["c_score"] == 42.0
+    assert alert.payload["h1_score"] == 47.0
+    assert alert.payload["h5_score"] == 51.0
+    assert alert.payload["blend_score"] == 49.0
+    assert alert.payload["healthy_floor"] == 55.0
+    assert alert.payload["breached_fields"] == ["C", "H1", "H5", "blend"]
+
+
+def test_held_unhealthy_floor_no_alert_when_all_scores_are_healthy() -> None:
+    from market_health.alert_detectors import detect_held_unhealthy_floor
+
+    alerts = detect_held_unhealthy_floor(
+        symbol="SPY",
+        current_score=56,
+        h1_score=57,
+        h5_score=58,
+        blend_score=59,
+        healthy_floor=55,
+    )
+
+    assert alerts == []

--- a/tests/test_alert_runner.py
+++ b/tests/test_alert_runner.py
@@ -11,6 +11,7 @@ def _write_ui(
     path: Path,
     *,
     state: str = "clean",
+    c: float = 72.0,
     h1: float = 69.0,
     h5: float = 68.0,
     blend: float = 70.0,
@@ -26,7 +27,7 @@ def _write_ui(
             "sectors": [
                 {
                     "symbol": "SPY",
-                    "C": 72.0,
+                    "C": c,
                     "Blend": blend,
                     "H1": h1,
                     "H5": h5,
@@ -234,3 +235,26 @@ def test_runner_records_blend_divergence_alert(tmp_path: Path) -> None:
     assert len(rows) == 1
     assert rows[0][0] == "held_forecast_divergence:SPY:blend"
     assert rows[0][1] == "held_forecast_divergence"
+
+
+def test_runner_records_unhealthy_floor_alert(tmp_path: Path) -> None:
+    db = tmp_path / "alerts.sqlite"
+    ui = tmp_path / "market_health.ui.v1.json"
+
+    _write_ui(ui, state="clean", c=56, h1=54, h5=56, blend=56)
+    result = run_once_alert_service(
+        AlertRunnerConfig(
+            db_path=db,
+            ui_path=ui,
+            telegram_mode="dry-run",
+            no_refresh=True,
+            healthy_score_floor=55,
+        ),
+        now_utc="2026-05-01T15:00:00Z",
+    )
+
+    assert result.allowed_count == 1
+    rows = _alert_rows(db)
+    assert len(rows) == 1
+    assert rows[0][0] == "held_unhealthy_floor:SPY:h1"
+    assert rows[0][1] == "held_unhealthy_floor"


### PR DESCRIPTION
## Summary

Adds held-position unhealthy floor alerts for cases where any held-position score field falls below the configured healthy floor.

The detector checks these fields independently:

- C
- H1
- H5
- blend

This catches the important edge case where a position is improving but still unhealthy, such as C < H1 < H5 while all values remain below the healthy floor.

Alert payloads include symbol, C, H1, H5, blend, healthy floor, and breached fields.

The alert runner now passes a configurable healthy score floor into forecast warning detection.

No recommendation logic is changed.

## Testing

- `.venv-ci/bin/python -m pytest tests/test_alert_detectors.py tests/test_alert_runner.py tests/test_alert_cooldowns.py tests/test_alert_snapshots.py tests/test_alert_store.py tests/test_telegram_notifier.py -q`
- `.venv-ci/bin/python -m py_compile market_health/alert_detectors.py market_health/alert_runner.py tests/test_alert_detectors.py tests/test_alert_runner.py`
- `.venv-ci/bin/ruff format --check market_health/alert_detectors.py market_health/alert_runner.py tests/test_alert_detectors.py tests/test_alert_runner.py`
- `.venv-ci/bin/ruff check market_health/alert_detectors.py market_health/alert_runner.py tests/test_alert_detectors.py tests/test_alert_runner.py`