### PR TITLE
Use absolute forecast horizon scores

### DIFF
--- a/market_health/alert_snapshots.py
+++ b/market_health/alert_snapshots.py
@@ -182,11 +182,7 @@ def _forecast_utility(
     if score is None:
         return None
 
-    if current_utility is None:
-        return float(score)
-
-    anchored = float(current_utility) + (float(score) - 0.50)
-    return max(0.0, min(1.0, anchored))
+    return max(0.0, min(1.0, float(score)))
 
 
 def _blend_utility(

--- a/market_health/dashboard_legacy.py
+++ b/market_health/dashboard_legacy.py
@@ -448,18 +448,7 @@ def _forecast_score_to_current_utility(forecast_score, current_utility):
         return None
     if abs(fs) > 1.000001:
         fs = fs / 100.0
-    fs = max(0.0, min(1.0, fs))
-
-    try:
-        cur = float(current_utility)
-    except Exception:
-        return fs
-    if abs(cur) > 1.000001:
-        cur = cur / 100.0
-    cur = max(0.0, min(1.0, cur))
-
-    anchored = cur + (fs - 0.50)
-    return max(0.0, min(1.0, anchored))
+    return max(0.0, min(1.0, fs))
 
 
 def _blend_from_components(c_val, h1_val, h5_val):

--- a/market_health/recommendations_engine.py
+++ b/market_health/recommendations_engine.py
@@ -127,44 +127,16 @@ def _forecast_payload_for(
     return raw if isinstance(raw, dict) else None
 
 
-def _forecast_utility(payload: Any, current_utility: Any = None) -> float | None:
+def _forecast_utility(payload: Any, *, current_utility: float) -> Optional[float]:
     if not isinstance(payload, dict):
         return None
-
-    score = None
-    for key in ("forecast_score", "score", "utility", "blend", "blended", "current"):
-        val = payload.get(key)
-        if isinstance(val, (int, float)):
-            score = float(val)
-            break
-        if isinstance(val, str):
-            txt = val.strip().replace("%", "")
-            if not txt:
-                continue
-            try:
-                score = float(txt)
-                break
-            except Exception:
-                continue
-
-    if score is None:
+    score = payload.get("forecast_score")
+    if isinstance(score, bool) or not isinstance(score, (int, float)):
         return None
-
+    score = float(score)
     if abs(score) > 1.000001:
         score = score / 100.0
-    score = max(0.0, min(1.0, score))
-
-    # Forecast is neutral at 0.50. Anchor horizon utility around current C.
-    if not isinstance(current_utility, (int, float)):
-        return score
-
-    cur = float(current_utility)
-    if abs(cur) > 1.000001:
-        cur = cur / 100.0
-    cur = max(0.0, min(1.0, cur))
-
-    anchored = cur + (score - 0.50)
-    return max(0.0, min(1.0, anchored))
+    return max(0.0, min(1.0, score))
 
 
 def _blend_utility_diagnostic(

--- a/tests/test_alert_snapshots.py
+++ b/tests/test_alert_snapshots.py
@@ -234,9 +234,9 @@ def test_collect_derives_scores_from_nested_ui_contract_payloads() -> None:
     snap = snapshots[0]
     assert snap.symbol == "SPY"
     assert round(snap.current_score or 0, 2) == 56.67
-    assert round(snap.h1_score or 0, 2) == 68.33
-    assert round(snap.h5_score or 0, 2) == 61.67
-    assert round(snap.blend_score or 0, 2) == 60.83
+    assert round(snap.h1_score or 0, 2) == 61.67
+    assert round(snap.h5_score or 0, 2) == 55.0
+    assert round(snap.blend_score or 0, 2) == 57.5
     assert snap.state == "DMG,OH,BRK"
     assert snap.sup_atr == 0.25
     assert snap.res_atr == 0.75

--- a/tests/test_forecast_blend_diagnostics.py
+++ b/tests/test_forecast_blend_diagnostics.py
@@ -16,8 +16,8 @@ def test_blend_diagnostic_explains_default_c_h1_h5_contributions() -> None:
     rows = [_score_row("SPY", [2, 1, 1, 1, 1])]  # C/current utility = 6/10 = 0.60
     forecast_scores = {
         "SPY": {
-            1: {"forecast_score": 0.70},  # anchored H1 = 0.80
-            5: {"forecast_score": 0.40},  # anchored H5 = 0.50
+            1: {"forecast_score": 0.70},
+            5: {"forecast_score": 0.40},
         }
     }
 
@@ -32,22 +32,22 @@ def test_blend_diagnostic_explains_default_c_h1_h5_contributions() -> None:
     components = diag["components"]
 
     assert round(meta["current_utility"], 6) == 0.6
-    assert round(meta["h1_utility"], 6) == 0.8
-    assert round(meta["h5_utility"], 6) == 0.5
-    assert round(meta["utility"], 6) == 0.625
+    assert round(meta["h1_utility"], 6) == 0.7
+    assert round(meta["h5_utility"], 6) == 0.4
+    assert round(meta["utility"], 6) == 0.575
 
     assert diag["present_components"] == ["c", "h1", "h5"]
     assert diag["raw_weights"] == {"c": 0.5, "h1": 0.25, "h5": 0.25}
     assert round(components["c"]["contribution"], 6) == 0.3
-    assert round(components["h1"]["contribution"], 6) == 0.2
-    assert round(components["h5"]["contribution"], 6) == 0.125
+    assert round(components["h1"]["contribution"], 6) == 0.175
+    assert round(components["h5"]["contribution"], 6) == 0.1
 
 
 def test_blend_diagnostic_shows_missing_horizon_weight_renormalization() -> None:
     rows = [_score_row("SPY", [2, 1, 1, 1, 1])]  # C/current utility = 0.60
     forecast_scores = {
         "SPY": {
-            1: {"forecast_score": 0.70},  # anchored H1 = 0.80
+            1: {"forecast_score": 0.70},
         }
     }
 
@@ -66,7 +66,7 @@ def test_blend_diagnostic_shows_missing_horizon_weight_renormalization() -> None
     assert components["h5"]["effective_weight"] == 0.0
     assert round(components["c"]["effective_weight"], 6) == 0.666667
     assert round(components["h1"]["effective_weight"], 6) == 0.333333
-    assert round(out["SPY"]["utility"], 6) == 0.666667
+    assert round(out["SPY"]["utility"], 6) == 0.633333
 
 
 def test_custom_utility_weights_are_normalized_and_explained() -> None:
@@ -87,4 +87,4 @@ def test_custom_utility_weights_are_normalized_and_explained() -> None:
 
     diag = out["SPY"]["utility_blend_diagnostic"]
     assert diag["raw_weights"] == {"c": 0.5, "h1": 0.25, "h5": 0.25}
-    assert round(diag["blended_utility"], 6) == 0.625
+    assert round(diag["blended_utility"], 6) == 0.575


### PR DESCRIPTION
## Summary

Removes the current-score anchoring adjustment from forecast horizon utility calculations.

Before this change, H1/H5 were computed as:

`current + (forecast_score - 0.50)`

That made displayed H1/H5 values diverge from the GlyphSpec audit totals, even though the glyphs correctly encoded the raw forecast horizon payloads.

After this change:

- H1 uses the absolute H1 `forecast_score`
- H5 uses the absolute H5 `forecast_score`
- Blend remains `0.50*C + 0.25*H1 + 0.25*H5`
- Glyph audit category totals reconcile directly to the compact tri-score panel

This updates dashboard rendering, recommendation utility blending, and alert snapshot derivation to use the same absolute horizon semantics.

## Testing

- `.venv-ci/bin/python -m pytest tests/test_forecast_blend_diagnostics.py tests/test_forecast_policy.py tests/test_forecast_recommendations_pm7.py tests/test_forecast_recommendations_pm11.py tests/test_forecast_recommendations_pm12.py tests/test_alert_snapshots.py tests/test_glyph_spec.py tests/test_forecast_audit.py tests/test_glyph_audit_panel.py -q`
- `.venv-ci/bin/python -m py_compile market_health/dashboard_legacy.py market_health/recommendations_engine.py market_health/alert_snapshots.py`
- `.venv-ci/bin/ruff check market_health/dashboard_legacy.py market_health/recommendations_engine.py market_health/alert_snapshots.py tests/test_forecast_blend_diagnostics.py tests/test_alert_snapshots.py`
- `mh_dev >/tmp/mh_dev_absolute_horizons.out`