### PR TITLE
Handle alert refresh failures with last-known-good UI

### DIFF
--- a/market_health/alert_runner.py
+++ b/market_health/alert_runner.py
@@ -230,6 +230,9 @@ def run_once_alert_service(
 
     try:
         refresh_code = _run_refresh(config, refresh_fn)
+        refresh_details = {}
+        ui_doc = None
+
         if refresh_code != 0:
             message = f"refresh failed with exit code {refresh_code}"
             add_system_event(
@@ -241,22 +244,35 @@ def run_once_alert_service(
                 ts_utc=now_utc,
                 payload={"exit_code": refresh_code},
             )
-            finish_run(
-                db_path=config.db_path,
-                run_id=run_id,
-                status="failed",
-                finished_at_utc=now_utc,
-                details={"refresh_exit_code": refresh_code},
-                error_text=message,
-            )
-            return AlertRunResult(
-                exit_code=2, run_id=run_id, status="failed", error_text=message
-            )
+
+            try:
+                ui_doc = load_ui_doc(config.ui_path)
+            except Exception:
+                finish_run(
+                    db_path=config.db_path,
+                    run_id=run_id,
+                    status="failed",
+                    finished_at_utc=now_utc,
+                    details={
+                        "refresh_exit_code": refresh_code,
+                        "using_last_known_good_ui": False,
+                    },
+                    error_text=message,
+                )
+                return AlertRunResult(
+                    exit_code=2, run_id=run_id, status="failed", error_text=message
+                )
+
+            refresh_details = {
+                "refresh_exit_code": refresh_code,
+                "using_last_known_good_ui": True,
+            }
 
         previous = _read_previous_snapshots(
             db_path=config.db_path, before_run_id=run_id
         )
-        ui_doc = load_ui_doc(config.ui_path)
+        if ui_doc is None:
+            ui_doc = load_ui_doc(config.ui_path)
         current_snapshots = collect_held_position_snapshots(ui_doc, ts_utc=now_utc)
 
         row_ids = write_held_position_snapshots(
@@ -294,17 +310,20 @@ def run_once_alert_service(
                 **kwargs,
             )
 
+        details = {
+            "snapshots_written": len(row_ids),
+            "candidates": len(candidates),
+            "allowed": len(allowed),
+            "suppressed": len(suppressed),
+        }
+        details.update(refresh_details)
+
         finish_run(
             db_path=config.db_path,
             run_id=run_id,
             status="success",
             finished_at_utc=now_utc,
-            details={
-                "snapshots_written": len(row_ids),
-                "candidates": len(candidates),
-                "allowed": len(allowed),
-                "suppressed": len(suppressed),
-            },
+            details=details,
         )
         return AlertRunResult(
             exit_code=0,

--- a/tests/test_alert_runner.py
+++ b/tests/test_alert_runner.py
@@ -58,6 +58,16 @@ def _run_status(db: Path, run_id: int) -> str:
     return row[0]
 
 
+def _run_details(db: Path, run_id: int) -> dict:
+    conn = sqlite3.connect(str(db))
+    row = conn.execute(
+        "SELECT details_json FROM runs WHERE id = ?", (run_id,)
+    ).fetchone()
+    conn.close()
+    assert row is not None
+    return json.loads(row[0] or "{}")
+
+
 def test_runner_first_run_writes_snapshots_without_inventory_storm(
     tmp_path: Path,
 ) -> None:
@@ -140,7 +150,7 @@ def test_runner_records_forecast_divergence_alert_and_suppresses_duplicate(
     assert rows[0][1] == "held_forecast_divergence"
 
 
-def test_runner_refresh_failure_returns_exit_code_2(tmp_path: Path) -> None:
+def test_runner_refresh_failure_without_ui_returns_exit_code_2(tmp_path: Path) -> None:
     db = tmp_path / "alerts.sqlite"
     ui = tmp_path / "missing.json"
 
@@ -156,6 +166,31 @@ def test_runner_refresh_failure_returns_exit_code_2(tmp_path: Path) -> None:
     assert result.status == "failed"
     assert _run_status(db, result.run_id) == "failed"
     assert count_rows(db, "system_events") == 1
+
+
+def test_runner_refresh_failure_with_existing_ui_uses_last_known_good_artifact(
+    tmp_path: Path,
+) -> None:
+    db = tmp_path / "alerts.sqlite"
+    ui = tmp_path / "market_health.ui.v1.json"
+    _write_ui(ui, state="clean")
+
+    result = run_once_alert_service(
+        AlertRunnerConfig(
+            db_path=db, ui_path=ui, telegram_mode="disabled", no_refresh=False
+        ),
+        refresh_fn=lambda: 7,
+        now_utc="2026-05-01T15:00:00Z",
+    )
+
+    assert result.exit_code == 0
+    assert result.status == "success"
+    assert _run_status(db, result.run_id) == "success"
+    assert result.snapshots_written == 1
+    assert count_rows(db, "system_events") == 1
+    details = _run_details(db, result.run_id)
+    assert details["refresh_exit_code"] == 7
+    assert details["using_last_known_good_ui"] is True
 
 
 def test_runner_uses_injected_telegram_sender_in_test_mode(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Continue alert runs after refresh command failures when a usable UI artifact already exists.
- Record refresh failures as `refresh_failed` system events.
- Preserve hard failure behavior when refresh fails and no UI artifact can be loaded.
- Add regression coverage for both refresh-failure paths.

## Verification
- `.venv/bin/python -m py_compile market_health/alert_runner.py market_health/alert_store.py market_health/alert_detectors.py market_health/alert_snapshots.py market_health/telegram_notifier.py`
- `.venv/bin/python -m pytest tests/test_alert_cooldowns.py tests/test_alert_detectors.py tests/test_alert_runner.py tests/test_alert_snapshots.py tests/test_alert_status.py tests/test_alert_store.py tests/test_m43_systemd_templates.py tests/test_m44_held_alert_deterministic_coverage.py tests/test_telegram_notifier.py tests/test_telegram_notify_status_change_v0.py -q`
- `git diff --check`