### PR TITLE
Add replay warmup window resolver

### DIFF
--- a/market_health/calibration/warmup_window.py
+++ b/market_health/calibration/warmup_window.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Iterable
+
+from market_health.calibration.price_cache import HistoricalPriceRow
+
+
+@dataclass(frozen=True)
+class ReplayWarmupWindow:
+    replay_date: date
+    lookback_rows: int
+    rows: tuple[HistoricalPriceRow, ...]
+    requested_symbols: tuple[str, ...]
+    available_symbols: tuple[str, ...]
+    missing_symbols: tuple[str, ...]
+    start_date: date | None
+    end_date: date
+
+    @property
+    def row_count(self) -> int:
+        return len(self.rows)
+
+
+def resolve_replay_warmup_window(
+    rows: Iterable[HistoricalPriceRow],
+    *,
+    replay_date: date,
+    lookback_rows: int,
+    symbols: Iterable[str] | None = None,
+) -> ReplayWarmupWindow:
+    """Select the last N available rows per symbol on or before replay date."""
+    if lookback_rows <= 0:
+        raise ValueError("lookback_rows must be positive")
+
+    requested_symbols = _normalize_symbols(symbols)
+    grouped: dict[str, list[HistoricalPriceRow]] = {}
+
+    for row in rows:
+        if row.date > replay_date:
+            continue
+        if requested_symbols and row.symbol not in requested_symbols:
+            continue
+        grouped.setdefault(row.symbol, []).append(row)
+
+    selected_rows: list[HistoricalPriceRow] = []
+    for symbol in sorted(grouped):
+        symbol_rows = sorted(grouped[symbol], key=lambda item: item.date)
+        selected_rows.extend(symbol_rows[-lookback_rows:])
+
+    resolved_rows = tuple(
+        sorted(selected_rows, key=lambda item: (item.symbol, item.date))
+    )
+    available_symbols = tuple(sorted(grouped))
+    missing_symbols = tuple(
+        symbol for symbol in requested_symbols if symbol not in available_symbols
+    )
+    start_date = min((row.date for row in resolved_rows), default=None)
+
+    return ReplayWarmupWindow(
+        replay_date=replay_date,
+        lookback_rows=lookback_rows,
+        rows=resolved_rows,
+        requested_symbols=requested_symbols,
+        available_symbols=available_symbols,
+        missing_symbols=missing_symbols,
+        start_date=start_date,
+        end_date=replay_date,
+    )
+
+
+def _normalize_symbols(symbols: Iterable[str] | None) -> tuple[str, ...]:
+    if symbols is None:
+        return ()
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for symbol in symbols:
+        value = symbol.strip().upper()
+        if not value or value in seen:
+            continue
+        normalized.append(value)
+        seen.add(value)
+
+    return tuple(normalized)

--- a/tests/test_calibration_warmup_window.py
+++ b/tests/test_calibration_warmup_window.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import unittest
+from datetime import date
+
+from market_health.calibration.price_cache import HistoricalPriceRow
+from market_health.calibration.warmup_window import (
+    resolve_replay_warmup_window,
+)
+
+
+class ReplayWarmupWindowTest(unittest.TestCase):
+    def test_resolver_uses_last_rows_on_or_before_replay_date(self) -> None:
+        rows = [
+            _row("SPY", date(2026, 5, 18), 100.0),
+            _row("SPY", date(2026, 5, 20), 101.0),
+            _row("SPY", date(2026, 5, 22), 102.0),
+            _row("SPY", date(2026, 5, 26), 103.0),
+        ]
+
+        window = resolve_replay_warmup_window(
+            rows,
+            replay_date=date(2026, 5, 22),
+            lookback_rows=2,
+            symbols=["SPY"],
+        )
+
+        self.assertEqual(
+            [(row.symbol, row.date.isoformat()) for row in window.rows],
+            [("SPY", "2026-05-20"), ("SPY", "2026-05-22")],
+        )
+        self.assertEqual(window.start_date, date(2026, 5, 20))
+        self.assertEqual(window.end_date, date(2026, 5, 22))
+        self.assertEqual(window.row_count, 2)
+
+    def test_resolver_handles_sparse_calendar_by_available_rows(self) -> None:
+        rows = [
+            _row("SPY", date(2026, 5, 1), 100.0),
+            _row("SPY", date(2026, 5, 8), 101.0),
+            _row("SPY", date(2026, 5, 22), 102.0),
+        ]
+
+        window = resolve_replay_warmup_window(
+            rows,
+            replay_date=date(2026, 5, 22),
+            lookback_rows=2,
+            symbols=["SPY"],
+        )
+
+        self.assertEqual(
+            [row.date for row in window.rows],
+            [date(2026, 5, 8), date(2026, 5, 22)],
+        )
+
+    def test_resolver_filters_symbols_and_reports_missing(self) -> None:
+        rows = [
+            _row("QQQ", date(2026, 5, 22), 200.0),
+            _row("SPY", date(2026, 5, 22), 100.0),
+        ]
+
+        window = resolve_replay_warmup_window(
+            rows,
+            replay_date=date(2026, 5, 22),
+            lookback_rows=3,
+            symbols=["SPY", "IWM"],
+        )
+
+        self.assertEqual(window.available_symbols, ("SPY",))
+        self.assertEqual(window.missing_symbols, ("IWM",))
+        self.assertEqual(
+            [(row.symbol, row.date.isoformat()) for row in window.rows],
+            [("SPY", "2026-05-22")],
+        )
+
+    def test_resolver_orders_rows_by_symbol_then_date(self) -> None:
+        rows = [
+            _row("SPY", date(2026, 5, 22), 100.0),
+            _row("QQQ", date(2026, 5, 22), 200.0),
+            _row("SPY", date(2026, 5, 21), 99.0),
+            _row("QQQ", date(2026, 5, 21), 199.0),
+        ]
+
+        window = resolve_replay_warmup_window(
+            rows,
+            replay_date=date(2026, 5, 22),
+            lookback_rows=2,
+        )
+
+        self.assertEqual(
+            [(row.symbol, row.date.isoformat()) for row in window.rows],
+            [
+                ("QQQ", "2026-05-21"),
+                ("QQQ", "2026-05-22"),
+                ("SPY", "2026-05-21"),
+                ("SPY", "2026-05-22"),
+            ],
+        )
+
+    def test_resolver_rejects_non_positive_lookback(self) -> None:
+        with self.assertRaisesRegex(ValueError, "lookback_rows must be positive"):
+            resolve_replay_warmup_window(
+                [],
+                replay_date=date(2026, 5, 22),
+                lookback_rows=0,
+            )
+
+
+def _row(symbol: str, price_date: date, close: float) -> HistoricalPriceRow:
+    return HistoricalPriceRow(
+        symbol=symbol,
+        date=price_date,
+        open=close - 1.0,
+        high=close + 1.0,
+        low=close - 2.0,
+        close=close,
+        adjusted_close=close,
+        volume=1000,
+    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds the M48 replay warm-up window resolver with deterministic symbol/date ordering, sparse-calendar handling, missing-symbol reporting, and no-future-leakage fixture coverage.

Refs #422
Refs #423