### PR TITLE
Add single-date as-of input bundle

### DIFF
--- a/market_health/calibration/asof_inputs.py
+++ b/market_health/calibration/asof_inputs.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Iterable
+
+from market_health.calibration.market_data import (
+    MarketDataDiagnostics,
+    build_market_data_diagnostics,
+)
+from market_health.calibration.price_cache import HistoricalPriceRow
+from market_health.calibration.warmup_window import (
+    ReplayWarmupWindow,
+    resolve_replay_warmup_window,
+)
+
+ASOF_INPUT_BUNDLE_SCHEMA_VERSION = "calibration_asof_input_bundle.v1"
+
+
+@dataclass(frozen=True)
+class AsOfInputBundle:
+    replay_date: date
+    lookback_rows: int
+    requested_symbols: tuple[str, ...]
+    eligible_symbols: tuple[str, ...]
+    price_rows: tuple[HistoricalPriceRow, ...]
+    warmup_window: ReplayWarmupWindow
+    market_data_diagnostics: MarketDataDiagnostics
+    excluded_future_row_count: int
+    schema_version: str = ASOF_INPUT_BUNDLE_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if self.schema_version != ASOF_INPUT_BUNDLE_SCHEMA_VERSION:
+            raise ValueError(
+                f"unsupported as-of input bundle schema version: {self.schema_version}"
+            )
+        if any(row.date > self.replay_date for row in self.price_rows):
+            raise ValueError("as-of input bundle cannot contain future rows")
+
+    @property
+    def row_count(self) -> int:
+        return len(self.price_rows)
+
+    def to_record(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "replay_date": self.replay_date.isoformat(),
+            "lookback_rows": self.lookback_rows,
+            "requested_symbols": list(self.requested_symbols),
+            "eligible_symbols": list(self.eligible_symbols),
+            "row_count": self.row_count,
+            "excluded_future_row_count": self.excluded_future_row_count,
+            "market_data_diagnostics": self.market_data_diagnostics.to_record(),
+        }
+
+
+def build_asof_input_bundle(
+    *,
+    replay_date: date,
+    symbols: Iterable[str],
+    price_rows: Iterable[HistoricalPriceRow],
+    lookback_rows: int,
+) -> AsOfInputBundle:
+    requested_symbols = _normalize_symbols(symbols)
+    source_rows = tuple(price_rows)
+    excluded_future_row_count = sum(
+        1
+        for row in source_rows
+        if row.date > replay_date
+        and (not requested_symbols or row.symbol in requested_symbols)
+    )
+
+    warmup_window = resolve_replay_warmup_window(
+        source_rows,
+        replay_date=replay_date,
+        lookback_rows=lookback_rows,
+        symbols=requested_symbols,
+    )
+    diagnostics = build_market_data_diagnostics(warmup_window)
+    eligible_symbols = tuple(
+        item.symbol for item in diagnostics.symbols if item.has_replay_date_row
+    )
+
+    return AsOfInputBundle(
+        replay_date=replay_date,
+        lookback_rows=lookback_rows,
+        requested_symbols=requested_symbols,
+        eligible_symbols=eligible_symbols,
+        price_rows=warmup_window.rows,
+        warmup_window=warmup_window,
+        market_data_diagnostics=diagnostics,
+        excluded_future_row_count=excluded_future_row_count,
+    )
+
+
+def _normalize_symbols(symbols: Iterable[str]) -> tuple[str, ...]:
+    normalized: list[str] = []
+    seen: set[str] = set()
+
+    for symbol in symbols:
+        value = symbol.strip().upper()
+        if not value or value in seen:
+            continue
+        normalized.append(value)
+        seen.add(value)
+
+    return tuple(normalized)

--- a/tests/test_calibration_asof_inputs.py
+++ b/tests/test_calibration_asof_inputs.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import unittest
+from datetime import date
+
+from market_health.calibration.asof_inputs import (
+    ASOF_INPUT_BUNDLE_SCHEMA_VERSION,
+    AsOfInputBundle,
+    build_asof_input_bundle,
+)
+from market_health.calibration.price_cache import HistoricalPriceRow
+
+
+class AsOfInputBundleTest(unittest.TestCase):
+    def test_bundle_filters_future_rows_and_reports_diagnostics(self) -> None:
+        bundle = build_asof_input_bundle(
+            replay_date=date(2026, 5, 22),
+            symbols=["spy", "QQQ", "IWM"],
+            price_rows=[
+                _row("SPY", date(2026, 5, 20), 100.0),
+                _row("SPY", date(2026, 5, 21), 101.0),
+                _row("SPY", date(2026, 5, 22), 102.0),
+                _row("SPY", date(2026, 5, 23), 103.0),
+                _row("QQQ", date(2026, 5, 21), 201.0),
+                _row("IWM", date(2026, 5, 23), 51.0),
+            ],
+            lookback_rows=2,
+        )
+
+        self.assertEqual(bundle.requested_symbols, ("SPY", "QQQ", "IWM"))
+        self.assertEqual(bundle.eligible_symbols, ("SPY",))
+        self.assertEqual(bundle.excluded_future_row_count, 2)
+        self.assertTrue(all(row.date <= date(2026, 5, 22) for row in bundle.price_rows))
+        self.assertEqual(
+            [(row.symbol, row.date.isoformat()) for row in bundle.price_rows],
+            [
+                ("QQQ", "2026-05-21"),
+                ("SPY", "2026-05-21"),
+                ("SPY", "2026-05-22"),
+            ],
+        )
+        self.assertEqual(bundle.market_data_diagnostics.missing_symbols, ("IWM",))
+        self.assertEqual(
+            bundle.market_data_diagnostics.missing_replay_date_symbols,
+            ("QQQ", "IWM"),
+        )
+        self.assertEqual(
+            bundle.market_data_diagnostics.partial_warmup_symbols,
+            ("QQQ",),
+        )
+
+    def test_bundle_record_has_stable_shape(self) -> None:
+        bundle = build_asof_input_bundle(
+            replay_date=date(2026, 5, 22),
+            symbols=["SPY"],
+            price_rows=[
+                _row("SPY", date(2026, 5, 21), 101.0),
+                _row("SPY", date(2026, 5, 22), 102.0),
+            ],
+            lookback_rows=2,
+        )
+
+        record = bundle.to_record()
+
+        self.assertEqual(
+            record["schema_version"],
+            ASOF_INPUT_BUNDLE_SCHEMA_VERSION,
+        )
+        self.assertEqual(record["replay_date"], "2026-05-22")
+        self.assertEqual(record["requested_symbols"], ["SPY"])
+        self.assertEqual(record["eligible_symbols"], ["SPY"])
+        self.assertEqual(record["row_count"], 2)
+        self.assertIn("market_data_diagnostics", record)
+
+    def test_bundle_rejects_future_rows_if_constructed_directly(self) -> None:
+        source = build_asof_input_bundle(
+            replay_date=date(2026, 5, 22),
+            symbols=["SPY"],
+            price_rows=[_row("SPY", date(2026, 5, 22), 102.0)],
+            lookback_rows=1,
+        )
+
+        with self.assertRaisesRegex(ValueError, "future rows"):
+            AsOfInputBundle(
+                replay_date=source.replay_date,
+                lookback_rows=source.lookback_rows,
+                requested_symbols=source.requested_symbols,
+                eligible_symbols=source.eligible_symbols,
+                price_rows=(_row("SPY", date(2026, 5, 23), 103.0),),
+                warmup_window=source.warmup_window,
+                market_data_diagnostics=source.market_data_diagnostics,
+                excluded_future_row_count=1,
+            )
+
+
+def _row(symbol: str, price_date: date, close: float) -> HistoricalPriceRow:
+    return HistoricalPriceRow(
+        symbol=symbol,
+        date=price_date,
+        open=close - 1.0,
+        high=close + 1.0,
+        low=close - 2.0,
+        close=close,
+        adjusted_close=close,
+        volume=1000,
+    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds the M49 single-date as-of input bundle with warm-up window resolution, market-data diagnostics, eligible-symbol selection, and explicit future-row exclusion.

Refs #430