### PR TITLE
Add as-of replay runner scaffold

### DIFF
--- a/market_health/calibration/runner.py
+++ b/market_health/calibration/runner.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+
+from market_health.calibration.defaults import assert_not_live_runtime_path
+from market_health.calibration.engine_metadata import capture_engine_metadata
+from market_health.calibration.export import (
+    write_replay_rows_csv,
+    write_replay_rows_sqlite,
+)
+from market_health.calibration.schema import ReplayArtifactRow
+from market_health.calibration.status import (
+    ReplayStatus,
+    mark_date_completed,
+    mark_date_started,
+    new_replay_status,
+    write_status,
+)
+
+
+@dataclass(frozen=True)
+class ReplayRunResult:
+    output_root: Path
+    rows: list[ReplayArtifactRow]
+    status: ReplayStatus
+    csv_path: Path
+    sqlite_path: Path
+    engine_metadata: dict[str, object]
+
+
+def fixture_rows_for_date(
+    replay_date: date, symbols: list[str]
+) -> list[ReplayArtifactRow]:
+    rows: list[ReplayArtifactRow] = []
+    for index, symbol in enumerate(symbols):
+        current_score = 8.0 - index
+        h1_score = current_score + 0.5
+        h5_score = current_score - 0.5
+        rows.append(
+            ReplayArtifactRow(
+                replay_date=replay_date,
+                symbol=symbol,
+                current_score=current_score,
+                h1_score=h1_score,
+                h5_score=h5_score,
+                blend_score=current_score + 0.1,
+                state="GREEN" if current_score >= 8.0 else "YELLOW",
+                audit_token=None,
+            )
+        )
+    return rows
+
+
+def run_fixture_replay(
+    *,
+    output_root: Path,
+    replay_dates: list[date],
+    symbols: list[str],
+    run_id: str = "fixture-run",
+) -> ReplayRunResult:
+    """Run a deterministic fixture replay through the artifact pipeline."""
+    assert_not_live_runtime_path(output_root)
+
+    status = new_replay_status(
+        run_id=run_id,
+        output_path=output_root,
+        total_dates=len(replay_dates),
+    )
+    write_status(output_root, status)
+
+    rows: list[ReplayArtifactRow] = []
+    for replay_date in replay_dates:
+        status = mark_date_started(status, replay_date)
+        write_status(output_root, status)
+
+        date_rows = fixture_rows_for_date(replay_date, symbols)
+        rows.extend(date_rows)
+
+        checkpoint_path = (
+            output_root / "checkpoints" / f"{replay_date.isoformat()}.json"
+        )
+        checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
+        checkpoint_path.write_text(
+            "\n".join(row.symbol for row in date_rows) + "\n",
+            encoding="utf-8",
+        )
+
+        status = mark_date_completed(
+            status,
+            replay_date,
+            rows_written=len(date_rows),
+            checkpoint_path=checkpoint_path,
+        )
+        write_status(output_root, status)
+
+    csv_path = write_replay_rows_csv(output_root / "replay_rows.csv", rows)
+    sqlite_path = write_replay_rows_sqlite(output_root / "calibration.sqlite", rows)
+    engine_metadata = capture_engine_metadata()
+
+    return ReplayRunResult(
+        output_root=output_root,
+        rows=rows,
+        status=status,
+        csv_path=csv_path,
+        sqlite_path=sqlite_path,
+        engine_metadata=engine_metadata,
+    )

--- a/tests/test_calibration_runner.py
+++ b/tests/test_calibration_runner.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import csv
+import json
+import sqlite3
+import tempfile
+import unittest
+from datetime import date
+from pathlib import Path
+
+from market_health.calibration.runner import (
+    fixture_rows_for_date,
+    run_fixture_replay,
+)
+
+
+class CalibrationRunnerTest(unittest.TestCase):
+    def test_fixture_rows_for_date_are_deterministic(self) -> None:
+        rows = fixture_rows_for_date(date(2026, 5, 22), ["SPY", "QQQ"])
+
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[0].symbol, "SPY")
+        self.assertEqual(rows[0].current_score, 8.0)
+        self.assertEqual(rows[0].h1_score, 8.5)
+        self.assertEqual(rows[0].h5_score, 7.5)
+        self.assertEqual(rows[0].state, "GREEN")
+        self.assertEqual(rows[1].symbol, "QQQ")
+        self.assertEqual(rows[1].state, "YELLOW")
+
+    def test_run_fixture_replay_writes_status_and_exports(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            output_root = Path(tmp) / "calibration"
+            result = run_fixture_replay(
+                output_root=output_root,
+                replay_dates=[date(2026, 5, 21), date(2026, 5, 22)],
+                symbols=["SPY", "QQQ"],
+                run_id="test-run",
+            )
+
+            status_payload = json.loads(
+                (output_root / "replay_status.json").read_text(encoding="utf-8")
+            )
+            with result.csv_path.open(encoding="utf-8", newline="") as handle:
+                csv_rows = list(csv.DictReader(handle))
+            with sqlite3.connect(result.sqlite_path) as conn:
+                sqlite_count = conn.execute(
+                    "SELECT COUNT(*) FROM calibration_replay_rows"
+                ).fetchone()[0]
+
+        self.assertEqual(len(result.rows), 4)
+        self.assertEqual(result.status.completed_dates, ["2026-05-21", "2026-05-22"])
+        self.assertEqual(result.status.rows_written, 4)
+        self.assertEqual(status_payload["run_id"], "test-run")
+        self.assertEqual(status_payload["current_stage"], "checkpointed")
+        self.assertEqual(len(csv_rows), 4)
+        self.assertEqual(sqlite_count, 4)
+        self.assertEqual(
+            result.engine_metadata["schema_version"], "calibration_engine_metadata.v1"
+        )
+
+    def test_run_fixture_replay_rejects_live_runtime_output(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            output_root = Path(tmp) / ".cache" / "jerboa" / "positions.v1.json"
+            with self.assertRaises(ValueError):
+                run_fixture_replay(
+                    output_root=output_root,
+                    replay_dates=[date(2026, 5, 22)],
+                    symbols=["SPY"],
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a deterministic fixture replay runner that wires replay rows, status updates, checkpoint files, CSV export, SQLite export, engine metadata, and output-path isolation.

Refs #409
Refs #413