### PR TITLE
Format held forecast risk Telegram alerts

### DIFF
--- a/market_health/telegram_notifier.py
+++ b/market_health/telegram_notifier.py
@@ -73,12 +73,151 @@ def _default_sender(url: str, data: Mapping[str, str], timeout: int) -> Any:
     return requests.post(url, data=dict(data), timeout=timeout)
 
 
+def _fmt_score(value: Any) -> str:
+    if isinstance(value, (int, float)):
+        return f"{float(value):.1f}"
+    return "n/a"
+
+
+def _fmt_threshold(value: Any) -> str:
+    if isinstance(value, (int, float)):
+        return f"{float(value):.1f}"
+    return "n/a"
+
+
+def _score_line(payload: Mapping[str, Any]) -> str:
+    return (
+        "Scores: "
+        f"C={_fmt_score(payload.get('c_score', payload.get('current_score')))} | "
+        f"H1={_fmt_score(payload.get('h1_score'))} | "
+        f"H5={_fmt_score(payload.get('h5_score'))} | "
+        f"blend={_fmt_score(payload.get('blend_score'))}"
+    )
+
+
+def _score_values_line(label: str, values: Mapping[str, Any]) -> str:
+    return (
+        f"{label}: "
+        f"C={_fmt_score(values.get('c_score', values.get('current_score')))} | "
+        f"H1={_fmt_score(values.get('h1_score'))} | "
+        f"H5={_fmt_score(values.get('h5_score'))} | "
+        f"blend={_fmt_score(values.get('blend_score'))}"
+    )
+
+
+def _safe_join(values: Any) -> str:
+    if isinstance(values, list):
+        return ", ".join(str(v) for v in values if str(v).strip()) or "n/a"
+    return str(values) if values is not None else "n/a"
+
+
+def _format_held_forecast_divergence(candidate: AlertCandidate, *, prefix: str) -> str:
+    payload = candidate.payload
+    return "\n".join(
+        [
+            f"{prefix}{candidate.title}",
+            f"Severity: {candidate.severity}",
+            f"Rule: {payload.get('triggered_rule', 'C>forecast')}",
+            _score_line(payload),
+            (
+                f"Drop: {_fmt_score(payload.get('drop'))} "
+                f"points; threshold={_fmt_threshold(payload.get('threshold'))}"
+            ),
+            f"Reason: {candidate.message}",
+        ]
+    )
+
+
+def _format_held_unhealthy_floor(candidate: AlertCandidate, *, prefix: str) -> str:
+    payload = candidate.payload
+    return "\n".join(
+        [
+            f"{prefix}{candidate.title}",
+            f"Severity: {candidate.severity}",
+            "Rule: below healthy floor",
+            _score_line(payload),
+            f"Healthy floor: {_fmt_threshold(payload.get('healthy_floor'))}",
+            f"Breached: {_safe_join(payload.get('breached_fields'))}",
+            f"Reason: {candidate.message}",
+        ]
+    )
+
+
+def _format_held_band_state_degraded(candidate: AlertCandidate, *, prefix: str) -> str:
+    payload = candidate.payload
+    previous_values = payload.get("previous_values")
+    current_values = payload.get("current_values")
+    previous_values = previous_values if isinstance(previous_values, Mapping) else {}
+    current_values = current_values if isinstance(current_values, Mapping) else {}
+
+    return "\n".join(
+        [
+            f"{prefix}{candidate.title}",
+            f"Severity: {candidate.severity}",
+            "Rule: held state/score degradation",
+            (
+                f"State: {payload.get('previous_state', 'n/a')} -> "
+                f"{payload.get('current_state', 'n/a')}"
+            ),
+            _score_values_line("Previous", previous_values),
+            _score_values_line("Current", current_values),
+            f"Degraded fields: {_safe_join(payload.get('degraded_fields'))}",
+            f"Reason: {payload.get('reason') or candidate.message}",
+        ]
+    )
+
+
+def _format_held_significant_score_drop(
+    candidate: AlertCandidate, *, prefix: str
+) -> str:
+    payload = candidate.payload
+    previous_values = payload.get("previous_values")
+    current_values = payload.get("current_values")
+    previous_values = previous_values if isinstance(previous_values, Mapping) else {}
+    current_values = current_values if isinstance(current_values, Mapping) else {}
+    drops = payload.get("drops")
+    drops = drops if isinstance(drops, Mapping) else {}
+    affected = payload.get("affected_fields")
+
+    drop_text = ", ".join(
+        f"{field} -{_fmt_score(drops.get(field))}"
+        for field in affected
+        if isinstance(affected, list)
+    )
+
+    return "\n".join(
+        [
+            f"{prefix}{candidate.title}",
+            f"Severity: {candidate.severity}",
+            "Rule: significant score drop",
+            _score_values_line("Previous", previous_values),
+            _score_values_line("Current", current_values),
+            f"Drops: {drop_text or 'n/a'}",
+            f"Threshold: {_fmt_threshold(payload.get('threshold'))}",
+            f"Affected: {_safe_join(affected)}",
+        ]
+    )
+
+
 def format_alert_message(
     candidate: AlertCandidate,
     *,
     test_prefix: bool = False,
 ) -> str:
     prefix = "TEST: " if test_prefix else ""
+
+    if candidate.alert_type == "held_forecast_divergence":
+        return _format_held_forecast_divergence(candidate, prefix=prefix)
+
+    if candidate.alert_type == "held_unhealthy_floor":
+        return _format_held_unhealthy_floor(candidate, prefix=prefix)
+
+    if candidate.alert_type == "held_band_state_degraded":
+        return _format_held_band_state_degraded(candidate, prefix=prefix)
+
+    if candidate.alert_type == "held_significant_score_drop":
+        return _format_held_significant_score_drop(candidate, prefix=prefix)
+
     parts = [
         f"{prefix}{candidate.title}",
         candidate.message,

--- a/tests/test_telegram_notifier.py
+++ b/tests/test_telegram_notifier.py
@@ -234,3 +234,143 @@ def test_send_and_record_alert_candidate_records_send_error(tmp_path: Path) -> N
     conn.close()
 
     assert row == ("error", "network down")
+
+
+def test_format_held_forecast_divergence_message_is_actionable() -> None:
+    candidate = AlertCandidate(
+        alert_key="held_forecast_divergence:SPY:H1",
+        alert_type="held_forecast_divergence",
+        severity="warning",
+        symbol="SPY",
+        title="SPY forecast divergence: C > H1",
+        message="SPY current score is 6.0 points above H1.",
+        payload={
+            "symbol": "SPY",
+            "triggered_rule": "C>H1",
+            "c_score": 72.0,
+            "h1_score": 66.0,
+            "h5_score": 60.0,
+            "blend_score": 68.0,
+            "drop": 6.0,
+            "threshold": 5.0,
+        },
+    )
+
+    text = format_alert_message(candidate, test_prefix=True)
+
+    assert text.startswith("TEST: SPY forecast divergence: C > H1")
+    assert "Severity: warning" in text
+    assert "Rule: C>H1" in text
+    assert "Scores: C=72.0 | H1=66.0 | H5=60.0 | blend=68.0" in text
+    assert "Drop: 6.0 points; threshold=5.0" in text
+    assert "/root" not in text
+
+
+def test_format_held_unhealthy_floor_message_is_actionable() -> None:
+    candidate = AlertCandidate(
+        alert_key="held_unhealthy_floor:SPY:h1",
+        alert_type="held_unhealthy_floor",
+        severity="warning",
+        symbol="SPY",
+        title="SPY below healthy floor",
+        message="SPY has held-position score fields below the healthy floor 55.0: H1=54.0.",
+        payload={
+            "symbol": "SPY",
+            "c_score": 56.0,
+            "h1_score": 54.0,
+            "h5_score": 56.0,
+            "blend_score": 56.0,
+            "healthy_floor": 55.0,
+            "breached_fields": ["H1"],
+        },
+    )
+
+    text = format_alert_message(candidate)
+
+    assert text.startswith("SPY below healthy floor")
+    assert "Rule: below healthy floor" in text
+    assert "Scores: C=56.0 | H1=54.0 | H5=56.0 | blend=56.0" in text
+    assert "Healthy floor: 55.0" in text
+    assert "Breached: H1" in text
+    assert "/root" not in text
+
+
+def test_format_held_band_state_degraded_message_is_actionable() -> None:
+    candidate = AlertCandidate(
+        alert_key="held_band_state_degradation:SPY:state-c",
+        alert_type="held_band_state_degraded",
+        severity="warning",
+        symbol="SPY",
+        title="SPY held state/score degraded",
+        message="SPY held position degraded.",
+        payload={
+            "symbol": "SPY",
+            "previous_state": "HOLD",
+            "current_state": "UNHEALTHY",
+            "previous_values": {
+                "c_score": 72.0,
+                "h1_score": 70.0,
+                "h5_score": 69.0,
+                "blend_score": 71.0,
+            },
+            "current_values": {
+                "c_score": 54.0,
+                "h1_score": 50.0,
+                "h5_score": 52.0,
+                "blend_score": 53.0,
+            },
+            "degraded_fields": ["C", "H1", "H5", "blend"],
+            "reason": "state HOLD->UNHEALTHY; C band green->red",
+        },
+    )
+
+    text = format_alert_message(candidate, test_prefix=True)
+
+    assert text.startswith("TEST: SPY held state/score degraded")
+    assert "Rule: held state/score degradation" in text
+    assert "State: HOLD -> UNHEALTHY" in text
+    assert "Previous: C=72.0 | H1=70.0 | H5=69.0 | blend=71.0" in text
+    assert "Current: C=54.0 | H1=50.0 | H5=52.0 | blend=53.0" in text
+    assert "Degraded fields: C, H1, H5, blend" in text
+    assert "Reason: state HOLD->UNHEALTHY; C band green->red" in text
+    assert "/root" not in text
+
+
+def test_format_held_significant_score_drop_message_is_actionable() -> None:
+    candidate = AlertCandidate(
+        alert_key="held_significant_score_drop:SPY:c",
+        alert_type="held_significant_score_drop",
+        severity="warning",
+        symbol="SPY",
+        title="SPY significant held score drop",
+        message="SPY held-position score dropped materially: C -8.0.",
+        payload={
+            "symbol": "SPY",
+            "previous_values": {
+                "c_score": 84.0,
+                "h1_score": 84.0,
+                "h5_score": 84.0,
+                "blend_score": 84.0,
+            },
+            "current_values": {
+                "c_score": 76.0,
+                "h1_score": 84.0,
+                "h5_score": 84.0,
+                "blend_score": 84.0,
+            },
+            "drops": {"C": 8.0},
+            "threshold": 7.0,
+            "affected_fields": ["C"],
+        },
+    )
+
+    text = format_alert_message(candidate)
+
+    assert text.startswith("SPY significant held score drop")
+    assert "Rule: significant score drop" in text
+    assert "Previous: C=84.0 | H1=84.0 | H5=84.0 | blend=84.0" in text
+    assert "Current: C=76.0 | H1=84.0 | H5=84.0 | blend=84.0" in text
+    assert "Drops: C -8.0" in text
+    assert "Threshold: 7.0" in text
+    assert "Affected: C" in text
+    assert "/root" not in text


### PR DESCRIPTION
## Summary

Adds readable, actionable Telegram formatting for held forecast-risk alerts.

Formatted alert families now include:

- held forecast divergence
- held unhealthy floor
- held band/state degradation
- held significant score drop

Messages include symbol, severity, triggered rule, C/H1/H5/blend values, previous values when relevant, thresholds, and short reasons.

Dry-run/test mode continues to store the rendered Telegram text in SQLite. Live sender behavior remains mocked in tests.

No recommendation logic is changed.

## Testing

- `.venv-ci/bin/python -m pytest tests/test_telegram_notifier.py tests/test_alert_runner.py tests/test_alert_detectors.py tests/test_alert_cooldowns.py tests/test_alert_snapshots.py tests/test_alert_store.py -q`
- `.venv-ci/bin/python -m py_compile market_health/telegram_notifier.py tests/test_telegram_notifier.py tests/test_alert_runner.py`
- `.venv-ci/bin/ruff format --check market_health/telegram_notifier.py tests/test_telegram_notifier.py tests/test_alert_runner.py`
- `.venv-ci/bin/ruff check market_health/telegram_notifier.py tests/test_telegram_notifier.py tests/test_alert_runner.py`