### PR TITLE
Add range replay progress state

### DIFF
--- a/market_health/calibration/range_progress.py
+++ b/market_health/calibration/range_progress.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from datetime import date
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+from market_health.calibration.defaults import assert_not_live_runtime_path
+from market_health.calibration.range_request import RangeReplayRequest
+from market_health.calibration.status import utc_now_iso
+
+RANGE_REPLAY_PROGRESS_SCHEMA_VERSION = "calibration_range_replay_progress.v1"
+RANGE_REPLAY_PROGRESS_FILENAME = "range_replay_progress.json"
+
+
+@dataclass(frozen=True)
+class RangeReplayProgress:
+    schema_version: str
+    run_id: str
+    started_at: str
+    updated_at: str
+    request_record: dict[str, object]
+    total_dates: int
+    completed_dates: tuple[str, ...] = field(default_factory=tuple)
+    failed_dates: tuple[str, ...] = field(default_factory=tuple)
+    current_replay_date: str | None = None
+    rows_written: int = 0
+    latest_checkpoint: str | None = None
+    errors: tuple[str, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        if self.schema_version != RANGE_REPLAY_PROGRESS_SCHEMA_VERSION:
+            raise ValueError(
+                f"unsupported range replay progress schema version: {self.schema_version}"
+            )
+        if self.total_dates < 0:
+            raise ValueError("range replay progress total_dates cannot be negative")
+        if self.rows_written < 0:
+            raise ValueError("range replay progress rows_written cannot be negative")
+
+        object.__setattr__(self, "completed_dates", tuple(self.completed_dates))
+        object.__setattr__(self, "failed_dates", tuple(self.failed_dates))
+        object.__setattr__(self, "errors", tuple(self.errors))
+
+    @property
+    def completed_date_count(self) -> int:
+        return len(self.completed_dates)
+
+    @property
+    def failed_date_count(self) -> int:
+        return len(self.failed_dates)
+
+    @property
+    def pending_date_count(self) -> int:
+        return max(
+            0,
+            self.total_dates - self.completed_date_count - self.failed_date_count,
+        )
+
+    def to_record(self) -> dict[str, object]:
+        record = asdict(self)
+        record["completed_dates"] = list(self.completed_dates)
+        record["failed_dates"] = list(self.failed_dates)
+        record["errors"] = list(self.errors)
+        record["completed_date_count"] = self.completed_date_count
+        record["failed_date_count"] = self.failed_date_count
+        record["pending_date_count"] = self.pending_date_count
+        return record
+
+
+def new_range_replay_progress(
+    *,
+    request: RangeReplayRequest,
+    run_id: str,
+) -> RangeReplayProgress:
+    now = utc_now_iso()
+    return RangeReplayProgress(
+        schema_version=RANGE_REPLAY_PROGRESS_SCHEMA_VERSION,
+        run_id=run_id,
+        started_at=now,
+        updated_at=now,
+        request_record=request.to_record(),
+        total_dates=request.date_count,
+    )
+
+
+def pending_replay_dates(
+    request: RangeReplayRequest,
+    progress: RangeReplayProgress,
+) -> tuple[date, ...]:
+    completed = set(progress.completed_dates)
+    failed = set(progress.failed_dates)
+    return tuple(
+        replay_date
+        for replay_date in request.replay_dates
+        if replay_date.isoformat() not in completed
+        and replay_date.isoformat() not in failed
+    )
+
+
+def next_replay_date(
+    request: RangeReplayRequest,
+    progress: RangeReplayProgress,
+) -> date | None:
+    pending = pending_replay_dates(request, progress)
+    return pending[0] if pending else None
+
+
+def should_skip_replay_date(progress: RangeReplayProgress, replay_date: date) -> bool:
+    replay_date_text = replay_date.isoformat()
+    return (
+        replay_date_text in progress.completed_dates
+        or replay_date_text in progress.failed_dates
+    )
+
+
+def mark_range_date_started(
+    progress: RangeReplayProgress,
+    replay_date: date,
+) -> RangeReplayProgress:
+    return _replace_progress(
+        progress,
+        updated_at=utc_now_iso(),
+        current_replay_date=replay_date.isoformat(),
+    )
+
+
+def mark_range_date_completed(
+    progress: RangeReplayProgress,
+    replay_date: date,
+    *,
+    rows_written: int,
+    checkpoint_path: Path | None = None,
+) -> RangeReplayProgress:
+    replay_date_text = replay_date.isoformat()
+    completed_dates = _append_unique(progress.completed_dates, replay_date_text)
+    failed_dates = tuple(
+        item for item in progress.failed_dates if item != replay_date_text
+    )
+
+    return _replace_progress(
+        progress,
+        updated_at=utc_now_iso(),
+        completed_dates=completed_dates,
+        failed_dates=failed_dates,
+        current_replay_date=None,
+        rows_written=progress.rows_written + rows_written,
+        latest_checkpoint=str(checkpoint_path)
+        if checkpoint_path
+        else progress.latest_checkpoint,
+    )
+
+
+def mark_range_date_failed(
+    progress: RangeReplayProgress,
+    replay_date: date,
+    *,
+    message: str,
+) -> RangeReplayProgress:
+    replay_date_text = replay_date.isoformat()
+    failed_dates = _append_unique(progress.failed_dates, replay_date_text)
+
+    return _replace_progress(
+        progress,
+        updated_at=utc_now_iso(),
+        failed_dates=failed_dates,
+        current_replay_date=None,
+        errors=(*progress.errors, f"{replay_date_text}: {message}"),
+    )
+
+
+def range_progress_path(output_root: Path) -> Path:
+    return output_root / RANGE_REPLAY_PROGRESS_FILENAME
+
+
+def write_range_progress(output_root: Path, progress: RangeReplayProgress) -> Path:
+    assert_not_live_runtime_path(output_root)
+    output_root.mkdir(parents=True, exist_ok=True)
+
+    path = range_progress_path(output_root)
+    payload = json.dumps(progress.to_record(), indent=2, sort_keys=True) + "\n"
+
+    with NamedTemporaryFile(
+        "w",
+        encoding="utf-8",
+        dir=output_root,
+        prefix=f".{RANGE_REPLAY_PROGRESS_FILENAME}.",
+        delete=False,
+    ) as tmp:
+        tmp.write(payload)
+        temp_path = Path(tmp.name)
+
+    temp_path.replace(path)
+    return path
+
+
+def read_range_progress(output_root: Path) -> RangeReplayProgress:
+    assert_not_live_runtime_path(output_root)
+    payload = json.loads(range_progress_path(output_root).read_text(encoding="utf-8"))
+    return RangeReplayProgress(
+        schema_version=payload["schema_version"],
+        run_id=payload["run_id"],
+        started_at=payload["started_at"],
+        updated_at=payload["updated_at"],
+        request_record=payload["request_record"],
+        total_dates=payload["total_dates"],
+        completed_dates=tuple(payload.get("completed_dates", ())),
+        failed_dates=tuple(payload.get("failed_dates", ())),
+        current_replay_date=payload.get("current_replay_date"),
+        rows_written=payload.get("rows_written", 0),
+        latest_checkpoint=payload.get("latest_checkpoint"),
+        errors=tuple(payload.get("errors", ())),
+    )
+
+
+def _replace_progress(
+    progress: RangeReplayProgress,
+    **updates: object,
+) -> RangeReplayProgress:
+    record = {
+        "schema_version": progress.schema_version,
+        "run_id": progress.run_id,
+        "started_at": progress.started_at,
+        "updated_at": progress.updated_at,
+        "request_record": progress.request_record,
+        "total_dates": progress.total_dates,
+        "completed_dates": progress.completed_dates,
+        "failed_dates": progress.failed_dates,
+        "current_replay_date": progress.current_replay_date,
+        "rows_written": progress.rows_written,
+        "latest_checkpoint": progress.latest_checkpoint,
+        "errors": progress.errors,
+    }
+    record.update(updates)
+    return RangeReplayProgress(**record)
+
+
+def _append_unique(values: tuple[str, ...], value: str) -> tuple[str, ...]:
+    if value in values:
+        return values
+    return (*values, value)

--- a/tests/test_calibration_range_progress.py
+++ b/tests/test_calibration_range_progress.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from datetime import date
+from pathlib import Path
+
+from market_health.calibration.range_progress import (
+    RANGE_REPLAY_PROGRESS_FILENAME,
+    RANGE_REPLAY_PROGRESS_SCHEMA_VERSION,
+    mark_range_date_completed,
+    mark_range_date_failed,
+    mark_range_date_started,
+    new_range_replay_progress,
+    next_replay_date,
+    pending_replay_dates,
+    range_progress_path,
+    read_range_progress,
+    should_skip_replay_date,
+    write_range_progress,
+)
+from market_health.calibration.range_request import build_range_replay_request
+
+
+class RangeReplayProgressTest(unittest.TestCase):
+    def test_new_progress_record_has_stable_shape(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            request = _request(tmp)
+            progress = new_range_replay_progress(request=request, run_id="run-1")
+
+        record = progress.to_record()
+
+        self.assertEqual(record["schema_version"], RANGE_REPLAY_PROGRESS_SCHEMA_VERSION)
+        self.assertEqual(record["run_id"], "run-1")
+        self.assertEqual(record["total_dates"], 3)
+        self.assertEqual(record["completed_dates"], [])
+        self.assertEqual(record["failed_dates"], [])
+        self.assertEqual(record["completed_date_count"], 0)
+        self.assertEqual(record["failed_date_count"], 0)
+        self.assertEqual(record["pending_date_count"], 3)
+        self.assertEqual(record["request_record"]["start_date"], "2026-05-20")
+
+    def test_started_and_completed_dates_update_progress(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            request = _request(tmp)
+            progress = new_range_replay_progress(request=request, run_id="run-1")
+
+        progress = mark_range_date_started(progress, date(2026, 5, 20))
+        self.assertEqual(progress.current_replay_date, "2026-05-20")
+
+        progress = mark_range_date_completed(
+            progress,
+            date(2026, 5, 20),
+            rows_written=2,
+            checkpoint_path=Path("checkpoint.json"),
+        )
+
+        self.assertEqual(progress.completed_dates, ("2026-05-20",))
+        self.assertEqual(progress.current_replay_date, None)
+        self.assertEqual(progress.rows_written, 2)
+        self.assertEqual(progress.latest_checkpoint, "checkpoint.json")
+        self.assertEqual(progress.pending_date_count, 2)
+
+    def test_completion_is_idempotent_for_dates_but_not_row_accounting(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            request = _request(tmp)
+            progress = new_range_replay_progress(request=request, run_id="run-1")
+
+        progress = mark_range_date_completed(
+            progress,
+            date(2026, 5, 20),
+            rows_written=2,
+        )
+        progress = mark_range_date_completed(
+            progress,
+            date(2026, 5, 20),
+            rows_written=0,
+        )
+
+        self.assertEqual(progress.completed_dates, ("2026-05-20",))
+        self.assertEqual(progress.rows_written, 2)
+
+    def test_failed_dates_are_tracked_for_resume_skip(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            request = _request(tmp)
+            progress = new_range_replay_progress(request=request, run_id="run-1")
+
+        progress = mark_range_date_failed(
+            progress,
+            date(2026, 5, 21),
+            message="fixture failure",
+        )
+
+        self.assertEqual(progress.failed_dates, ("2026-05-21",))
+        self.assertEqual(progress.failed_date_count, 1)
+        self.assertEqual(progress.pending_date_count, 2)
+        self.assertIn("2026-05-21: fixture failure", progress.errors)
+        self.assertTrue(should_skip_replay_date(progress, date(2026, 5, 21)))
+
+    def test_pending_dates_skip_completed_and_failed_dates(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            request = _request(tmp)
+            progress = new_range_replay_progress(request=request, run_id="run-1")
+
+        progress = mark_range_date_completed(
+            progress,
+            date(2026, 5, 20),
+            rows_written=1,
+        )
+        progress = mark_range_date_failed(
+            progress,
+            date(2026, 5, 21),
+            message="boom",
+        )
+
+        self.assertEqual(pending_replay_dates(request, progress), (date(2026, 5, 22),))
+        self.assertEqual(next_replay_date(request, progress), date(2026, 5, 22))
+        self.assertTrue(should_skip_replay_date(progress, date(2026, 5, 20)))
+        self.assertFalse(should_skip_replay_date(progress, date(2026, 5, 22)))
+
+    def test_write_and_read_progress_round_trip(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            output_root = Path(tmp) / "calibration"
+            request = _request(tmp)
+            progress = new_range_replay_progress(request=request, run_id="run-1")
+            progress = mark_range_date_completed(
+                progress,
+                date(2026, 5, 20),
+                rows_written=3,
+            )
+
+            path = write_range_progress(output_root, progress)
+            loaded = read_range_progress(output_root)
+
+        self.assertEqual(path.name, RANGE_REPLAY_PROGRESS_FILENAME)
+        self.assertEqual(
+            range_progress_path(output_root).name, RANGE_REPLAY_PROGRESS_FILENAME
+        )
+        self.assertEqual(loaded.run_id, progress.run_id)
+        self.assertEqual(loaded.completed_dates, ("2026-05-20",))
+        self.assertEqual(loaded.rows_written, 3)
+
+    def test_live_runtime_output_root_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            request = _request(tmp)
+            progress = new_range_replay_progress(request=request, run_id="run-1")
+            output_root = Path(tmp) / ".cache" / "jerboa" / "runtime"
+
+            with self.assertRaisesRegex(ValueError, "live runtime state"):
+                write_range_progress(output_root, progress)
+
+
+def _request(tmp: str):
+    return build_range_replay_request(
+        start_date=date(2026, 5, 20),
+        end_date=date(2026, 5, 22),
+        symbols=["SPY"],
+        lookback_rows=2,
+        output_root=Path(tmp) / "calibration",
+    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds M50 range replay progress state with started, completed, failed, pending, row-count, checkpoint, read/write, and resume-skip primitives.

Refs #443