### PR TITLE
Add held band and state degradation alerts

### DIFF
--- a/market_health/alert_detectors.py
+++ b/market_health/alert_detectors.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, Iterable, List, Optional, Set
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Set
 
 
 @dataclass(frozen=True)
@@ -328,6 +328,159 @@ def detect_held_unhealthy_floor(
                 "blend_score": values["blend"],
                 "healthy_floor": floor,
                 "breached_fields": breached,
+            },
+        )
+    ]
+
+
+def _state_label(value: Optional[str]) -> str:
+    tokens = _normalize_state_tokens(value)
+    return ",".join(sorted(tokens)) or "clean"
+
+
+def _state_degradation_rank(value: Optional[str]) -> int:
+    tokens = _normalize_state_tokens(value)
+    if not tokens:
+        return 0
+
+    unhealthy = {
+        "BRK",
+        "BROKEN",
+        "DAMAGE",
+        "DAMAGED",
+        "DMG",
+        "FAIL",
+        "FAILED",
+        "RED",
+        "UNHEALTHY",
+    }
+    caution = {
+        "CAUTION",
+        "RCL",
+        "RISK",
+        "WATCH",
+        "WARN",
+        "WARNING",
+        "YELLOW",
+        "OH",
+    }
+    clean = {"GREEN", "HEALTHY", "HOLD"}
+
+    rank = 0
+    for token in tokens:
+        if token in unhealthy:
+            rank = max(rank, 2)
+        elif token in caution:
+            rank = max(rank, 1)
+        elif token in clean:
+            rank = max(rank, 0)
+        else:
+            rank = max(rank, 1)
+    return rank
+
+
+def _score_value(values: Mapping[str, Any], field: str) -> Optional[float]:
+    aliases = {
+        "C": ("C", "c", "current", "current_score", "score"),
+        "H1": ("H1", "h1", "h1_score"),
+        "H5": ("H5", "h5", "h5_score"),
+        "blend": ("blend", "Blend", "blended", "blend_score"),
+    }
+    for key in aliases[field]:
+        if key in values:
+            return _as_float_score(values[key])
+    return None
+
+
+def _score_values_payload(values: Mapping[str, Any]) -> Dict[str, Optional[float]]:
+    c = _score_value(values, "C")
+    return {
+        "current_score": c,
+        "c_score": c,
+        "h1_score": _score_value(values, "H1"),
+        "h5_score": _score_value(values, "H5"),
+        "blend_score": _score_value(values, "blend"),
+    }
+
+
+def _score_bands_payload(values: Mapping[str, Any]) -> Dict[str, str]:
+    return {
+        "C": _score_band(_score_value(values, "C")),
+        "H1": _score_band(_score_value(values, "H1")),
+        "H5": _score_band(_score_value(values, "H5")),
+        "blend": _score_band(_score_value(values, "blend")),
+    }
+
+
+def detect_held_band_state_degradation(
+    *,
+    symbol: str,
+    previous_state: Optional[str],
+    current_state: Optional[str],
+    previous_values: Mapping[str, Any],
+    current_values: Mapping[str, Any],
+) -> List[AlertCandidate]:
+    """Detect held-position score-band or state degradation between snapshots."""
+
+    normalized_symbol = str(symbol).strip().upper()
+    if not normalized_symbol:
+        return []
+
+    previous_state_label = _state_label(previous_state)
+    current_state_label = _state_label(current_state)
+
+    reasons: List[str] = []
+    degraded_fields: List[str] = []
+
+    previous_state_rank = _state_degradation_rank(previous_state)
+    current_state_rank = _state_degradation_rank(current_state)
+    state_degraded = current_state_rank > previous_state_rank
+    if state_degraded:
+        reasons.append(f"state {previous_state_label}->{current_state_label}")
+
+    for score_field in ("C", "H1", "H5", "blend"):
+        previous_score = _score_value(previous_values, score_field)
+        current_score = _score_value(current_values, score_field)
+        if previous_score is None or current_score is None:
+            continue
+
+        previous_band = _score_band(previous_score)
+        current_band = _score_band(current_score)
+        if _band_rank(current_band) < _band_rank(previous_band):
+            degraded_fields.append(score_field)
+            reasons.append(f"{score_field} band {previous_band}->{current_band}")
+
+    if not reasons:
+        return []
+
+    reason_parts = []
+    if state_degraded:
+        reason_parts.append("state")
+    reason_parts.extend(field.lower() for field in degraded_fields)
+    reason_key = "-".join(reason_parts)
+
+    return [
+        AlertCandidate(
+            alert_key=f"held_band_state_degradation:{normalized_symbol}:{reason_key}",
+            alert_type="held_band_state_degraded",
+            severity="warning",
+            symbol=normalized_symbol,
+            title=f"{normalized_symbol} held state/score degraded",
+            message=f"{normalized_symbol} held position degraded: {'; '.join(reasons)}.",
+            payload={
+                "symbol": normalized_symbol,
+                "previous_state": previous_state_label,
+                "current_state": current_state_label,
+                "previous_values": _score_values_payload(previous_values),
+                "current_values": _score_values_payload(current_values),
+                "previous_bands": _score_bands_payload(previous_values),
+                "current_bands": _score_bands_payload(current_values),
+                "previous_state_rank": previous_state_rank,
+                "current_state_rank": current_state_rank,
+                "state_degraded": state_degraded,
+                "degraded_fields": degraded_fields,
+                "reason": "; ".join(reasons),
+                "reasons": reasons,
             },
         )
     ]

--- a/market_health/alert_runner.py
+++ b/market_health/alert_runner.py
@@ -14,8 +14,8 @@ from market_health.alert_cooldowns import (
 from market_health.alert_detectors import (
     AlertCandidate,
     detect_forecast_warnings,
+    detect_held_band_state_degradation,
     detect_position_inventory_changes,
-    detect_position_state_changes,
 )
 from market_health.alert_snapshots import (
     HeldPositionSnapshot,
@@ -92,7 +92,7 @@ def _read_previous_snapshots(
 
         rows = conn.execute(
             """
-            SELECT symbol, state, current_score, h1_score, h5_score
+            SELECT symbol, state, current_score, blend_score, h1_score, h5_score
             FROM symbol_snapshots
             WHERE run_id = ? AND is_held = 1
             ORDER BY symbol
@@ -153,17 +153,29 @@ def _detect_alerts(
             current_symbols=current_symbols,
         )
     )
-    candidates.extend(
-        detect_position_state_changes(
-            previous_states={
-                symbol: row.get("state") for symbol, row in previous.items()
-            },
-            current_states=_snapshot_states(current_snapshots),
-        )
-    )
-
     for snapshot in current_snapshots:
         prev = previous.get(snapshot.symbol, {})
+        if prev:
+            candidates.extend(
+                detect_held_band_state_degradation(
+                    symbol=snapshot.symbol,
+                    previous_state=prev.get("state"),  # type: ignore[arg-type]
+                    current_state=snapshot.state,
+                    previous_values={
+                        "C": prev.get("current_score"),
+                        "H1": prev.get("h1_score"),
+                        "H5": prev.get("h5_score"),
+                        "blend": prev.get("blend_score"),
+                    },
+                    current_values={
+                        "C": snapshot.current_score,
+                        "H1": snapshot.h1_score,
+                        "H5": snapshot.h5_score,
+                        "blend": snapshot.blend_score,
+                    },
+                )
+            )
+
         candidates.extend(
             detect_forecast_warnings(
                 symbol=snapshot.symbol,
@@ -364,6 +376,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         refresh_cmd=tuple(shlex.split(args.refresh_cmd)),
         trigger_name=args.trigger_name,
         git_commit=args.git_commit,
+        healthy_score_floor=args.healthy_score_floor,
     )
     result = run_once_alert_service(config)
     return result.exit_code

--- a/tests/test_alert_detectors.py
+++ b/tests/test_alert_detectors.py
@@ -369,3 +369,76 @@ def test_held_unhealthy_floor_no_alert_when_all_scores_are_healthy() -> None:
     )
 
     assert alerts == []
+
+
+def test_held_band_state_degradation_detects_one_step_score_worsening() -> None:
+    from market_health.alert_detectors import detect_held_band_state_degradation
+
+    alerts = detect_held_band_state_degradation(
+        symbol="SPY",
+        previous_state="clean",
+        current_state="clean",
+        previous_values={"C": 72, "H1": 66, "H5": 70, "blend": 71},
+        current_values={"C": 68, "H1": 66, "H5": 70, "blend": 71},
+    )
+
+    assert len(alerts) == 1
+    alert = alerts[0]
+    assert alert.alert_type == "held_band_state_degraded"
+    assert alert.alert_key == "held_band_state_degradation:SPY:c"
+    assert alert.payload["previous_bands"]["C"] == "green"
+    assert alert.payload["current_bands"]["C"] == "yellow"
+    assert alert.payload["degraded_fields"] == ["C"]
+    assert alert.payload["state_degraded"] is False
+    assert "C band green->yellow" in alert.payload["reason"]
+
+
+def test_held_band_state_degradation_detects_severe_state_and_score_worsening() -> None:
+    from market_health.alert_detectors import detect_held_band_state_degradation
+
+    alerts = detect_held_band_state_degradation(
+        symbol="SPY",
+        previous_state="hold",
+        current_state="unhealthy",
+        previous_values={"C": 72, "H1": 70, "H5": 69, "blend": 71},
+        current_values={"C": 54, "H1": 50, "H5": 52, "blend": 53},
+    )
+
+    assert len(alerts) == 1
+    alert = alerts[0]
+    assert alert.severity == "warning"
+    assert alert.payload["previous_state"] == "HOLD"
+    assert alert.payload["current_state"] == "UNHEALTHY"
+    assert alert.payload["state_degraded"] is True
+    assert alert.payload["degraded_fields"] == ["C", "H1", "H5", "blend"]
+    assert alert.payload["previous_values"]["c_score"] == 72.0
+    assert alert.payload["current_values"]["c_score"] == 54.0
+    assert "state HOLD->UNHEALTHY" in alert.payload["reason"]
+
+
+def test_held_band_state_degradation_no_alert_when_unchanged() -> None:
+    from market_health.alert_detectors import detect_held_band_state_degradation
+
+    alerts = detect_held_band_state_degradation(
+        symbol="SPY",
+        previous_state="caution",
+        current_state="caution",
+        previous_values={"C": 68, "H1": 61, "H5": 59, "blend": 63},
+        current_values={"C": 66, "H1": 60, "H5": 58, "blend": 62},
+    )
+
+    assert alerts == []
+
+
+def test_held_band_state_degradation_no_alert_when_improving() -> None:
+    from market_health.alert_detectors import detect_held_band_state_degradation
+
+    alerts = detect_held_band_state_degradation(
+        symbol="SPY",
+        previous_state="unhealthy",
+        current_state="clean",
+        previous_values={"C": 54, "H1": 50, "H5": 52, "blend": 53},
+        current_values={"C": 68, "H1": 60, "H5": 59, "blend": 62},
+    )
+
+    assert alerts == []

--- a/tests/test_alert_runner.py
+++ b/tests/test_alert_runner.py
@@ -109,7 +109,7 @@ def test_runner_detects_and_records_state_alert_on_second_run(tmp_path: Path) ->
     assert result.allowed_count == 1
     rows = _alert_rows(db)
     assert len(rows) == 1
-    assert rows[0][1] == "position_state_changed"
+    assert rows[0][1] == "held_band_state_degraded"
     assert rows[0][2] == "dry-run"
 
 
@@ -190,7 +190,7 @@ def test_runner_uses_injected_telegram_sender_in_test_mode(tmp_path: Path) -> No
     assert result.allowed_count == 1
     sender.assert_called_once()
     data = sender.call_args.args[1]
-    assert data["text"].startswith("TEST: SPY state changed")
+    assert data["text"].startswith("TEST: SPY held state/score degraded")
 
 
 def test_runner_main_supports_no_refresh_fixture_mode(tmp_path: Path) -> None:
@@ -258,3 +258,69 @@ def test_runner_records_unhealthy_floor_alert(tmp_path: Path) -> None:
     assert len(rows) == 1
     assert rows[0][0] == "held_unhealthy_floor:SPY:h1"
     assert rows[0][1] == "held_unhealthy_floor"
+
+
+def test_runner_records_score_band_degradation_alert(tmp_path: Path) -> None:
+    db = tmp_path / "alerts.sqlite"
+    ui = tmp_path / "market_health.ui.v1.json"
+
+    _write_ui(ui, state="clean", c=72, h1=69, h5=68, blend=70)
+    run_once_alert_service(
+        AlertRunnerConfig(
+            db_path=db,
+            ui_path=ui,
+            telegram_mode="dry-run",
+            no_refresh=True,
+        ),
+        now_utc="2026-05-01T15:00:00Z",
+    )
+
+    _write_ui(ui, state="clean", c=68, h1=69, h5=68, blend=70)
+    result = run_once_alert_service(
+        AlertRunnerConfig(
+            db_path=db,
+            ui_path=ui,
+            telegram_mode="dry-run",
+            no_refresh=True,
+        ),
+        now_utc="2026-05-01T15:15:00Z",
+    )
+
+    assert result.allowed_count == 1
+    rows = _alert_rows(db)
+    assert len(rows) == 1
+    assert rows[0][0] == "held_band_state_degradation:SPY:c"
+    assert rows[0][1] == "held_band_state_degraded"
+
+
+def test_runner_does_not_alert_on_score_band_improvement(tmp_path: Path) -> None:
+    db = tmp_path / "alerts.sqlite"
+    ui = tmp_path / "market_health.ui.v1.json"
+
+    _write_ui(ui, state="DMG", c=54, h1=56, h5=56, blend=56)
+    run_once_alert_service(
+        AlertRunnerConfig(
+            db_path=db,
+            ui_path=ui,
+            telegram_mode="dry-run",
+            no_refresh=True,
+            healthy_score_floor=40,
+        ),
+        now_utc="2026-05-01T15:00:00Z",
+    )
+
+    _write_ui(ui, state="clean", c=68, h1=68, h5=68, blend=68)
+    result = run_once_alert_service(
+        AlertRunnerConfig(
+            db_path=db,
+            ui_path=ui,
+            telegram_mode="dry-run",
+            no_refresh=True,
+            healthy_score_floor=40,
+        ),
+        now_utc="2026-05-01T15:15:00Z",
+    )
+
+    assert result.allowed_count == 0
+    rows = _alert_rows(db)
+    assert rows == []


### PR DESCRIPTION
## Summary

Adds held-position band and state degradation alerts.

The detector compares previous and current held-position snapshots and alerts only on worsening transitions, including:

- score band degradation across C, H1, H5, and blend
- state degradation such as clean -> caution, caution -> unhealthy, or clean -> damaged

Improving and unchanged transitions do not alert.

Alert payloads include symbol, previous state, current state, previous values, current values, previous bands, current bands, degraded fields, and reasons.

No recommendation logic is changed.

## Testing

- `.venv-ci/bin/python -m pytest tests/test_alert_detectors.py tests/test_alert_runner.py tests/test_alert_cooldowns.py tests/test_alert_snapshots.py tests/test_alert_store.py tests/test_telegram_notifier.py -q`
- `.venv-ci/bin/python -m py_compile market_health/alert_detectors.py market_health/alert_runner.py tests/test_alert_detectors.py tests/test_alert_runner.py`
- `.venv-ci/bin/ruff format --check market_health/alert_detectors.py market_health/alert_runner.py tests/test_alert_detectors.py tests/test_alert_runner.py`
- `.venv-ci/bin/ruff check market_health/alert_detectors.py market_health/alert_runner.py tests/test_alert_detectors.py tests/test_alert_runner.py`