### PR TITLE
Add range replay request model

### DIFF
--- a/market_health/calibration/range_request.py
+++ b/market_health/calibration/range_request.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Iterable
+
+from market_health.calibration.defaults import assert_not_live_runtime_path
+
+RANGE_REPLAY_REQUEST_SCHEMA_VERSION = "calibration_range_replay_request.v1"
+
+RANGE_REPLAY_REQUEST_COLUMNS = (
+    "schema_version",
+    "start_date",
+    "end_date",
+    "date_count",
+    "symbols",
+    "lookback_rows",
+    "output_root",
+)
+
+
+@dataclass(frozen=True)
+class RangeReplayRequest:
+    start_date: date
+    end_date: date
+    symbols: tuple[str, ...]
+    lookback_rows: int
+    output_root: Path
+    schema_version: str = RANGE_REPLAY_REQUEST_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if self.schema_version != RANGE_REPLAY_REQUEST_SCHEMA_VERSION:
+            raise ValueError(
+                f"unsupported range replay request schema version: {self.schema_version}"
+            )
+        if self.start_date > self.end_date:
+            raise ValueError("range replay start date must be on or before end date")
+        if self.lookback_rows <= 0:
+            raise ValueError("range replay lookback_rows must be positive")
+
+        normalized_symbols = normalize_range_symbols(self.symbols)
+        if not normalized_symbols:
+            raise ValueError("range replay request requires at least one symbol")
+
+        output_root = Path(self.output_root)
+        assert_not_live_runtime_path(output_root)
+
+        object.__setattr__(self, "symbols", normalized_symbols)
+        object.__setattr__(self, "output_root", output_root)
+
+    @property
+    def replay_dates(self) -> tuple[date, ...]:
+        return tuple(iter_replay_dates(self.start_date, self.end_date))
+
+    @property
+    def date_count(self) -> int:
+        return len(self.replay_dates)
+
+    def to_record(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "start_date": self.start_date.isoformat(),
+            "end_date": self.end_date.isoformat(),
+            "date_count": self.date_count,
+            "symbols": list(self.symbols),
+            "lookback_rows": self.lookback_rows,
+            "output_root": str(self.output_root),
+        }
+
+
+def build_range_replay_request(
+    *,
+    start_date: date,
+    end_date: date,
+    symbols: Iterable[str],
+    lookback_rows: int,
+    output_root: Path,
+) -> RangeReplayRequest:
+    return RangeReplayRequest(
+        start_date=start_date,
+        end_date=end_date,
+        symbols=normalize_range_symbols(symbols),
+        lookback_rows=lookback_rows,
+        output_root=output_root,
+    )
+
+
+def iter_replay_dates(start_date: date, end_date: date) -> Iterable[date]:
+    if start_date > end_date:
+        raise ValueError("range replay start date must be on or before end date")
+
+    current = start_date
+    while current <= end_date:
+        yield current
+        current += timedelta(days=1)
+
+
+def normalize_range_symbols(symbols: Iterable[str]) -> tuple[str, ...]:
+    normalized: list[str] = []
+    seen: set[str] = set()
+
+    for symbol in symbols:
+        value = symbol.strip().upper()
+        if not value or value in seen:
+            continue
+        normalized.append(value)
+        seen.add(value)
+
+    return tuple(normalized)

--- a/tests/test_calibration_range_request.py
+++ b/tests/test_calibration_range_request.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from datetime import date
+from pathlib import Path
+
+from market_health.calibration.range_request import (
+    RANGE_REPLAY_REQUEST_COLUMNS,
+    RANGE_REPLAY_REQUEST_SCHEMA_VERSION,
+    RangeReplayRequest,
+    build_range_replay_request,
+    iter_replay_dates,
+    normalize_range_symbols,
+)
+
+
+class RangeReplayRequestTest(unittest.TestCase):
+    def test_request_record_has_stable_shape(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            request = build_range_replay_request(
+                start_date=date(2026, 5, 20),
+                end_date=date(2026, 5, 22),
+                symbols=["spy", "QQQ", "spy", ""],
+                lookback_rows=5,
+                output_root=Path(tmp) / "calibration",
+            )
+
+        record = request.to_record()
+
+        self.assertEqual(tuple(record), RANGE_REPLAY_REQUEST_COLUMNS)
+        self.assertEqual(record["schema_version"], RANGE_REPLAY_REQUEST_SCHEMA_VERSION)
+        self.assertEqual(record["start_date"], "2026-05-20")
+        self.assertEqual(record["end_date"], "2026-05-22")
+        self.assertEqual(record["date_count"], 3)
+        self.assertEqual(record["symbols"], ["SPY", "QQQ"])
+        self.assertEqual(record["lookback_rows"], 5)
+
+    def test_iter_replay_dates_is_inclusive_and_deterministic(self) -> None:
+        self.assertEqual(
+            tuple(iter_replay_dates(date(2026, 5, 20), date(2026, 5, 22))),
+            (
+                date(2026, 5, 20),
+                date(2026, 5, 21),
+                date(2026, 5, 22),
+            ),
+        )
+
+    def test_single_day_range_is_valid(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            request = build_range_replay_request(
+                start_date=date(2026, 5, 22),
+                end_date=date(2026, 5, 22),
+                symbols=["SPY"],
+                lookback_rows=1,
+                output_root=Path(tmp) / "calibration",
+            )
+
+        self.assertEqual(request.replay_dates, (date(2026, 5, 22),))
+        self.assertEqual(request.date_count, 1)
+
+    def test_symbol_normalization_deduplicates_and_omits_blanks(self) -> None:
+        self.assertEqual(
+            normalize_range_symbols([" spy ", "QQQ", "spy", "", " qqq "]),
+            ("SPY", "QQQ"),
+        )
+
+    def test_invalid_range_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "start date"):
+            tuple(iter_replay_dates(date(2026, 5, 23), date(2026, 5, 22)))
+
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaisesRegex(ValueError, "start date"):
+                build_range_replay_request(
+                    start_date=date(2026, 5, 23),
+                    end_date=date(2026, 5, 22),
+                    symbols=["SPY"],
+                    lookback_rows=1,
+                    output_root=Path(tmp) / "calibration",
+                )
+
+    def test_empty_symbols_are_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaisesRegex(ValueError, "at least one symbol"):
+                build_range_replay_request(
+                    start_date=date(2026, 5, 22),
+                    end_date=date(2026, 5, 22),
+                    symbols=["", "  "],
+                    lookback_rows=1,
+                    output_root=Path(tmp) / "calibration",
+                )
+
+    def test_non_positive_lookback_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaisesRegex(ValueError, "lookback_rows"):
+                build_range_replay_request(
+                    start_date=date(2026, 5, 22),
+                    end_date=date(2026, 5, 22),
+                    symbols=["SPY"],
+                    lookback_rows=0,
+                    output_root=Path(tmp) / "calibration",
+                )
+
+    def test_live_runtime_output_root_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaisesRegex(ValueError, "live runtime state"):
+                RangeReplayRequest(
+                    start_date=date(2026, 5, 22),
+                    end_date=date(2026, 5, 22),
+                    symbols=("SPY",),
+                    lookback_rows=1,
+                    output_root=Path(tmp) / ".cache" / "jerboa" / "runtime",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds the M50 range replay request model with inclusive date iteration, symbol normalization, lookback validation, output-root validation, and stable record serialization.

Refs #441