### PR TITLE
Add held significant score drop alerts

### DIFF
--- a/market_health/alert_detectors.py
+++ b/market_health/alert_detectors.py
@@ -486,6 +486,62 @@ def detect_held_band_state_degradation(
     ]
 
 
+def detect_held_significant_score_drop(
+    *,
+    symbol: str,
+    previous_values: Mapping[str, Any],
+    current_values: Mapping[str, Any],
+    threshold: float = 7.0,
+) -> List[AlertCandidate]:
+    """Detect material held-position score drops between snapshots."""
+
+    normalized_symbol = str(symbol).strip().upper()
+    if not normalized_symbol:
+        return []
+
+    drops: Dict[str, float] = {}
+    affected_fields: List[str] = []
+
+    for score_field in ("C", "H1", "H5", "blend"):
+        previous_score = _score_value(previous_values, score_field)
+        current_score = _score_value(current_values, score_field)
+        if previous_score is None or current_score is None:
+            continue
+
+        drop = float(previous_score) - float(current_score)
+        if drop >= float(threshold):
+            affected_fields.append(score_field)
+            drops[score_field] = drop
+
+    if not affected_fields:
+        return []
+
+    key_suffix = "-".join(field.lower() for field in affected_fields)
+    drop_text = ", ".join(f"{field} -{drops[field]:.1f}" for field in affected_fields)
+
+    return [
+        AlertCandidate(
+            alert_key=f"held_significant_score_drop:{normalized_symbol}:{key_suffix}",
+            alert_type="held_significant_score_drop",
+            severity="warning",
+            symbol=normalized_symbol,
+            title=f"{normalized_symbol} significant held score drop",
+            message=(
+                f"{normalized_symbol} held-position score dropped materially: "
+                f"{drop_text}."
+            ),
+            payload={
+                "symbol": normalized_symbol,
+                "previous_values": _score_values_payload(previous_values),
+                "current_values": _score_values_payload(current_values),
+                "drops": drops,
+                "threshold": float(threshold),
+                "affected_fields": affected_fields,
+            },
+        )
+    ]
+
+
 def detect_forecast_warnings(
     *,
     symbol: str,

--- a/market_health/alert_runner.py
+++ b/market_health/alert_runner.py
@@ -15,6 +15,7 @@ from market_health.alert_detectors import (
     AlertCandidate,
     detect_forecast_warnings,
     detect_held_band_state_degradation,
+    detect_held_significant_score_drop,
     detect_position_inventory_changes,
 )
 from market_health.alert_snapshots import (
@@ -52,6 +53,7 @@ class AlertRunnerConfig:
     git_commit: Optional[str] = None
     current_drop_threshold: float = 5.0
     previous_drop_threshold: float = 7.0
+    score_drop_threshold: float = 7.0
     healthy_score_floor: float = 55.0
 
 
@@ -142,6 +144,7 @@ def _detect_alerts(
     current_snapshots: Sequence[HeldPositionSnapshot],
     current_drop_threshold: float,
     previous_drop_threshold: float,
+    score_drop_threshold: float,
     healthy_score_floor: float,
 ) -> List[AlertCandidate]:
     current_symbols = [snapshot.symbol for snapshot in current_snapshots]
@@ -156,23 +159,34 @@ def _detect_alerts(
     for snapshot in current_snapshots:
         prev = previous.get(snapshot.symbol, {})
         if prev:
+            previous_values = {
+                "C": prev.get("current_score"),
+                "H1": prev.get("h1_score"),
+                "H5": prev.get("h5_score"),
+                "blend": prev.get("blend_score"),
+            }
+            current_values = {
+                "C": snapshot.current_score,
+                "H1": snapshot.h1_score,
+                "H5": snapshot.h5_score,
+                "blend": snapshot.blend_score,
+            }
+
             candidates.extend(
                 detect_held_band_state_degradation(
                     symbol=snapshot.symbol,
                     previous_state=prev.get("state"),  # type: ignore[arg-type]
                     current_state=snapshot.state,
-                    previous_values={
-                        "C": prev.get("current_score"),
-                        "H1": prev.get("h1_score"),
-                        "H5": prev.get("h5_score"),
-                        "blend": prev.get("blend_score"),
-                    },
-                    current_values={
-                        "C": snapshot.current_score,
-                        "H1": snapshot.h1_score,
-                        "H5": snapshot.h5_score,
-                        "blend": snapshot.blend_score,
-                    },
+                    previous_values=previous_values,
+                    current_values=current_values,
+                )
+            )
+            candidates.extend(
+                detect_held_significant_score_drop(
+                    symbol=snapshot.symbol,
+                    previous_values=previous_values,
+                    current_values=current_values,
+                    threshold=score_drop_threshold,
                 )
             )
 
@@ -257,6 +271,7 @@ def run_once_alert_service(
             current_snapshots=current_snapshots,
             current_drop_threshold=config.current_drop_threshold,
             previous_drop_threshold=config.previous_drop_threshold,
+            score_drop_threshold=config.score_drop_threshold,
             healthy_score_floor=config.healthy_score_floor,
         )
         history = read_alert_history_from_store(db_path=config.db_path)
@@ -361,6 +376,12 @@ def build_arg_parser() -> argparse.ArgumentParser:
         default=55.0,
         help="Held-position healthy score floor for C/H1/H5/blend alerts.",
     )
+    parser.add_argument(
+        "--score-drop-threshold",
+        type=float,
+        default=7.0,
+        help="Material held-position score-drop threshold for C/H1/H5/blend.",
+    )
 
     return parser
 
@@ -376,6 +397,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         refresh_cmd=tuple(shlex.split(args.refresh_cmd)),
         trigger_name=args.trigger_name,
         git_commit=args.git_commit,
+        score_drop_threshold=args.score_drop_threshold,
         healthy_score_floor=args.healthy_score_floor,
     )
     result = run_once_alert_service(config)

--- a/tests/test_alert_detectors.py
+++ b/tests/test_alert_detectors.py
@@ -442,3 +442,82 @@ def test_held_band_state_degradation_no_alert_when_improving() -> None:
     )
 
     assert alerts == []
+
+
+def test_held_significant_score_drop_detects_c_drop() -> None:
+    from market_health.alert_detectors import detect_held_significant_score_drop
+
+    alerts = detect_held_significant_score_drop(
+        symbol="SPY",
+        previous_values={"C": 92, "H1": 90, "H5": 88, "blend": 89},
+        current_values={"C": 82, "H1": 90, "H5": 88, "blend": 89},
+        threshold=7,
+    )
+
+    assert len(alerts) == 1
+    alert = alerts[0]
+    assert alert.alert_type == "held_significant_score_drop"
+    assert alert.alert_key == "held_significant_score_drop:SPY:c"
+    assert alert.payload["affected_fields"] == ["C"]
+    assert alert.payload["drops"]["C"] == 10.0
+    assert alert.payload["previous_values"]["c_score"] == 92.0
+    assert alert.payload["current_values"]["c_score"] == 82.0
+    assert alert.payload["threshold"] == 7.0
+
+
+def test_held_significant_score_drop_detects_h1_drop() -> None:
+    from market_health.alert_detectors import detect_held_significant_score_drop
+
+    alerts = detect_held_significant_score_drop(
+        symbol="SPY",
+        previous_values={"C": 82, "H1": 90, "H5": 88, "blend": 89},
+        current_values={"C": 82, "H1": 78, "H5": 88, "blend": 89},
+        threshold=7,
+    )
+
+    assert len(alerts) == 1
+    assert alerts[0].payload["affected_fields"] == ["H1"]
+    assert alerts[0].payload["drops"]["H1"] == 12.0
+
+
+def test_held_significant_score_drop_detects_h5_drop() -> None:
+    from market_health.alert_detectors import detect_held_significant_score_drop
+
+    alerts = detect_held_significant_score_drop(
+        symbol="SPY",
+        previous_values={"C": 82, "H1": 90, "H5": 88, "blend": 89},
+        current_values={"C": 82, "H1": 90, "H5": 76, "blend": 89},
+        threshold=7,
+    )
+
+    assert len(alerts) == 1
+    assert alerts[0].payload["affected_fields"] == ["H5"]
+    assert alerts[0].payload["drops"]["H5"] == 12.0
+
+
+def test_held_significant_score_drop_detects_blend_drop() -> None:
+    from market_health.alert_detectors import detect_held_significant_score_drop
+
+    alerts = detect_held_significant_score_drop(
+        symbol="SPY",
+        previous_values={"C": 82, "H1": 90, "H5": 88, "blend": 89},
+        current_values={"C": 82, "H1": 90, "H5": 88, "blend": 80},
+        threshold=7,
+    )
+
+    assert len(alerts) == 1
+    assert alerts[0].payload["affected_fields"] == ["blend"]
+    assert alerts[0].payload["drops"]["blend"] == 9.0
+
+
+def test_held_significant_score_drop_no_alert_below_threshold() -> None:
+    from market_health.alert_detectors import detect_held_significant_score_drop
+
+    alerts = detect_held_significant_score_drop(
+        symbol="SPY",
+        previous_values={"C": 92, "H1": 90, "H5": 88, "blend": 89},
+        current_values={"C": 86, "H1": 84, "H5": 82, "blend": 83},
+        threshold=7,
+    )
+
+    assert alerts == []

--- a/tests/test_alert_runner.py
+++ b/tests/test_alert_runner.py
@@ -324,3 +324,40 @@ def test_runner_does_not_alert_on_score_band_improvement(tmp_path: Path) -> None
     assert result.allowed_count == 0
     rows = _alert_rows(db)
     assert rows == []
+
+
+def test_runner_records_significant_score_drop_alert_without_band_change(
+    tmp_path: Path,
+) -> None:
+    db = tmp_path / "alerts.sqlite"
+    ui = tmp_path / "market_health.ui.v1.json"
+
+    _write_ui(ui, state="clean", c=84, h1=84, h5=84, blend=84)
+    run_once_alert_service(
+        AlertRunnerConfig(
+            db_path=db,
+            ui_path=ui,
+            telegram_mode="dry-run",
+            no_refresh=True,
+            score_drop_threshold=7,
+        ),
+        now_utc="2026-05-01T15:00:00Z",
+    )
+
+    _write_ui(ui, state="clean", c=76, h1=84, h5=84, blend=84)
+    result = run_once_alert_service(
+        AlertRunnerConfig(
+            db_path=db,
+            ui_path=ui,
+            telegram_mode="dry-run",
+            no_refresh=True,
+            score_drop_threshold=7,
+        ),
+        now_utc="2026-05-01T15:15:00Z",
+    )
+
+    assert result.allowed_count == 1
+    rows = _alert_rows(db)
+    assert len(rows) == 1
+    assert rows[0][0] == "held_significant_score_drop:SPY:c"
+    assert rows[0][1] == "held_significant_score_drop"


### PR DESCRIPTION
## Summary

Adds held-position significant score-drop alerts.

The detector compares previous and current held-position values for:

- C
- H1
- H5
- blend

This catches material deterioration even when the score remains in the same band, such as green -> green but with a large drop.

Alert payloads include symbol, previous values, current values, drop sizes, threshold, and affected fields.

The alert runner now accepts a configurable score-drop threshold.

No recommendation logic is changed.

## Testing

- `.venv-ci/bin/python -m pytest tests/test_alert_detectors.py tests/test_alert_runner.py tests/test_alert_cooldowns.py tests/test_alert_snapshots.py tests/test_alert_store.py tests/test_telegram_notifier.py -q`
- `.venv-ci/bin/python -m py_compile market_health/alert_detectors.py market_health/alert_runner.py tests/test_alert_detectors.py tests/test_alert_runner.py`
- `.venv-ci/bin/ruff format --check market_health/alert_detectors.py market_health/alert_runner.py tests/test_alert_detectors.py tests/test_alert_runner.py`
- `.venv-ci/bin/ruff check market_health/alert_detectors.py market_health/alert_runner.py tests/test_alert_detectors.py tests/test_alert_runner.py`