### PR TITLE
Render GlyphSpec audit overview panel

### DIFF
--- a/market_health/dashboard_legacy.py
+++ b/market_health/dashboard_legacy.py
@@ -3680,6 +3680,53 @@ def main() -> int:
             t.stylize(_style(val, denom))
             return t
 
+        try:
+            from market_health.forecast_audit import build_symbol_audit_row
+            from market_health.glyph_audit_panel import render_glyph_audit_overview
+
+            audit_asof = str(
+                forecast_doc.get("asof")
+                or forecast_doc.get("generated_at")
+                or forecast_doc.get("computed_at")
+                or ""
+            )
+            audit_rows = []
+            held_set = {str(sym).upper() for sym in held_syms}
+
+            for sym in overview_order:
+                row = by2.get(sym)
+                if not isinstance(row, dict):
+                    continue
+
+                by_h = (
+                    forecast_scores.get(sym)
+                    if isinstance(forecast_scores, dict)
+                    else None
+                )
+                if not isinstance(by_h, dict):
+                    continue
+
+                h1_payload = by_h.get(1) or by_h.get("1")
+                h5_payload = by_h.get(5) or by_h.get("5")
+                if not isinstance(h1_payload, dict) or not isinstance(h5_payload, dict):
+                    continue
+
+                audit_rows.append(
+                    build_symbol_audit_row(
+                        symbol=sym,
+                        asof=audit_asof,
+                        current_payload=row,
+                        h1_payload=h1_payload,
+                        h5_payload=h5_payload,
+                        is_held=sym in held_set,
+                    )
+                )
+
+            if audit_rows:
+                sys.stdout.write(render_glyph_audit_overview(audit_rows) + "\n\n")
+        except Exception:
+            pass
+
         console2 = Console()
         t = Table(
             title="Overview (A–E totals per universe)",

--- a/market_health/glyph_audit_panel.py
+++ b/market_health/glyph_audit_panel.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import re
+from typing import Iterable
+
+from market_health.forecast_audit import SymbolAuditRow
+from market_health.glyph_spec import GLYPH_SPEC_VERSION, base13_to_int, decode_glyph
+
+RESET = "\033[0m"
+BOLD = "\033[1m"
+DIM = "\033[2m"
+RED = "\033[31m"
+YELLOW = "\033[33m"
+GREEN = "\033[32m"
+CYAN = "\033[36m"
+
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _visible_len(value: str) -> int:
+    return len(ANSI_RE.sub("", value))
+
+
+def _pad(value: str, width: int) -> str:
+    return value + (" " * max(0, width - _visible_len(value)))
+
+
+def _ansi(value: str, enabled: bool) -> str:
+    return value if enabled else ""
+
+
+def _total_color(value: int) -> str:
+    if value <= 3:
+        return RED
+    if value <= 7:
+        return YELLOW
+    return GREEN
+
+
+def _glyph_color(glyph: str) -> str:
+    pattern = decode_glyph(glyph)
+    score = sum(int(ch) for ch in pattern)
+    if score <= 2:
+        return RED
+    if score <= 3:
+        return YELLOW
+    return GREEN
+
+
+def color_display_token(display_token: str, *, color: bool = True) -> str:
+    if display_token == "BAD":
+        return f"{_ansi(RED, color)}BAD{_ansi(RESET, color)}"
+
+    if ":" not in display_token:
+        return display_token
+
+    totals, fingerprint = display_token.split(":", 1)
+    if len(totals) != 3 or len(fingerprint) != 6:
+        return f"{_ansi(RED, color)}BAD{_ansi(RESET, color)}"
+
+    parts: list[str] = []
+
+    for digit in totals:
+        try:
+            value = base13_to_int(digit)
+        except ValueError:
+            return f"{_ansi(RED, color)}BAD{_ansi(RESET, color)}"
+        parts.append(f"{_ansi(_total_color(value), color)}{digit}{_ansi(RESET, color)}")
+
+    parts.append(":")
+
+    for glyph in fingerprint:
+        try:
+            color_code = _glyph_color(glyph)
+        except ValueError:
+            return f"{_ansi(RED, color)}BAD{_ansi(RESET, color)}"
+        parts.append(f"{_ansi(color_code, color)}{glyph}{_ansi(RESET, color)}")
+
+    return "".join(parts)
+
+
+def render_glyph_audit_overview(
+    rows: Iterable[SymbolAuditRow],
+    *,
+    color: bool = True,
+) -> str:
+    rows = list(rows)
+
+    widths = {
+        "Sym": 7,
+        "A": 14,
+        "B": 14,
+        "C": 14,
+        "D": 14,
+        "E": 14,
+        "ck": 6,
+    }
+    headers = ["Sym", "A", "B", "C", "D", "E", "ck"]
+
+    out: list[str] = []
+    out.append(
+        f"{_ansi(BOLD, color)}Market Health — Glyph Audit Overview • {GLYPH_SPEC_VERSION}{_ansi(RESET, color)}"
+    )
+    out.append(
+        f"{_ansi(DIM, color)}cell=totals:fingerprint   totals=C/H1/H5   •=held{_ansi(RESET, color)}"
+    )
+    out.append("")
+    out.append(
+        " ".join(
+            _pad(f"{_ansi(BOLD, color)}{header}{_ansi(RESET, color)}", widths[header])
+            for header in headers
+        )
+    )
+    out.append(" ".join("─" * widths[header] for header in headers))
+
+    for row in rows:
+        symbol = row.symbol + ("•" if row.is_held else "")
+        checksum = row.checksum if row.all_valid else "FAIL"
+        checksum_color = DIM if row.all_valid else RED
+
+        cells = [
+            f"{_ansi(CYAN, color)}{symbol}{_ansi(RESET, color)}",
+            color_display_token(row.display_cells.get("A", "BAD"), color=color),
+            color_display_token(row.display_cells.get("B", "BAD"), color=color),
+            color_display_token(row.display_cells.get("C", "BAD"), color=color),
+            color_display_token(row.display_cells.get("D", "BAD"), color=color),
+            color_display_token(row.display_cells.get("E", "BAD"), color=color),
+            f"{_ansi(checksum_color, color)}{checksum}{_ansi(RESET, color)}",
+        ]
+
+        out.append(
+            " ".join(
+                _pad(cells[index], widths[headers[index]])
+                for index in range(len(headers))
+            )
+        )
+
+    return "\n".join(out)

--- a/tests/test_glyph_audit_panel.py
+++ b/tests/test_glyph_audit_panel.py
@@ -1,0 +1,80 @@
+from market_health.forecast_audit import build_symbol_audit_row
+from market_health.glyph_audit_panel import (
+    color_display_token,
+    render_glyph_audit_overview,
+)
+
+
+PATTERNS_BY_CATEGORY = {
+    "A": ["122", "111", "122", "122", "122", "100"],
+    "B": ["000", "011", "000", "000", "100", "000"],
+    "C": ["222", "022", "101", "200", "210", "111"],
+    "D": ["122", "200", "200", "111", "122", "200"],
+    "E": ["222", "111", "100", "022", "011", "100"],
+}
+
+
+def _payload_from_patterns(symbol: str, horizon_index: int) -> dict:
+    categories = {}
+    for category, patterns in PATTERNS_BY_CATEGORY.items():
+        categories[category] = {
+            "checks": [
+                {"id": f"{category}{index + 1}", "score": int(pattern[horizon_index])}
+                for index, pattern in enumerate(patterns)
+            ]
+        }
+
+    return {"symbol": symbol, "categories": categories}
+
+
+def test_color_display_token_can_render_without_color() -> None:
+    assert color_display_token("699:+1+++c", color=False) == "699:+1+++c"
+    assert color_display_token("BAD", color=False) == "BAD"
+
+
+def test_render_glyph_audit_overview_minimal_columns_without_color() -> None:
+    current = _payload_from_patterns("SYNTH", 0)
+    h1 = _payload_from_patterns("SYNTH", 1)
+    h5 = _payload_from_patterns("SYNTH", 2)
+
+    row = build_symbol_audit_row(
+        symbol="SYNTH",
+        asof="2026-05-15T14:30:00Z",
+        current_payload=current,
+        h1_payload=h1,
+        h5_payload=h5,
+        is_held=True,
+    )
+
+    output = render_glyph_audit_overview([row], color=False)
+
+    assert "Market Health — Glyph Audit Overview • GlyphSpec v1" in output
+    assert "cell=totals:fingerprint   totals=C/H1/H5   •=held" in output
+    assert "Sym" in output
+    assert "ck" in output
+    assert "SYNTH•" in output
+    assert "699:+1+++c" in output
+    assert "111:0f00c0" in output
+    assert "866:2FuC<1" in output
+    assert "955:+CC1+C" in output
+    assert "566:21cFfc" in output
+
+
+def test_render_glyph_audit_overview_marks_invalid_rows() -> None:
+    current = _payload_from_patterns("SYNTH", 0)
+    h1 = _payload_from_patterns("SYNTH", 1)
+    h5 = _payload_from_patterns("SYNTH", 2)
+    current["categories"]["A"]["checks"].pop()
+
+    row = build_symbol_audit_row(
+        symbol="SYNTH",
+        asof="2026-05-15T14:30:00Z",
+        current_payload=current,
+        h1_payload=h1,
+        h5_payload=h5,
+    )
+
+    output = render_glyph_audit_overview([row], color=False)
+
+    assert "BAD" in output
+    assert "FAIL" in output


### PR DESCRIPTION
## Summary

Adds the first visible M45 GlyphSpec audit overview panel.

The new panel renders above the existing A/B/C/D/E totals overview and keeps the old panel below it for comparison. It uses the reusable audit-row builder from #391 and displays the minimal audit view:

- `Sym`
- `A`
- `B`
- `C`
- `D`
- `E`
- `ck`

Each category cell uses the compact `totals:fingerprint` format, for example `699:+1+++c`. Held symbols are marked with `•`.

This does not remove the old overview panel yet, does not change scoring formulas, and does not change trading rules.

Closes #387.

## Testing

- `.venv-ci/bin/python -m pytest tests/test_glyph_spec.py tests/test_forecast_audit.py tests/test_glyph_audit_panel.py -q`
- `.venv-ci/bin/python -m py_compile market_health/dashboard_legacy.py market_health/glyph_audit_panel.py tests/test_glyph_audit_panel.py`
- `.venv-ci/bin/ruff format --check market_health/dashboard_legacy.py market_health/glyph_audit_panel.py tests/test_glyph_audit_panel.py`
- `.venv-ci/bin/ruff check market_health/dashboard_legacy.py market_health/glyph_audit_panel.py tests/test_glyph_audit_panel.py`
- `mh_dev >/tmp/mh_dev_glyph_panel.out`