### PR TITLE
Export forecast audit artifact

### DIFF
--- a/market_health/dashboard_legacy.py
+++ b/market_health/dashboard_legacy.py
@@ -3670,7 +3670,10 @@ def main() -> int:
             return t
 
         try:
-            from market_health.forecast_audit import build_symbol_audit_row
+            from market_health.forecast_audit import (
+                build_symbol_audit_row,
+                write_forecast_audit_json,
+            )
             from market_health.glyph_audit_panel import render_glyph_audit_overview
 
             audit_asof = str(
@@ -3712,6 +3715,10 @@ def main() -> int:
                 )
 
             if audit_rows:
+                audit_path = (
+                    Path.home() / ".cache" / "jerboa" / "forecast_audit.v1.json"
+                )
+                write_forecast_audit_json(audit_path, audit_rows, asof=audit_asof)
                 sys.stdout.write(render_glyph_audit_overview(audit_rows) + "\n\n")
         except Exception:
             pass

--- a/market_health/forecast_audit.py
+++ b/market_health/forecast_audit.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
-from typing import Any, Mapping
+from pathlib import Path
+from typing import Any, Iterable, Mapping
 
 from market_health.glyph_spec import (
     CATEGORY_KEYS,
@@ -204,3 +206,65 @@ def build_symbol_audit_row(
         checksum=checksum,
         is_held=is_held,
     )
+
+
+def category_audit_cell_to_dict(cell: CategoryAuditCell) -> dict[str, Any]:
+    return {
+        "category": cell.category,
+        "token": cell.token,
+        "display_token": cell.display_token,
+        "valid": cell.valid,
+        "totals": list(cell.totals) if cell.totals is not None else None,
+        "fingerprint": cell.fingerprint,
+        "patterns": list(cell.patterns),
+        "error": cell.error,
+    }
+
+
+def symbol_audit_row_to_dict(row: SymbolAuditRow) -> dict[str, Any]:
+    return {
+        "symbol": row.symbol,
+        "asof": row.asof,
+        "is_held": row.is_held,
+        "checksum": row.checksum,
+        "valid": row.all_valid,
+        "glyph_spec_version": row.glyph_spec_version,
+        "cells": {
+            category: category_audit_cell_to_dict(cell)
+            for category, cell in row.cells.items()
+        },
+        "display_cells": row.display_cells,
+        "canonical_tokens": row.canonical_tokens,
+    }
+
+
+def forecast_audit_document(
+    rows: Iterable[SymbolAuditRow],
+    *,
+    asof: str,
+) -> dict[str, Any]:
+    row_list = list(rows)
+    return {
+        "schema": "forecast_audit.v1",
+        "glyph_spec_version": GLYPH_SPEC_VERSION,
+        "asof": str(asof),
+        "columns": ["Sym", "A", "B", "C", "D", "E", "ck"],
+        "row_count": len(row_list),
+        "rows": [symbol_audit_row_to_dict(row) for row in row_list],
+    }
+
+
+def write_forecast_audit_json(
+    path: str | Path,
+    rows: Iterable[SymbolAuditRow],
+    *,
+    asof: str,
+) -> Path:
+    out_path = Path(path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    doc = forecast_audit_document(rows, asof=asof)
+    out_path.write_text(
+        json.dumps(doc, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return out_path

--- a/tests/test_forecast_audit.py
+++ b/tests/test_forecast_audit.py
@@ -1,7 +1,12 @@
+import json
+
 from market_health.forecast_audit import (
     build_category_audit_cell,
     build_symbol_audit_row,
     category_patterns_from_payloads,
+    forecast_audit_document,
+    symbol_audit_row_to_dict,
+    write_forecast_audit_json,
 )
 
 
@@ -161,3 +166,78 @@ def test_invalid_cell_makes_symbol_row_invalid_but_still_checksumed() -> None:
     assert row.cells["C"].display_token == "BAD"
     assert row.cells["C"].error == "category C check 1 score must be 0, 1, or 2"
     assert len(row.checksum) == 4
+
+
+def test_symbol_audit_row_serializes_for_export() -> None:
+    current = _payload_from_patterns("synth", 0)
+    h1 = _payload_from_patterns("synth", 1)
+    h5 = _payload_from_patterns("synth", 2)
+
+    row = build_symbol_audit_row(
+        symbol="synth",
+        asof="2026-05-15T14:30:00Z",
+        current_payload=current,
+        h1_payload=h1,
+        h5_payload=h5,
+        is_held=True,
+    )
+
+    exported = symbol_audit_row_to_dict(row)
+
+    assert exported["symbol"] == "SYNTH"
+    assert exported["is_held"] is True
+    assert exported["valid"] is True
+    assert exported["cells"]["A"]["token"] == "A=699:+1+++c"
+    assert exported["cells"]["A"]["display_token"] == "699:+1+++c"
+    assert exported["cells"]["A"]["totals"] == [6, 9, 9]
+    assert exported["display_cells"]["A"] == "699:+1+++c"
+    assert exported["canonical_tokens"]["A"] == "A=699:+1+++c"
+
+
+def test_forecast_audit_document_has_stable_v1_shape() -> None:
+    current = _payload_from_patterns("synth", 0)
+    h1 = _payload_from_patterns("synth", 1)
+    h5 = _payload_from_patterns("synth", 2)
+
+    row = build_symbol_audit_row(
+        symbol="synth",
+        asof="2026-05-15T14:30:00Z",
+        current_payload=current,
+        h1_payload=h1,
+        h5_payload=h5,
+    )
+
+    doc = forecast_audit_document([row], asof="2026-05-15T14:30:00Z")
+
+    assert doc["schema"] == "forecast_audit.v1"
+    assert doc["glyph_spec_version"] == "GlyphSpec v1"
+    assert doc["asof"] == "2026-05-15T14:30:00Z"
+    assert doc["columns"] == ["Sym", "A", "B", "C", "D", "E", "ck"]
+    assert doc["row_count"] == 1
+    assert doc["rows"][0]["symbol"] == "SYNTH"
+
+
+def test_write_forecast_audit_json_round_trips(tmp_path) -> None:
+    current = _payload_from_patterns("synth", 0)
+    h1 = _payload_from_patterns("synth", 1)
+    h5 = _payload_from_patterns("synth", 2)
+
+    row = build_symbol_audit_row(
+        symbol="synth",
+        asof="2026-05-15T14:30:00Z",
+        current_payload=current,
+        h1_payload=h1,
+        h5_payload=h5,
+    )
+
+    out = write_forecast_audit_json(
+        tmp_path / "forecast_audit.v1.json",
+        [row],
+        asof="2026-05-15T14:30:00Z",
+    )
+
+    loaded = json.loads(out.read_text(encoding="utf-8"))
+
+    assert loaded["schema"] == "forecast_audit.v1"
+    assert loaded["row_count"] == 1
+    assert loaded["rows"][0]["cells"]["A"]["token"] == "A=699:+1+++c"


### PR DESCRIPTION
## Summary

Adds a Forecast Audit v1 JSON export for the M45 GlyphSpec audit panel.

When the glyph audit overview is built, `mh_dev` now writes:

`~/.cache/jerboa/forecast_audit.v1.json`

The artifact includes:

- schema/version metadata
- `GlyphSpec v1`
- stable column contract: `Sym | A | B | C | D | E | ck`
- row count
- per-symbol held metadata
- canonical category tokens such as `A=699:+1+++c`
- display cells such as `699:+1+++c`
- decoded totals, fingerprints, patterns, validation state, and checksums

This uses the corrected absolute H1/H5 semantics from #393, so the exported glyph totals reconcile with the compact tri-score panel.

Closes #388.

## Testing

- `.venv-ci/bin/python -m pytest tests/test_glyph_spec.py tests/test_forecast_audit.py tests/test_glyph_audit_panel.py tests/test_forecast_blend_diagnostics.py tests/test_alert_snapshots.py -q`
- `.venv-ci/bin/python -m py_compile market_health/forecast_audit.py market_health/dashboard_legacy.py tests/test_forecast_audit.py`
- `.venv-ci/bin/ruff check market_health/forecast_audit.py market_health/dashboard_legacy.py tests/test_forecast_audit.py`
- `mh_dev >/tmp/mh_dev_forecast_audit_export.out`
- Verified `/root-dev/.cache/jerboa/forecast_audit.v1.json` loads as `forecast_audit.v1`