### PR TITLE
Build GlyphSpec audit rows from score payloads

### DIFF
--- a/market_health/forecast_audit.py
+++ b/market_health/forecast_audit.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from market_health.glyph_spec import (
+    CATEGORY_KEYS,
+    GLYPH_SPEC_VERSION,
+    display_category_token,
+    make_category_token,
+    row_checksum,
+    validate_category_token,
+)
+
+
+@dataclass(frozen=True)
+class CategoryAuditCell:
+    category: str
+    token: str | None
+    display_token: str
+    valid: bool
+    totals: tuple[int, int, int] | None = None
+    fingerprint: str | None = None
+    patterns: tuple[str, ...] = ()
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class SymbolAuditRow:
+    symbol: str
+    asof: str
+    cells: dict[str, CategoryAuditCell]
+    checksum: str
+    is_held: bool = False
+    glyph_spec_version: str = GLYPH_SPEC_VERSION
+
+    @property
+    def all_valid(self) -> bool:
+        return all(cell.valid for cell in self.cells.values())
+
+    @property
+    def display_cells(self) -> dict[str, str]:
+        return {category: cell.display_token for category, cell in self.cells.items()}
+
+    @property
+    def canonical_tokens(self) -> dict[str, str]:
+        return {
+            category: cell.token
+            for category, cell in self.cells.items()
+            if cell.token is not None
+        }
+
+
+def _error_cell(category: str, error: str) -> CategoryAuditCell:
+    return CategoryAuditCell(
+        category=category,
+        token=None,
+        display_token="BAD",
+        valid=False,
+        error=error,
+    )
+
+
+def _cat_node(payload: Mapping[str, Any], category: str) -> Any:
+    categories = payload.get("categories")
+    if isinstance(categories, Mapping):
+        return categories.get(category)
+    return payload.get(category)
+
+
+def _checks_for_category(
+    payload: Mapping[str, Any], category: str
+) -> list[Mapping[str, Any]]:
+    node = _cat_node(payload, category)
+    if isinstance(node, Mapping) and isinstance(node.get("checks"), list):
+        checks = [check for check in node["checks"] if isinstance(check, Mapping)]
+    elif isinstance(node, list):
+        checks = [check for check in node if isinstance(check, Mapping)]
+    else:
+        raise ValueError(f"missing category payload for {category}")
+
+    if len(checks) != 6:
+        raise ValueError(f"category {category} must contain exactly six checks")
+
+    return checks
+
+
+def _score_digit(check: Mapping[str, Any], *, category: str, index: int) -> str:
+    value = check.get("score")
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"category {category} check {index + 1} has no numeric score")
+
+    if int(value) != value:
+        raise ValueError(
+            f"category {category} check {index + 1} score must be 0, 1, or 2"
+        )
+
+    score = int(value)
+    if score < 0 or score > 2:
+        raise ValueError(
+            f"category {category} check {index + 1} score must be 0, 1, or 2"
+        )
+
+    return str(score)
+
+
+def category_patterns_from_payloads(
+    *,
+    category: str,
+    current_payload: Mapping[str, Any],
+    h1_payload: Mapping[str, Any],
+    h5_payload: Mapping[str, Any],
+) -> tuple[str, ...]:
+    cat = category.strip().upper()
+    if cat not in CATEGORY_KEYS:
+        raise ValueError(f"category must be one of A/B/C/D/E: {category!r}")
+
+    current_checks = _checks_for_category(current_payload, cat)
+    h1_checks = _checks_for_category(h1_payload, cat)
+    h5_checks = _checks_for_category(h5_payload, cat)
+
+    patterns: list[str] = []
+    for index in range(6):
+        patterns.append(
+            _score_digit(current_checks[index], category=cat, index=index)
+            + _score_digit(h1_checks[index], category=cat, index=index)
+            + _score_digit(h5_checks[index], category=cat, index=index)
+        )
+
+    return tuple(patterns)
+
+
+def build_category_audit_cell(
+    *,
+    category: str,
+    current_payload: Mapping[str, Any],
+    h1_payload: Mapping[str, Any],
+    h5_payload: Mapping[str, Any],
+) -> CategoryAuditCell:
+    cat = category.strip().upper()
+
+    try:
+        patterns = category_patterns_from_payloads(
+            category=cat,
+            current_payload=current_payload,
+            h1_payload=h1_payload,
+            h5_payload=h5_payload,
+        )
+        token = make_category_token(cat, patterns)
+        validation = validate_category_token(token)
+        if not validation.valid:
+            return _error_cell(cat, validation.error or "invalid category token")
+
+        return CategoryAuditCell(
+            category=cat,
+            token=token,
+            display_token=display_category_token(token),
+            valid=True,
+            totals=validation.totals,
+            fingerprint=validation.fingerprint,
+            patterns=validation.patterns,
+        )
+    except ValueError as exc:
+        return _error_cell(cat, str(exc))
+
+
+def build_symbol_audit_row(
+    *,
+    symbol: str,
+    asof: str,
+    current_payload: Mapping[str, Any],
+    h1_payload: Mapping[str, Any],
+    h5_payload: Mapping[str, Any],
+    is_held: bool = False,
+) -> SymbolAuditRow:
+    symbol_u = symbol.strip().upper()
+    cells = {
+        category: build_category_audit_cell(
+            category=category,
+            current_payload=current_payload,
+            h1_payload=h1_payload,
+            h5_payload=h5_payload,
+        )
+        for category in CATEGORY_KEYS
+    }
+
+    checksum_inputs = [
+        cell.token
+        if cell.token is not None
+        else f"{cell.category}=INVALID:{cell.error or ''}"
+        for cell in cells.values()
+    ]
+
+    checksum = row_checksum(
+        symbol=symbol_u,
+        asof=str(asof),
+        category_tokens=checksum_inputs,
+    )
+
+    return SymbolAuditRow(
+        symbol=symbol_u,
+        asof=str(asof),
+        cells=cells,
+        checksum=checksum,
+        is_held=is_held,
+    )

--- a/tests/test_forecast_audit.py
+++ b/tests/test_forecast_audit.py
@@ -1,0 +1,163 @@
+from market_health.forecast_audit import (
+    build_category_audit_cell,
+    build_symbol_audit_row,
+    category_patterns_from_payloads,
+)
+
+
+PATTERNS_BY_CATEGORY = {
+    "A": ["122", "111", "122", "122", "122", "100"],
+    "B": ["000", "011", "000", "000", "100", "000"],
+    "C": ["222", "022", "101", "200", "210", "111"],
+    "D": ["122", "200", "200", "111", "122", "200"],
+    "E": ["222", "111", "100", "022", "011", "100"],
+}
+
+
+def _payload_from_patterns(symbol: str, horizon_index: int) -> dict:
+    categories = {}
+    for category, patterns in PATTERNS_BY_CATEGORY.items():
+        categories[category] = {
+            "checks": [
+                {"id": f"{category}{index + 1}", "score": int(pattern[horizon_index])}
+                for index, pattern in enumerate(patterns)
+            ]
+        }
+
+    return {"symbol": symbol, "categories": categories}
+
+
+def test_category_patterns_are_built_from_current_h1_h5_payloads() -> None:
+    current = _payload_from_patterns("SYNTH", 0)
+    h1 = _payload_from_patterns("SYNTH", 1)
+    h5 = _payload_from_patterns("SYNTH", 2)
+
+    assert category_patterns_from_payloads(
+        category="A",
+        current_payload=current,
+        h1_payload=h1,
+        h5_payload=h5,
+    ) == tuple(PATTERNS_BY_CATEGORY["A"])
+
+
+def test_build_category_audit_cell_produces_canonical_and_display_tokens() -> None:
+    current = _payload_from_patterns("SYNTH", 0)
+    h1 = _payload_from_patterns("SYNTH", 1)
+    h5 = _payload_from_patterns("SYNTH", 2)
+
+    cell = build_category_audit_cell(
+        category="A",
+        current_payload=current,
+        h1_payload=h1,
+        h5_payload=h5,
+    )
+
+    assert cell.valid
+    assert cell.category == "A"
+    assert cell.token == "A=699:+1+++c"
+    assert cell.display_token == "699:+1+++c"
+    assert cell.totals == (6, 9, 9)
+    assert cell.fingerprint == "+1+++c"
+    assert cell.patterns == tuple(PATTERNS_BY_CATEGORY["A"])
+
+
+def test_build_symbol_audit_row_contains_all_category_cells() -> None:
+    current = _payload_from_patterns("synth", 0)
+    h1 = _payload_from_patterns("synth", 1)
+    h5 = _payload_from_patterns("synth", 2)
+
+    row = build_symbol_audit_row(
+        symbol="synth",
+        asof="2026-05-15T14:30:00Z",
+        current_payload=current,
+        h1_payload=h1,
+        h5_payload=h5,
+        is_held=True,
+    )
+
+    assert row.symbol == "SYNTH"
+    assert row.asof == "2026-05-15T14:30:00Z"
+    assert row.is_held
+    assert row.all_valid
+    assert len(row.checksum) == 4
+
+    assert row.canonical_tokens == {
+        "A": "A=699:+1+++c",
+        "B": "B=111:0f00c0",
+        "C": "C=866:2FuC<1",
+        "D": "D=955:+CC1+C",
+        "E": "E=566:21cFfc",
+    }
+
+    assert row.display_cells == {
+        "A": "699:+1+++c",
+        "B": "111:0f00c0",
+        "C": "866:2FuC<1",
+        "D": "955:+CC1+C",
+        "E": "566:21cFfc",
+    }
+
+
+def test_row_checksum_changes_when_payload_changes() -> None:
+    current = _payload_from_patterns("SYNTH", 0)
+    h1 = _payload_from_patterns("SYNTH", 1)
+    h5 = _payload_from_patterns("SYNTH", 2)
+
+    original = build_symbol_audit_row(
+        symbol="SYNTH",
+        asof="2026-05-15T14:30:00Z",
+        current_payload=current,
+        h1_payload=h1,
+        h5_payload=h5,
+    )
+
+    changed_h5 = _payload_from_patterns("SYNTH", 2)
+    changed_h5["categories"]["E"]["checks"][5]["score"] = 2
+
+    changed = build_symbol_audit_row(
+        symbol="SYNTH",
+        asof="2026-05-15T14:30:00Z",
+        current_payload=current,
+        h1_payload=h1,
+        h5_payload=changed_h5,
+    )
+
+    assert original.checksum != changed.checksum
+
+
+def test_invalid_category_payload_marks_cell_bad_without_crashing() -> None:
+    current = _payload_from_patterns("SYNTH", 0)
+    h1 = _payload_from_patterns("SYNTH", 1)
+    h5 = _payload_from_patterns("SYNTH", 2)
+    current["categories"]["A"]["checks"].pop()
+
+    cell = build_category_audit_cell(
+        category="A",
+        current_payload=current,
+        h1_payload=h1,
+        h5_payload=h5,
+    )
+
+    assert not cell.valid
+    assert cell.display_token == "BAD"
+    assert cell.error == "category A must contain exactly six checks"
+
+
+def test_invalid_cell_makes_symbol_row_invalid_but_still_checksumed() -> None:
+    current = _payload_from_patterns("SYNTH", 0)
+    h1 = _payload_from_patterns("SYNTH", 1)
+    h5 = _payload_from_patterns("SYNTH", 2)
+    current["categories"]["C"]["checks"][0]["score"] = 9
+
+    row = build_symbol_audit_row(
+        symbol="SYNTH",
+        asof="2026-05-15T14:30:00Z",
+        current_payload=current,
+        h1_payload=h1,
+        h5_payload=h5,
+    )
+
+    assert not row.all_valid
+    assert row.cells["C"].display_token == "BAD"
+    assert row.cells["C"].error == "category C check 1 score must be 0, 1, or 2"
+    assert len(row.checksum) == 4


### PR DESCRIPTION
## Summary

Adds a reusable GlyphSpec audit-row builder for M45.

This PR builds symbol-level audit rows from Current, H1, and H5 category/check payloads. It produces:

- canonical category tokens such as `A=699:+1+++c`
- compact display cells such as `699:+1+++c`
- stable row checksums
- per-cell validation state
- held marker metadata

This does not change dashboard rendering, exports, scoring formulas, or trading rules.

Closes #386.

## Testing

- `.venv-ci/bin/python -m pytest tests/test_glyph_spec.py tests/test_forecast_audit.py -q`
- `.venv-ci/bin/python -m py_compile market_health/forecast_audit.py tests/test_forecast_audit.py`
- `.venv-ci/bin/ruff format --check market_health/forecast_audit.py tests/test_forecast_audit.py`
- `.venv-ci/bin/ruff check market_health/forecast_audit.py tests/test_forecast_audit.py`