### PR TITLE
Align rolling correlation on trailing overlap

### DIFF
--- a/market_health/forecast_features.py
+++ b/market_health/forecast_features.py
@@ -375,7 +375,15 @@ def rolling_correlation(
 ) -> List[Optional[float]]:
     if window <= 1:
         raise ValueError("window must be >= 2")
-    _require_same_length(x, y)
+
+    # Live vendor data can occasionally return one symbol with a missing or
+    # extra bar versus SPY. Correlation is a risk feature, not a hard dashboard
+    # dependency, so align on trailing overlap instead of crashing.
+    if len(x) != len(y):
+        n0 = min(len(x), len(y))
+        x = list(x)[-n0:]
+        y = list(y)[-n0:]
+
     xx = [None if v is None else float(v) for v in x]
     yy = [None if v is None else float(v) for v in y]
     n = len(xx)

--- a/tests/test_forecast_features_rolling_correlation.py
+++ b/tests/test_forecast_features_rolling_correlation.py
@@ -1,0 +1,25 @@
+from market_health.forecast_features import rolling_correlation
+
+
+def test_rolling_correlation_aligns_trailing_overlap_when_left_series_is_longer() -> (
+    None
+):
+    got = rolling_correlation([99.0, 1.0, 2.0, 3.0, 4.0], [1.0, 2.0, 3.0, 4.0], 3)
+
+    assert len(got) == 4
+    assert got[0] is None
+    assert got[1] is None
+    assert round(got[2] or 0.0, 6) == 1.0
+    assert round(got[3] or 0.0, 6) == 1.0
+
+
+def test_rolling_correlation_aligns_trailing_overlap_when_right_series_is_longer() -> (
+    None
+):
+    got = rolling_correlation([1.0, 2.0, 3.0, 4.0], [99.0, 1.0, 2.0, 3.0, 4.0], 3)
+
+    assert len(got) == 4
+    assert got[0] is None
+    assert got[1] is None
+    assert round(got[2] or 0.0, 6) == 1.0
+    assert round(got[3] or 0.0, 6) == 1.0


### PR DESCRIPTION
## Summary

Prevents forecast backfill from crashing when live vendor data returns one return series with a missing or extra bar versus the benchmark series.

Rolling correlation now aligns both inputs on their trailing overlap before computing the windowed correlation.

## Testing

- `.venv-ci/bin/python -m pytest tests/test_forecast_features_rolling_correlation.py -q`
- `.venv-ci/bin/python -m py_compile market_health/forecast_features.py tests/test_forecast_features_rolling_correlation.py`
- `.venv-ci/bin/ruff format --check market_health/forecast_features.py tests/test_forecast_features_rolling_correlation.py`
- `.venv-ci/bin/ruff check market_health/forecast_features.py tests/test_forecast_features_rolling_correlation.py`
- `mh_dev`