### PR TITLE
Add GlyphSpec v1 codec

### DIFF
--- a/market_health/glyph_spec.py
+++ b/market_health/glyph_spec.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import itertools
+import re
+import zlib
+from dataclasses import dataclass
+from typing import Iterable, Mapping, Sequence
+
+GLYPH_SPEC_VERSION = "GlyphSpec v1"
+
+CATEGORY_KEYS = ("A", "B", "C", "D", "E")
+BASE13_DIGITS = "0123456789ABC"
+
+PATTERN_TO_GLYPH: dict[str, str] = {
+    "000": "0",
+    "111": "1",
+    "222": "2",
+    "100": "c",
+    "200": "C",
+    "010": "h",
+    "020": "H",
+    "001": "w",
+    "002": "W",
+    "110": "n",
+    "220": "N",
+    "101": "u",
+    "202": "U",
+    "011": "f",
+    "022": "F",
+    "012": ">",
+    "210": "<",
+    "102": "r",
+    "201": "d",
+    "021": "p",
+    "120": "s",
+    "112": "/",
+    "221": "\\",
+    "121": "^",
+    "212": "V",
+    "122": "+",
+    "211": "-",
+}
+
+GLYPH_TO_PATTERN: dict[str, str] = {
+    glyph: pattern for pattern, glyph in PATTERN_TO_GLYPH.items()
+}
+
+_CATEGORY_TOKEN_RE = re.compile(r"^([A-E])=([0-9ABC]{3}):(.{6})$")
+
+
+@dataclass(frozen=True)
+class CategoryTokenValidation:
+    category: str | None
+    token: str
+    valid: bool
+    totals: tuple[int, int, int] | None = None
+    decoded_totals: tuple[int, int, int] | None = None
+    fingerprint: str | None = None
+    patterns: tuple[str, ...] = ()
+    error: str | None = None
+
+
+def _normalize_pattern(pattern: Sequence[int | str] | str) -> str:
+    if isinstance(pattern, str):
+        text = pattern.strip()
+    else:
+        text = "".join(str(x) for x in pattern)
+
+    if len(text) != 3 or any(ch not in "012" for ch in text):
+        raise ValueError(f"invalid glyph pattern: {pattern!r}")
+
+    return text
+
+
+def encode_pattern(pattern: Sequence[int | str] | str) -> str:
+    text = _normalize_pattern(pattern)
+    return PATTERN_TO_GLYPH[text]
+
+
+def decode_glyph(glyph: str) -> str:
+    if len(glyph) != 1 or glyph not in GLYPH_TO_PATTERN:
+        raise ValueError(f"unknown GlyphSpec v1 glyph: {glyph!r}")
+    return GLYPH_TO_PATTERN[glyph]
+
+
+def int_to_base13(value: int) -> str:
+    if not isinstance(value, int) or value < 0 or value > 12:
+        raise ValueError(f"category total must be 0..12: {value!r}")
+    return BASE13_DIGITS[value]
+
+
+def base13_to_int(value: str) -> int:
+    if len(value) != 1 or value not in BASE13_DIGITS:
+        raise ValueError(f"invalid base-13 category total digit: {value!r}")
+    return BASE13_DIGITS.index(value)
+
+
+def encode_totals(totals: Sequence[int]) -> str:
+    if len(totals) != 3:
+        raise ValueError("totals must contain Current, H1, and H5")
+    return "".join(int_to_base13(int(v)) for v in totals)
+
+
+def decode_totals(text: str) -> tuple[int, int, int]:
+    if len(text) != 3:
+        raise ValueError("visible totals must have exactly three characters")
+    return tuple(base13_to_int(ch) for ch in text)  # type: ignore[return-value]
+
+
+def encode_fingerprint(patterns: Sequence[Sequence[int | str] | str]) -> str:
+    if len(patterns) != 6:
+        raise ValueError("category fingerprint requires exactly six subcheck patterns")
+    return "".join(encode_pattern(pattern) for pattern in patterns)
+
+
+def decode_fingerprint(fingerprint: str) -> tuple[str, ...]:
+    if len(fingerprint) != 6:
+        raise ValueError("category fingerprint must have exactly six glyphs")
+    return tuple(decode_glyph(glyph) for glyph in fingerprint)
+
+
+def totals_from_patterns(
+    patterns: Iterable[Sequence[int | str] | str],
+) -> tuple[int, int, int]:
+    normalized = tuple(_normalize_pattern(pattern) for pattern in patterns)
+    if len(normalized) != 6:
+        raise ValueError("category totals require exactly six subcheck patterns")
+
+    current = sum(int(pattern[0]) for pattern in normalized)
+    h1 = sum(int(pattern[1]) for pattern in normalized)
+    h5 = sum(int(pattern[2]) for pattern in normalized)
+    return current, h1, h5
+
+
+def make_category_token(
+    category: str, patterns: Sequence[Sequence[int | str] | str]
+) -> str:
+    cat = category.strip().upper()
+    if cat not in CATEGORY_KEYS:
+        raise ValueError(f"category must be one of A/B/C/D/E: {category!r}")
+
+    normalized = tuple(_normalize_pattern(pattern) for pattern in patterns)
+    totals = totals_from_patterns(normalized)
+    return f"{cat}={encode_totals(totals)}:{encode_fingerprint(normalized)}"
+
+
+def display_category_token(token: str) -> str:
+    validation = validate_category_token(token)
+    if (
+        not validation.valid
+        or validation.totals is None
+        or validation.fingerprint is None
+    ):
+        raise ValueError(validation.error or f"invalid category token: {token!r}")
+    return f"{encode_totals(validation.totals)}:{validation.fingerprint}"
+
+
+def validate_category_token(token: str) -> CategoryTokenValidation:
+    match = _CATEGORY_TOKEN_RE.fullmatch(str(token))
+    if not match:
+        return CategoryTokenValidation(
+            category=None,
+            token=str(token),
+            valid=False,
+            error="token must match '<category>=<three totals>:<six glyphs>'",
+        )
+
+    category, visible_totals_text, fingerprint = match.groups()
+
+    try:
+        visible_totals = decode_totals(visible_totals_text)
+        patterns = decode_fingerprint(fingerprint)
+        decoded_totals = totals_from_patterns(patterns)
+    except ValueError as exc:
+        return CategoryTokenValidation(
+            category=category,
+            token=str(token),
+            valid=False,
+            fingerprint=fingerprint,
+            error=str(exc),
+        )
+
+    if decoded_totals != visible_totals:
+        return CategoryTokenValidation(
+            category=category,
+            token=str(token),
+            valid=False,
+            totals=visible_totals,
+            decoded_totals=decoded_totals,
+            fingerprint=fingerprint,
+            patterns=patterns,
+            error="visible totals do not match decoded fingerprint totals",
+        )
+
+    return CategoryTokenValidation(
+        category=category,
+        token=str(token),
+        valid=True,
+        totals=visible_totals,
+        decoded_totals=decoded_totals,
+        fingerprint=fingerprint,
+        patterns=patterns,
+    )
+
+
+def row_checksum(
+    *,
+    symbol: str,
+    asof: str,
+    category_tokens: Mapping[str, str] | Sequence[str],
+    length: int = 4,
+) -> str:
+    if length < 2 or length > 8:
+        raise ValueError("checksum length must be between 2 and 8 characters")
+
+    symbol_part = symbol.strip().upper()
+    asof_part = str(asof).strip()
+
+    if isinstance(category_tokens, Mapping):
+        token_part = "|".join(
+            f"{cat}={category_tokens[cat]}" for cat in sorted(category_tokens)
+        )
+    else:
+        token_part = "|".join(str(token) for token in category_tokens)
+
+    payload = f"{GLYPH_SPEC_VERSION}|{symbol_part}|{asof_part}|{token_part}"
+    crc = zlib.crc32(payload.encode("utf-8")) & 0xFFFFFFFF
+    return f"{crc:08X}"[:length]
+
+
+def all_glyph_patterns() -> tuple[str, ...]:
+    return tuple("".join(parts) for parts in itertools.product("012", repeat=3))

--- a/tests/test_glyph_spec.py
+++ b/tests/test_glyph_spec.py
@@ -1,0 +1,184 @@
+import pytest
+
+from market_health.glyph_spec import (
+    GLYPH_SPEC_VERSION,
+    PATTERN_TO_GLYPH,
+    all_glyph_patterns,
+    base13_to_int,
+    decode_fingerprint,
+    decode_glyph,
+    decode_totals,
+    display_category_token,
+    encode_fingerprint,
+    encode_pattern,
+    encode_totals,
+    int_to_base13,
+    make_category_token,
+    row_checksum,
+    totals_from_patterns,
+    validate_category_token,
+)
+
+
+def test_glyph_spec_version_is_v1() -> None:
+    assert GLYPH_SPEC_VERSION == "GlyphSpec v1"
+
+
+def test_glyph_map_is_frozen() -> None:
+    assert PATTERN_TO_GLYPH == {
+        "000": "0",
+        "111": "1",
+        "222": "2",
+        "100": "c",
+        "200": "C",
+        "010": "h",
+        "020": "H",
+        "001": "w",
+        "002": "W",
+        "110": "n",
+        "220": "N",
+        "101": "u",
+        "202": "U",
+        "011": "f",
+        "022": "F",
+        "012": ">",
+        "210": "<",
+        "102": "r",
+        "201": "d",
+        "021": "p",
+        "120": "s",
+        "112": "/",
+        "221": "\\",
+        "121": "^",
+        "212": "V",
+        "122": "+",
+        "211": "-",
+    }
+
+
+def test_all_27_patterns_round_trip() -> None:
+    patterns = all_glyph_patterns()
+
+    assert len(patterns) == 27
+    assert set(patterns) == set(PATTERN_TO_GLYPH)
+
+    for pattern in patterns:
+        glyph = encode_pattern(pattern)
+        assert decode_glyph(glyph) == pattern
+
+
+def test_base13_totals_round_trip() -> None:
+    for value, digit in enumerate("0123456789ABC"):
+        assert int_to_base13(value) == digit
+        assert base13_to_int(digit) == value
+
+    assert encode_totals((6, 10, 12)) == "6AC"
+    assert decode_totals("6AC") == (6, 10, 12)
+
+
+def test_example_token_validates() -> None:
+    validation = validate_category_token("A=668:0Hr/V2")
+
+    assert validation.valid
+    assert validation.category == "A"
+    assert validation.totals == (6, 6, 8)
+    assert validation.decoded_totals == (6, 6, 8)
+    assert validation.patterns == ("000", "020", "102", "112", "212", "222")
+    assert display_category_token("A=668:0Hr/V2") == "668:0Hr/V2"
+
+
+def test_make_category_token_from_patterns() -> None:
+    token = make_category_token(
+        "A",
+        ["000", "020", "102", "112", "212", "222"],
+    )
+
+    assert token == "A=668:0Hr/V2"
+    assert validate_category_token(token).valid
+
+
+def test_corrupted_visible_total_fails_validation() -> None:
+    validation = validate_category_token("A=6A7:0Hr/V2")
+
+    assert not validation.valid
+    assert validation.totals == (6, 10, 7)
+    assert validation.decoded_totals == (6, 6, 8)
+    assert validation.error == "visible totals do not match decoded fingerprint totals"
+
+
+def test_unknown_glyph_fails_validation() -> None:
+    validation = validate_category_token("A=668:0Hr?V2")
+
+    assert not validation.valid
+    assert validation.error == "unknown GlyphSpec v1 glyph: '?'"
+
+
+@pytest.mark.parametrize(
+    "token",
+    [
+        "A=668:0Hr/V",
+        "A=668:0Hr/V22",
+        "Z=668:0Hr/V2",
+        "A=66:0Hr/V2",
+        "A=6680Hr/V2",
+    ],
+)
+def test_malformed_tokens_fail_validation(token: str) -> None:
+    assert not validate_category_token(token).valid
+
+
+def test_fingerprint_totals_and_round_trip() -> None:
+    patterns = ("122", "111", "122", "122", "122", "100")
+
+    assert encode_fingerprint(patterns) == "+1+++c"
+    assert decode_fingerprint("+1+++c") == patterns
+    assert totals_from_patterns(patterns) == (6, 9, 9)
+
+
+def test_row_checksum_is_stable_and_detects_changes() -> None:
+    tokens = {
+        "A": "A=699:+1+++c",
+        "B": "B=111:0f00c0",
+        "C": "C=866:2FuC<1",
+        "D": "D=955:+CC1+C",
+        "E": "E=566:21cFfc",
+    }
+
+    checksum = row_checksum(
+        symbol="SYNTH",
+        asof="2026-05-15T14:30:00Z",
+        category_tokens=tokens,
+    )
+
+    assert checksum == row_checksum(
+        symbol="synth",
+        asof="2026-05-15T14:30:00Z",
+        category_tokens=tokens,
+    )
+
+    changed = dict(tokens)
+    changed["E"] = "E=567:21cFf/"
+    assert checksum != row_checksum(
+        symbol="SYNTH",
+        asof="2026-05-15T14:30:00Z",
+        category_tokens=changed,
+    )
+
+
+def test_invalid_inputs_raise_for_encoder_helpers() -> None:
+    with pytest.raises(ValueError):
+        encode_pattern("123")
+
+    with pytest.raises(ValueError):
+        make_category_token("Z", ["000"] * 6)
+
+    with pytest.raises(ValueError):
+        encode_fingerprint(["000"] * 5)
+
+    with pytest.raises(ValueError):
+        row_checksum(
+            symbol="SYNTH",
+            asof="2026-05-15T14:30:00Z",
+            category_tokens=[],
+            length=1,
+        )


### PR DESCRIPTION
## Summary

Adds the standalone GlyphSpec v1 codec for encoding and decoding Current/H1/H5 subcheck patterns.

This PR includes:

- frozen 27-glyph map
- reverse glyph decoding
- base-13 category total encoding
- category fingerprint encoding/decoding
- canonical category token validation
- compact display-token conversion
- stable row checksum helper

This is the first M45 building block and does not change dashboard rendering, scoring formulas, trading rules, or export behavior.

Closes #385.

## Testing

- `.venv-ci/bin/python -m pytest tests/test_glyph_spec.py -q`
- `.venv-ci/bin/python -m py_compile market_health/glyph_spec.py tests/test_glyph_spec.py`
- `.venv-ci/bin/ruff format --check market_health/glyph_spec.py tests/test_glyph_spec.py`
- `.venv-ci/bin/ruff check market_health/glyph_spec.py tests/test_glyph_spec.py`