### PR TITLE
Add replay progress status artifact

### DIFF
--- a/market_health/calibration/status.py
+++ b/market_health/calibration/status.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from datetime import date, datetime, timezone
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+
+STATUS_SCHEMA_VERSION = "calibration_replay_status.v1"
+STATUS_FILENAME = "replay_status.json"
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass(frozen=True)
+class ReplayStatus:
+    schema_version: str
+    run_id: str
+    started_at: str
+    updated_at: str
+    current_stage: str
+    output_path: str
+    total_dates: int = 0
+    completed_dates: list[str] = field(default_factory=list)
+    current_replay_date: str | None = None
+    rows_written: int = 0
+    latest_checkpoint: str | None = None
+    errors: list[str] = field(default_factory=list)
+
+    def to_record(self) -> dict[str, object]:
+        return asdict(self)
+
+
+def new_replay_status(
+    *,
+    run_id: str,
+    output_path: Path,
+    total_dates: int = 0,
+    current_stage: str = "initialized",
+) -> ReplayStatus:
+    now = utc_now_iso()
+    return ReplayStatus(
+        schema_version=STATUS_SCHEMA_VERSION,
+        run_id=run_id,
+        started_at=now,
+        updated_at=now,
+        current_stage=current_stage,
+        output_path=str(output_path),
+        total_dates=total_dates,
+    )
+
+
+def status_path(output_root: Path) -> Path:
+    return output_root / STATUS_FILENAME
+
+
+def write_status(output_root: Path, status: ReplayStatus) -> Path:
+    output_root.mkdir(parents=True, exist_ok=True)
+    path = status_path(output_root)
+    payload = json.dumps(status.to_record(), indent=2, sort_keys=True) + "\n"
+
+    with NamedTemporaryFile(
+        "w",
+        encoding="utf-8",
+        dir=output_root,
+        prefix=f".{STATUS_FILENAME}.",
+        delete=False,
+    ) as tmp:
+        tmp.write(payload)
+        temp_path = Path(tmp.name)
+
+    temp_path.replace(path)
+    return path
+
+
+def read_status(output_root: Path) -> ReplayStatus:
+    payload = json.loads(status_path(output_root).read_text(encoding="utf-8"))
+    return ReplayStatus(**payload)
+
+
+def mark_date_started(status: ReplayStatus, replay_date: date) -> ReplayStatus:
+    return ReplayStatus(
+        **{
+            **status.to_record(),
+            "updated_at": utc_now_iso(),
+            "current_stage": "replaying_date",
+            "current_replay_date": replay_date.isoformat(),
+        }
+    )
+
+
+def mark_date_completed(
+    status: ReplayStatus,
+    replay_date: date,
+    *,
+    rows_written: int,
+    checkpoint_path: Path | None = None,
+) -> ReplayStatus:
+    replay_date_text = replay_date.isoformat()
+    completed_dates = list(status.completed_dates)
+    if replay_date_text not in completed_dates:
+        completed_dates.append(replay_date_text)
+
+    return ReplayStatus(
+        **{
+            **status.to_record(),
+            "updated_at": utc_now_iso(),
+            "current_stage": "checkpointed",
+            "current_replay_date": None,
+            "completed_dates": completed_dates,
+            "rows_written": status.rows_written + rows_written,
+            "latest_checkpoint": str(checkpoint_path) if checkpoint_path else None,
+        }
+    )
+
+
+def mark_failed(status: ReplayStatus, message: str) -> ReplayStatus:
+    return ReplayStatus(
+        **{
+            **status.to_record(),
+            "updated_at": utc_now_iso(),
+            "current_stage": "failed",
+            "errors": [*status.errors, message],
+        }
+    )

--- a/tests/test_calibration_status.py
+++ b/tests/test_calibration_status.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from datetime import date
+from pathlib import Path
+
+from market_health.calibration.status import (
+    STATUS_FILENAME,
+    STATUS_SCHEMA_VERSION,
+    mark_date_completed,
+    mark_date_started,
+    mark_failed,
+    new_replay_status,
+    read_status,
+    status_path,
+    write_status,
+)
+
+
+class ReplayStatusTest(unittest.TestCase):
+    def test_new_status_shape(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            output_root = Path(tmp)
+            status = new_replay_status(
+                run_id="run-001",
+                output_path=output_root,
+                total_dates=3,
+            )
+
+        self.assertEqual(status.schema_version, STATUS_SCHEMA_VERSION)
+        self.assertEqual(status.run_id, "run-001")
+        self.assertEqual(status.current_stage, "initialized")
+        self.assertEqual(status.total_dates, 3)
+        self.assertEqual(status.completed_dates, [])
+        self.assertEqual(status.rows_written, 0)
+        self.assertEqual(status.errors, [])
+
+    def test_status_path_uses_stable_filename(self) -> None:
+        self.assertEqual(
+            status_path(Path("/tmp/out")), Path("/tmp/out") / STATUS_FILENAME
+        )
+
+    def test_write_and_read_status_round_trip(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            output_root = Path(tmp)
+            status = new_replay_status(run_id="run-002", output_path=output_root)
+
+            written = write_status(output_root, status)
+            loaded = read_status(output_root)
+
+        self.assertEqual(written.name, STATUS_FILENAME)
+        self.assertEqual(loaded, status)
+
+    def test_written_status_is_pretty_sorted_json(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            output_root = Path(tmp)
+            status = new_replay_status(run_id="run-003", output_path=output_root)
+
+            written = write_status(output_root, status)
+            payload = json.loads(written.read_text(encoding="utf-8"))
+
+        self.assertEqual(payload["schema_version"], STATUS_SCHEMA_VERSION)
+        self.assertEqual(payload["run_id"], "run-003")
+
+    def test_mark_date_started(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            status = new_replay_status(run_id="run-004", output_path=Path(tmp))
+            updated = mark_date_started(status, date(2026, 5, 22))
+
+        self.assertEqual(updated.current_stage, "replaying_date")
+        self.assertEqual(updated.current_replay_date, "2026-05-22")
+        self.assertEqual(updated.completed_dates, [])
+
+    def test_mark_date_completed_is_idempotent_for_completed_date(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            status = new_replay_status(
+                run_id="run-005",
+                output_path=Path(tmp),
+                total_dates=1,
+            )
+            started = mark_date_started(status, date(2026, 5, 22))
+            completed_once = mark_date_completed(
+                started,
+                date(2026, 5, 22),
+                rows_written=10,
+                checkpoint_path=Path(tmp) / "checkpoint-001.json",
+            )
+            completed_twice = mark_date_completed(
+                completed_once,
+                date(2026, 5, 22),
+                rows_written=5,
+                checkpoint_path=Path(tmp) / "checkpoint-001.json",
+            )
+
+        self.assertEqual(completed_once.current_stage, "checkpointed")
+        self.assertIsNone(completed_once.current_replay_date)
+        self.assertEqual(completed_once.completed_dates, ["2026-05-22"])
+        self.assertEqual(completed_once.rows_written, 10)
+        self.assertEqual(completed_twice.completed_dates, ["2026-05-22"])
+        self.assertEqual(completed_twice.rows_written, 15)
+
+    def test_mark_failed_appends_errors(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            status = new_replay_status(run_id="run-006", output_path=Path(tmp))
+            failed = mark_failed(status, "fixture data unavailable")
+
+        self.assertEqual(failed.current_stage, "failed")
+        self.assertEqual(failed.errors, ["fixture data unavailable"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds the calibration replay status artifact model, atomic replay_status.json writes, checkpoint update helpers, failure status handling, and focused tests.

Refs #410