### PR TITLE
Add calibration replay scaffold

### DIFF
--- a/market_health/calibration/__init__.py
+++ b/market_health/calibration/__init__.py
@@ -1,0 +1,11 @@
+"""Historical replay calibration support.
+
+This package is intentionally separate from the live runtime path.
+Replay outputs are written to isolated calibration artifact locations.
+"""
+
+__all__ = [
+    "defaults",
+    "engine_metadata",
+    "schema",
+]

--- a/market_health/calibration/cli.py
+++ b/market_health/calibration/cli.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from market_health.calibration.defaults import (
+    assert_not_live_runtime_path,
+    default_output_root,
+)
+from market_health.calibration.engine_metadata import capture_engine_metadata
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="market-health-calibration")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    doctor = subparsers.add_parser("doctor", help="Validate replay scaffold defaults.")
+    doctor.add_argument("--out", type=Path, default=default_output_root())
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    if args.command == "doctor":
+        output_root = args.out.expanduser()
+        assert_not_live_runtime_path(output_root)
+        payload = {
+            "status": "ok",
+            "output_root": str(output_root),
+            "engine": capture_engine_metadata(),
+        }
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0
+
+    raise AssertionError(f"unhandled command: {args.command}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/market_health/calibration/defaults.py
+++ b/market_health/calibration/defaults.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+DEFAULT_RELATIVE_OUTPUT_ROOT = Path("jerboa") / "calibration" / "m47"
+
+LIVE_RUNTIME_PATH_MARKERS = (
+    "/.cache/jerboa/positions",
+    "/.cache/jerboa/recommendations",
+    "/.cache/jerboa/forecast_scores",
+    "/.cache/jerboa/candidate",
+    "/.cache/jerboa/swap",
+    "/.cache/jerboa/dashboard",
+    "/.config/jerboa",
+)
+
+
+def default_output_root() -> Path:
+    """Return the default isolated calibration output root."""
+    xdg_cache_home = os.environ.get("XDG_CACHE_HOME")
+    base = Path(xdg_cache_home).expanduser() if xdg_cache_home else Path.home() / ".cache"
+    return base / DEFAULT_RELATIVE_OUTPUT_ROOT
+
+
+def assert_not_live_runtime_path(path: Path) -> None:
+    """Reject output paths that target live runtime or production state."""
+    resolved = path.expanduser().resolve()
+    text = str(resolved)
+
+    if any(marker in text for marker in LIVE_RUNTIME_PATH_MARKERS):
+        raise ValueError(
+            "calibration replay output must not target live runtime state: "
+            f"{resolved}"
+        )

--- a/market_health/calibration/defaults.py
+++ b/market_health/calibration/defaults.py
@@ -19,7 +19,11 @@ LIVE_RUNTIME_PATH_MARKERS = (
 def default_output_root() -> Path:
     """Return the default isolated calibration output root."""
     xdg_cache_home = os.environ.get("XDG_CACHE_HOME")
-    base = Path(xdg_cache_home).expanduser() if xdg_cache_home else Path.home() / ".cache"
+    base = (
+        Path(xdg_cache_home).expanduser()
+        if xdg_cache_home
+        else Path.home() / ".cache"
+    )
     return base / DEFAULT_RELATIVE_OUTPUT_ROOT
 
 

--- a/market_health/calibration/defaults.py
+++ b/market_health/calibration/defaults.py
@@ -20,9 +20,7 @@ def default_output_root() -> Path:
     """Return the default isolated calibration output root."""
     xdg_cache_home = os.environ.get("XDG_CACHE_HOME")
     base = (
-        Path(xdg_cache_home).expanduser()
-        if xdg_cache_home
-        else Path.home() / ".cache"
+        Path(xdg_cache_home).expanduser() if xdg_cache_home else Path.home() / ".cache"
     )
     return base / DEFAULT_RELATIVE_OUTPUT_ROOT
 
@@ -34,6 +32,5 @@ def assert_not_live_runtime_path(path: Path) -> None:
 
     if any(marker in text for marker in LIVE_RUNTIME_PATH_MARKERS):
         raise ValueError(
-            "calibration replay output must not target live runtime state: "
-            f"{resolved}"
+            f"calibration replay output must not target live runtime state: {resolved}"
         )

--- a/market_health/calibration/engine_metadata.py
+++ b/market_health/calibration/engine_metadata.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import subprocess
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class EngineMetadata:
+    schema_version: str
+    generated_at: str
+    repo_root: str
+    git_commit: str
+    git_dirty: bool
+
+
+def _git(repo_root: Path, *args: str) -> str:
+    try:
+        return subprocess.check_output(
+            ["git", "-C", str(repo_root), *args],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except Exception:
+        return "unknown"
+
+
+def capture_engine_metadata(repo_root: Path | None = None) -> dict[str, object]:
+    """Capture deterministic replay provenance metadata."""
+    root = (repo_root or Path.cwd()).resolve()
+    status = _git(root, "status", "--porcelain")
+    return asdict(
+        EngineMetadata(
+            schema_version="calibration_engine_metadata.v1",
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            repo_root=str(root),
+            git_commit=_git(root, "rev-parse", "HEAD"),
+            git_dirty=bool(status and status != "unknown"),
+        )
+    )

--- a/market_health/calibration/schema.py
+++ b/market_health/calibration/schema.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import date
+
+
+REPLAY_ARTIFACT_SCHEMA_VERSION = "calibration_replay_artifact.v1"
+
+
+@dataclass(frozen=True)
+class ReplayArtifactRow:
+    replay_date: date
+    symbol: str
+    current_score: float
+    h1_score: float
+    h5_score: float
+    blend_score: float
+    state: str
+    audit_token: str | None = None
+
+    def to_record(self) -> dict[str, object]:
+        record = asdict(self)
+        record["schema_version"] = REPLAY_ARTIFACT_SCHEMA_VERSION
+        record["replay_date"] = self.replay_date.isoformat()
+        return record

--- a/tests/test_calibration_scaffold.py
+++ b/tests/test_calibration_scaffold.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import os
+import tempfile
+import unittest
+from datetime import date
+from pathlib import Path
+from unittest import mock
+
+from market_health.calibration.cli import main
+from market_health.calibration.defaults import (
+    assert_not_live_runtime_path,
+    default_output_root,
+)
+from market_health.calibration.engine_metadata import capture_engine_metadata
+from market_health.calibration.schema import (
+    REPLAY_ARTIFACT_SCHEMA_VERSION,
+    ReplayArtifactRow,
+)
+
+
+class CalibrationScaffoldTest(unittest.TestCase):
+    def test_default_output_root_uses_isolated_calibration_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with mock.patch.dict(os.environ, {"XDG_CACHE_HOME": tmp}):
+                self.assertEqual(
+                    default_output_root(),
+                    Path(tmp) / "jerboa" / "calibration" / "m47",
+                )
+
+    def test_live_runtime_paths_are_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            blocked_paths = [
+                root / ".cache" / "jerboa" / "positions.v1.json",
+                root / ".cache" / "jerboa" / "recommendations.v1.json",
+                root / ".cache" / "jerboa" / "forecast_scores.v1.json",
+                root / ".config" / "jerboa" / "schwab_oauth.json",
+            ]
+
+            for path in blocked_paths:
+                with self.subTest(path=path):
+                    with self.assertRaises(ValueError):
+                        assert_not_live_runtime_path(path)
+
+    def test_engine_metadata_shape(self) -> None:
+        metadata = capture_engine_metadata()
+
+        self.assertEqual(
+            metadata["schema_version"],
+            "calibration_engine_metadata.v1",
+        )
+        self.assertIsInstance(metadata["generated_at"], str)
+        self.assertIsInstance(metadata["repo_root"], str)
+        self.assertIsInstance(metadata["git_commit"], str)
+        self.assertIsInstance(metadata["git_dirty"], bool)
+
+    def test_replay_artifact_row_record_shape(self) -> None:
+        row = ReplayArtifactRow(
+            replay_date=date(2026, 5, 22),
+            symbol="SPY",
+            current_score=8.0,
+            h1_score=8.5,
+            h5_score=7.5,
+            blend_score=8.1,
+            state="GREEN",
+            audit_token="A=888:111111",
+        )
+
+        record = row.to_record()
+
+        self.assertEqual(record["schema_version"], REPLAY_ARTIFACT_SCHEMA_VERSION)
+        self.assertEqual(record["replay_date"], "2026-05-22")
+        self.assertEqual(record["symbol"], "SPY")
+        self.assertEqual(record["audit_token"], "A=888:111111")
+
+    def test_doctor_outputs_json(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with mock.patch.dict(os.environ, {"XDG_CACHE_HOME": tmp}):
+                stdout = io.StringIO()
+                with contextlib.redirect_stdout(stdout):
+                    self.assertEqual(main(["doctor"]), 0)
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["status"], "ok")
+        self.assertTrue(payload["output_root"].endswith("jerboa/calibration/m47"))
+        self.assertEqual(
+            payload["engine"]["schema_version"],
+            "calibration_engine_metadata.v1",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds the initial calibration replay package, isolated output defaults, engine metadata capture, replay artifact row schema, and focused tests for live-runtime path isolation.

Refs #408
Refs #409
Refs #413