### PR TITLE
Add market data diagnostics to fixture replay

### DIFF
--- a/market_health/calibration/market_data.py
+++ b/market_health/calibration/market_data.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+from market_health.calibration.defaults import assert_not_live_runtime_path
+from market_health.calibration.warmup_window import ReplayWarmupWindow
+
+MARKET_DATA_DIAGNOSTICS_SCHEMA_VERSION = "calibration_market_data_diagnostics.v1"
+
+
+@dataclass(frozen=True)
+class MarketDataSymbolDiagnostic:
+    symbol: str
+    available_rows: int
+    has_replay_date_row: bool
+    is_missing_symbol: bool
+    is_partial_warmup: bool
+
+    def to_record(self) -> dict[str, object]:
+        return {
+            "symbol": self.symbol,
+            "available_rows": self.available_rows,
+            "has_replay_date_row": self.has_replay_date_row,
+            "is_missing_symbol": self.is_missing_symbol,
+            "is_partial_warmup": self.is_partial_warmup,
+        }
+
+
+@dataclass(frozen=True)
+class MarketDataDiagnostics:
+    replay_date: date
+    lookback_rows: int
+    requested_symbols: tuple[str, ...]
+    available_symbols: tuple[str, ...]
+    missing_symbols: tuple[str, ...]
+    missing_replay_date_symbols: tuple[str, ...]
+    partial_warmup_symbols: tuple[str, ...]
+    symbols: tuple[MarketDataSymbolDiagnostic, ...]
+    schema_version: str = MARKET_DATA_DIAGNOSTICS_SCHEMA_VERSION
+
+    def to_record(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "replay_date": self.replay_date.isoformat(),
+            "lookback_rows": self.lookback_rows,
+            "requested_symbols": list(self.requested_symbols),
+            "available_symbols": list(self.available_symbols),
+            "missing_symbols": list(self.missing_symbols),
+            "missing_replay_date_symbols": list(self.missing_replay_date_symbols),
+            "partial_warmup_symbols": list(self.partial_warmup_symbols),
+            "symbols": [symbol.to_record() for symbol in self.symbols],
+        }
+
+
+def build_market_data_diagnostics(
+    window: ReplayWarmupWindow,
+) -> MarketDataDiagnostics:
+    requested_symbols = window.requested_symbols or window.available_symbols
+    rows_by_symbol = {
+        symbol: tuple(row for row in window.rows if row.symbol == symbol)
+        for symbol in requested_symbols
+    }
+
+    symbol_diagnostics: list[MarketDataSymbolDiagnostic] = []
+    missing_replay_date_symbols: list[str] = []
+    partial_warmup_symbols: list[str] = []
+
+    for symbol in requested_symbols:
+        symbol_rows = rows_by_symbol.get(symbol, ())
+        available_rows = len(symbol_rows)
+        has_replay_date_row = any(row.date == window.replay_date for row in symbol_rows)
+        is_missing_symbol = symbol in window.missing_symbols
+        is_partial_warmup = available_rows > 0 and available_rows < window.lookback_rows
+
+        if not has_replay_date_row:
+            missing_replay_date_symbols.append(symbol)
+        if is_partial_warmup:
+            partial_warmup_symbols.append(symbol)
+
+        symbol_diagnostics.append(
+            MarketDataSymbolDiagnostic(
+                symbol=symbol,
+                available_rows=available_rows,
+                has_replay_date_row=has_replay_date_row,
+                is_missing_symbol=is_missing_symbol,
+                is_partial_warmup=is_partial_warmup,
+            )
+        )
+
+    return MarketDataDiagnostics(
+        replay_date=window.replay_date,
+        lookback_rows=window.lookback_rows,
+        requested_symbols=requested_symbols,
+        available_symbols=window.available_symbols,
+        missing_symbols=window.missing_symbols,
+        missing_replay_date_symbols=tuple(missing_replay_date_symbols),
+        partial_warmup_symbols=tuple(partial_warmup_symbols),
+        symbols=tuple(symbol_diagnostics),
+    )
+
+
+def market_data_diagnostics_path(output_root: Path, replay_date: date) -> Path:
+    return output_root / "market_data_diagnostics" / f"{replay_date.isoformat()}.json"
+
+
+def write_market_data_diagnostics(
+    path: Path,
+    diagnostics: MarketDataDiagnostics,
+) -> Path:
+    assert_not_live_runtime_path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    with NamedTemporaryFile(
+        "w",
+        delete=False,
+        dir=path.parent,
+        encoding="utf-8",
+    ) as handle:
+        json.dump(diagnostics.to_record(), handle, indent=2, sort_keys=True)
+        handle.write("\n")
+        temp_path = Path(handle.name)
+
+    temp_path.replace(path)
+    return path

--- a/market_health/calibration/runner.py
+++ b/market_health/calibration/runner.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
+from typing import Iterable
 
 from market_health.calibration.defaults import assert_not_live_runtime_path
 from market_health.calibration.engine_metadata import capture_engine_metadata
@@ -18,6 +19,14 @@ from market_health.calibration.status import (
     new_replay_status,
     write_status,
 )
+
+from market_health.calibration.market_data import (
+    build_market_data_diagnostics,
+    market_data_diagnostics_path,
+    write_market_data_diagnostics,
+)
+from market_health.calibration.price_cache import HistoricalPriceRow
+from market_health.calibration.warmup_window import resolve_replay_warmup_window
 
 
 @dataclass(frozen=True)
@@ -107,3 +116,61 @@ def run_fixture_replay(
         sqlite_path=sqlite_path,
         engine_metadata=engine_metadata,
     )
+
+
+def run_fixture_market_data_replay(
+    output_root: Path,
+    replay_dates: Iterable[date],
+    symbols: Iterable[str],
+    price_rows: Iterable[HistoricalPriceRow],
+    *,
+    lookback_rows: int,
+    run_id: str = "fixture-market-data-run",
+) -> ReplayRunResult:
+    """Run fixture replay from historical market-data availability."""
+    replay_date_tuple = tuple(replay_dates)
+    requested_symbols = _normalize_market_data_symbols(symbols)
+    price_row_tuple = tuple(price_rows)
+
+    replay_symbols: set[str] = set()
+    diagnostics_paths: list[Path] = []
+
+    for replay_date in replay_date_tuple:
+        window = resolve_replay_warmup_window(
+            price_row_tuple,
+            replay_date=replay_date,
+            lookback_rows=lookback_rows,
+            symbols=requested_symbols,
+        )
+        diagnostics = build_market_data_diagnostics(window)
+        for symbol in diagnostics.symbols:
+            if symbol.has_replay_date_row:
+                replay_symbols.add(symbol.symbol)
+
+        diagnostics_path = market_data_diagnostics_path(
+            output_root,
+            replay_date,
+        )
+        write_market_data_diagnostics(diagnostics_path, diagnostics)
+        diagnostics_paths.append(diagnostics_path)
+
+    result = run_fixture_replay(
+        output_root=output_root,
+        replay_dates=replay_date_tuple,
+        symbols=tuple(sorted(replay_symbols)),
+        run_id=run_id,
+    )
+
+    return result
+
+
+def _normalize_market_data_symbols(symbols: Iterable[str]) -> tuple[str, ...]:
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for symbol in symbols:
+        value = symbol.strip().upper()
+        if not value or value in seen:
+            continue
+        normalized.append(value)
+        seen.add(value)
+    return tuple(normalized)

--- a/tests/test_calibration_market_data.py
+++ b/tests/test_calibration_market_data.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import csv
+import json
+import tempfile
+import unittest
+from datetime import date
+from pathlib import Path
+
+from market_health.calibration.market_data import (
+    build_market_data_diagnostics,
+    market_data_diagnostics_path,
+    write_market_data_diagnostics,
+)
+from market_health.calibration.price_cache import HistoricalPriceRow
+from market_health.calibration.runner import run_fixture_market_data_replay
+from market_health.calibration.warmup_window import (
+    resolve_replay_warmup_window,
+)
+
+
+class MarketDataDiagnosticsTest(unittest.TestCase):
+    def test_diagnostics_report_missing_and_partial_data(self) -> None:
+        window = resolve_replay_warmup_window(
+            [
+                _row("SPY", date(2026, 5, 21), 101.0),
+                _row("SPY", date(2026, 5, 22), 102.0),
+                _row("QQQ", date(2026, 5, 21), 201.0),
+                _row("IWM", date(2026, 5, 23), 51.0),
+            ],
+            replay_date=date(2026, 5, 22),
+            lookback_rows=2,
+            symbols=["SPY", "QQQ", "IWM"],
+        )
+
+        diagnostics = build_market_data_diagnostics(window)
+
+        self.assertEqual(diagnostics.available_symbols, ("QQQ", "SPY"))
+        self.assertEqual(diagnostics.missing_symbols, ("IWM",))
+        self.assertEqual(
+            diagnostics.missing_replay_date_symbols,
+            ("QQQ", "IWM"),
+        )
+        self.assertEqual(diagnostics.partial_warmup_symbols, ("QQQ",))
+        self.assertEqual(
+            [
+                (
+                    item.symbol,
+                    item.available_rows,
+                    item.has_replay_date_row,
+                    item.is_missing_symbol,
+                    item.is_partial_warmup,
+                )
+                for item in diagnostics.symbols
+            ],
+            [
+                ("SPY", 2, True, False, False),
+                ("QQQ", 1, False, False, True),
+                ("IWM", 0, False, True, False),
+            ],
+        )
+
+    def test_diagnostics_writer_outputs_stable_json(self) -> None:
+        window = resolve_replay_warmup_window(
+            [_row("SPY", date(2026, 5, 22), 102.0)],
+            replay_date=date(2026, 5, 22),
+            lookback_rows=1,
+            symbols=["SPY"],
+        )
+        diagnostics = build_market_data_diagnostics(window)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = market_data_diagnostics_path(
+                Path(tmp),
+                date(2026, 5, 22),
+            )
+            write_market_data_diagnostics(path, diagnostics)
+            payload = json.loads(path.read_text(encoding="utf-8"))
+
+        self.assertEqual(
+            payload["schema_version"],
+            "calibration_market_data_diagnostics.v1",
+        )
+        self.assertEqual(payload["replay_date"], "2026-05-22")
+        self.assertEqual(payload["missing_symbols"], [])
+
+    def test_runner_uses_fixture_market_data_availability(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            output_root = Path(tmp) / "calibration"
+            result = run_fixture_market_data_replay(
+                output_root=output_root,
+                replay_dates=[date(2026, 5, 22)],
+                symbols=["SPY", "QQQ", "IWM"],
+                price_rows=[
+                    _row("SPY", date(2026, 5, 21), 101.0),
+                    _row("SPY", date(2026, 5, 22), 102.0),
+                    _row("QQQ", date(2026, 5, 21), 201.0),
+                    _row("IWM", date(2026, 5, 23), 51.0),
+                ],
+                lookback_rows=2,
+            )
+
+            with result.csv_path.open(newline="", encoding="utf-8") as handle:
+                csv_rows = list(csv.DictReader(handle))
+
+            diagnostics_payload = json.loads(
+                market_data_diagnostics_path(
+                    output_root,
+                    date(2026, 5, 22),
+                ).read_text(encoding="utf-8")
+            )
+
+        self.assertEqual(len(csv_rows), 1)
+        self.assertEqual([row["symbol"] for row in csv_rows], ["SPY"])
+        self.assertEqual(
+            diagnostics_payload["missing_replay_date_symbols"],
+            ["QQQ", "IWM"],
+        )
+        self.assertEqual(diagnostics_payload["partial_warmup_symbols"], ["QQQ"])
+
+
+def _row(symbol: str, price_date: date, close: float) -> HistoricalPriceRow:
+    return HistoricalPriceRow(
+        symbol=symbol,
+        date=price_date,
+        open=close - 1.0,
+        high=close + 1.0,
+        low=close - 2.0,
+        close=close,
+        adjusted_close=close,
+        volume=1000,
+    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds M48 market-data diagnostics for missing symbols, missing replay-date rows, partial warm-up windows, and a fixture market-data replay runner path.

Refs #424
Refs #425