### PR TITLE
Add range replay runner skeleton

### DIFF
--- a/market_health/calibration/range_runner.py
+++ b/market_health/calibration/range_runner.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Iterable
+
+from market_health.calibration.asof_inputs import build_asof_input_bundle
+from market_health.calibration.engine_metadata import EngineMetadata
+from market_health.calibration.price_cache import HistoricalPriceRow
+from market_health.calibration.range_request import RangeReplayRequest
+from market_health.calibration.single_date_replay import (
+    SingleDateReplayResult,
+    build_single_date_replay_rows,
+)
+
+RANGE_REPLAY_RESULT_SCHEMA_VERSION = "calibration_range_replay_result.v1"
+
+
+@dataclass(frozen=True)
+class RangeReplayResult:
+    request: RangeReplayRequest
+    results: tuple[SingleDateReplayResult, ...]
+    schema_version: str = RANGE_REPLAY_RESULT_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if self.schema_version != RANGE_REPLAY_RESULT_SCHEMA_VERSION:
+            raise ValueError(
+                f"unsupported range replay result schema version: {self.schema_version}"
+            )
+
+        result_dates = tuple(result.replay_date for result in self.results)
+        if result_dates != self.request.replay_dates:
+            raise ValueError("range replay results must match request replay dates")
+
+    @property
+    def date_count(self) -> int:
+        return self.request.date_count
+
+    @property
+    def completed_date_count(self) -> int:
+        return len(self.results)
+
+    @property
+    def total_row_count(self) -> int:
+        return sum(result.row_count for result in self.results)
+
+    @property
+    def replay_dates(self) -> tuple[date, ...]:
+        return tuple(result.replay_date for result in self.results)
+
+    def result_for_date(self, replay_date: date) -> SingleDateReplayResult:
+        for result in self.results:
+            if result.replay_date == replay_date:
+                return result
+        raise KeyError(f"range replay result not found for date: {replay_date}")
+
+    def to_record(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "request": self.request.to_record(),
+            "date_count": self.date_count,
+            "completed_date_count": self.completed_date_count,
+            "total_row_count": self.total_row_count,
+            "replay_dates": [item.isoformat() for item in self.replay_dates],
+            "results": [result.to_record() for result in self.results],
+        }
+
+
+def run_range_replay(
+    *,
+    request: RangeReplayRequest,
+    price_rows: Iterable[HistoricalPriceRow],
+    engine_metadata: EngineMetadata | None = None,
+) -> RangeReplayResult:
+    source_rows = tuple(price_rows)
+    results = []
+
+    for replay_date in request.replay_dates:
+        bundle = build_asof_input_bundle(
+            replay_date=replay_date,
+            symbols=request.symbols,
+            price_rows=source_rows,
+            lookback_rows=request.lookback_rows,
+        )
+        results.append(
+            build_single_date_replay_rows(
+                bundle,
+                engine_metadata=engine_metadata,
+            )
+        )
+
+    return RangeReplayResult(
+        request=request,
+        results=tuple(results),
+    )

--- a/tests/test_calibration_range_runner.py
+++ b/tests/test_calibration_range_runner.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from datetime import date
+from pathlib import Path
+
+from market_health.calibration.price_cache import HistoricalPriceRow
+from market_health.calibration.range_request import build_range_replay_request
+from market_health.calibration.range_runner import (
+    RANGE_REPLAY_RESULT_SCHEMA_VERSION,
+    RangeReplayResult,
+    run_range_replay,
+)
+
+
+class RangeReplayRunnerTest(unittest.TestCase):
+    def test_range_runner_builds_one_single_date_result_per_date(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            request = build_range_replay_request(
+                start_date=date(2026, 5, 20),
+                end_date=date(2026, 5, 22),
+                symbols=["SPY"],
+                lookback_rows=2,
+                output_root=Path(tmp) / "calibration",
+            )
+            result = run_range_replay(
+                request=request,
+                price_rows=[
+                    _row("SPY", date(2026, 5, 20), 100.0),
+                    _row("SPY", date(2026, 5, 21), 101.0),
+                    _row("SPY", date(2026, 5, 22), 102.0),
+                    _row("SPY", date(2026, 5, 23), 200.0),
+                ],
+            )
+
+        self.assertEqual(result.schema_version, RANGE_REPLAY_RESULT_SCHEMA_VERSION)
+        self.assertEqual(result.date_count, 3)
+        self.assertEqual(result.completed_date_count, 3)
+        self.assertEqual(result.replay_dates, request.replay_dates)
+        self.assertEqual([item.row_count for item in result.results], [1, 1, 1])
+        self.assertEqual(result.total_row_count, 3)
+
+    def test_range_runner_uses_asof_inputs_for_each_date(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            request = build_range_replay_request(
+                start_date=date(2026, 5, 20),
+                end_date=date(2026, 5, 22),
+                symbols=["SPY"],
+                lookback_rows=2,
+                output_root=Path(tmp) / "calibration",
+            )
+            result = run_range_replay(
+                request=request,
+                price_rows=[
+                    _row("SPY", date(2026, 5, 20), 100.0),
+                    _row("SPY", date(2026, 5, 21), 101.0),
+                    _row("SPY", date(2026, 5, 22), 102.0),
+                    _row("SPY", date(2026, 5, 23), 200.0),
+                ],
+            )
+
+        first = result.result_for_date(date(2026, 5, 20))
+        last = result.result_for_date(date(2026, 5, 22))
+
+        self.assertEqual(
+            first.rows[0].audit_token, "single-date-asof:2026-05-20:SPY:1:100.0000"
+        )
+        self.assertEqual(
+            last.rows[0].audit_token, "single-date-asof:2026-05-22:SPY:2:102.0000"
+        )
+        self.assertEqual(first.asof_input_record["excluded_future_row_count"], 3)
+        self.assertEqual(last.asof_input_record["excluded_future_row_count"], 1)
+
+    def test_range_result_record_has_stable_shape(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            request = build_range_replay_request(
+                start_date=date(2026, 5, 22),
+                end_date=date(2026, 5, 22),
+                symbols=["SPY"],
+                lookback_rows=1,
+                output_root=Path(tmp) / "calibration",
+            )
+            result = run_range_replay(
+                request=request,
+                price_rows=[_row("SPY", date(2026, 5, 22), 102.0)],
+            )
+
+        record = result.to_record()
+
+        self.assertEqual(
+            tuple(record),
+            (
+                "schema_version",
+                "request",
+                "date_count",
+                "completed_date_count",
+                "total_row_count",
+                "replay_dates",
+                "results",
+            ),
+        )
+        self.assertEqual(record["schema_version"], RANGE_REPLAY_RESULT_SCHEMA_VERSION)
+        self.assertEqual(record["replay_dates"], ["2026-05-22"])
+        self.assertEqual(record["total_row_count"], 1)
+        self.assertEqual(len(record["results"]), 1)
+
+    def test_result_dates_must_match_request_dates(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            request = build_range_replay_request(
+                start_date=date(2026, 5, 20),
+                end_date=date(2026, 5, 21),
+                symbols=["SPY"],
+                lookback_rows=1,
+                output_root=Path(tmp) / "calibration",
+            )
+            source = run_range_replay(
+                request=request,
+                price_rows=[
+                    _row("SPY", date(2026, 5, 20), 100.0),
+                    _row("SPY", date(2026, 5, 21), 101.0),
+                ],
+            )
+
+        with self.assertRaisesRegex(ValueError, "must match request replay dates"):
+            RangeReplayResult(request=request, results=source.results[:1])
+
+    def test_missing_replay_date_lookup_raises_key_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            request = build_range_replay_request(
+                start_date=date(2026, 5, 22),
+                end_date=date(2026, 5, 22),
+                symbols=["SPY"],
+                lookback_rows=1,
+                output_root=Path(tmp) / "calibration",
+            )
+            result = run_range_replay(
+                request=request,
+                price_rows=[_row("SPY", date(2026, 5, 22), 102.0)],
+            )
+
+        with self.assertRaisesRegex(KeyError, "not found"):
+            result.result_for_date(date(2026, 5, 23))
+
+
+def _row(symbol: str, price_date: date, close: float) -> HistoricalPriceRow:
+    return HistoricalPriceRow(
+        symbol=symbol,
+        date=price_date,
+        open=close - 1.0,
+        high=close + 1.0,
+        low=close - 2.0,
+        close=close,
+        adjusted_close=close,
+        volume=1000,
+    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds the M50 range replay runner skeleton that iterates a range replay request, builds as-of bundles for each date, delegates to single-date replay rows, and returns a deterministic range replay result.

Refs #442