### PR TITLE
Add range replay artifact layout

### DIFF
--- a/market_health/calibration/range_artifacts.py
+++ b/market_health/calibration/range_artifacts.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Iterable, Mapping
+
+from market_health.calibration.check_output import (
+    CheckReplayRow,
+    build_fixture_check_replay_rows,
+)
+from market_health.calibration.defaults import assert_not_live_runtime_path
+from market_health.calibration.range_runner import RangeReplayResult
+from market_health.calibration.single_date_artifacts import (
+    SingleDateReplayArtifacts,
+    write_single_date_replay_artifacts,
+)
+from market_health.calibration.single_date_replay import SingleDateReplayResult
+
+RANGE_REPLAY_ARTIFACT_SCHEMA_VERSION = "calibration_range_replay_artifacts.v1"
+RANGE_REPLAY_MANIFEST_FILENAME = "range_manifest.json"
+
+
+@dataclass(frozen=True)
+class RangeReplayArtifacts:
+    output_dir: Path
+    manifest_path: Path
+    single_date_artifacts: tuple[SingleDateReplayArtifacts, ...]
+    schema_version: str = RANGE_REPLAY_ARTIFACT_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if self.schema_version != RANGE_REPLAY_ARTIFACT_SCHEMA_VERSION:
+            raise ValueError(
+                f"unsupported range replay artifact schema version: {self.schema_version}"
+            )
+
+    @property
+    def date_count(self) -> int:
+        return len(self.single_date_artifacts)
+
+    def to_record(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "output_dir": str(self.output_dir),
+            "manifest_path": str(self.manifest_path),
+            "date_count": self.date_count,
+            "single_date_artifacts": [
+                artifact.to_record() for artifact in self.single_date_artifacts
+            ],
+        }
+
+
+def range_replay_output_dir(
+    output_root: Path,
+    range_result: RangeReplayResult,
+) -> Path:
+    request = range_result.request
+    range_name = f"{request.start_date.isoformat()}_to_{request.end_date.isoformat()}"
+    return output_root / "range_replay" / range_name
+
+
+def write_range_replay_artifacts(
+    *,
+    output_root: Path,
+    range_result: RangeReplayResult,
+    check_rows_by_date: Mapping[date, Iterable[CheckReplayRow]] | None = None,
+) -> RangeReplayArtifacts:
+    assert_not_live_runtime_path(output_root)
+
+    output_dir = range_replay_output_dir(output_root, range_result)
+    assert_not_live_runtime_path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    single_date_artifacts = tuple(
+        write_single_date_replay_artifacts(
+            output_root=output_dir,
+            replay_result=result,
+            check_rows=_check_rows_for_result(
+                result,
+                check_rows_by_date=check_rows_by_date,
+            ),
+        )
+        for result in range_result.results
+    )
+
+    artifacts = RangeReplayArtifacts(
+        output_dir=output_dir,
+        manifest_path=output_dir / RANGE_REPLAY_MANIFEST_FILENAME,
+        single_date_artifacts=single_date_artifacts,
+    )
+    write_range_manifest_json(artifacts.manifest_path, range_result, artifacts)
+    return artifacts
+
+
+def write_range_manifest_json(
+    path: Path,
+    range_result: RangeReplayResult,
+    artifacts: RangeReplayArtifacts,
+) -> Path:
+    payload = {
+        "schema_version": RANGE_REPLAY_ARTIFACT_SCHEMA_VERSION,
+        "range_replay": range_result.to_record(),
+        "artifacts": artifacts.to_record(),
+    }
+    return _write_json(path, payload)
+
+
+def _check_rows_for_result(
+    result: SingleDateReplayResult,
+    *,
+    check_rows_by_date: Mapping[date, Iterable[CheckReplayRow]] | None,
+) -> tuple[CheckReplayRow, ...]:
+    if check_rows_by_date is not None:
+        return tuple(check_rows_by_date.get(result.replay_date, ()))
+
+    eligible_symbols = result.asof_input_record.get("eligible_symbols")
+    if isinstance(eligible_symbols, list | tuple):
+        symbols = tuple(str(symbol) for symbol in eligible_symbols)
+    else:
+        symbols = tuple(row.symbol for row in result.rows)
+
+    return build_fixture_check_replay_rows(
+        replay_date=result.replay_date,
+        symbols=symbols,
+    )
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> Path:
+    assert_not_live_runtime_path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    with NamedTemporaryFile(
+        "w",
+        delete=False,
+        dir=path.parent,
+        encoding="utf-8",
+    ) as handle:
+        json.dump(payload, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+        temp_path = Path(handle.name)
+
+    temp_path.replace(path)
+    return path

--- a/tests/test_calibration_range_artifacts.py
+++ b/tests/test_calibration_range_artifacts.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import csv
+import json
+import tempfile
+import unittest
+from datetime import date
+from pathlib import Path
+
+from market_health.calibration.check_output import build_fixture_check_replay_rows
+from market_health.calibration.price_cache import HistoricalPriceRow
+from market_health.calibration.range_artifacts import (
+    RANGE_REPLAY_ARTIFACT_SCHEMA_VERSION,
+    RANGE_REPLAY_MANIFEST_FILENAME,
+    range_replay_output_dir,
+    write_range_replay_artifacts,
+)
+from market_health.calibration.range_request import build_range_replay_request
+from market_health.calibration.range_runner import run_range_replay
+
+
+class RangeReplayArtifactsTest(unittest.TestCase):
+    def test_writer_outputs_range_manifest_and_per_date_artifacts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            output_root = Path(tmp) / "calibration"
+            range_result = _range_result(tmp)
+            check_rows_by_date = {
+                replay_date: build_fixture_check_replay_rows(
+                    replay_date=replay_date,
+                    symbols=["SPY"],
+                    horizons=["C"],
+                )
+                for replay_date in range_result.replay_dates
+            }
+
+            artifacts = write_range_replay_artifacts(
+                output_root=output_root,
+                range_result=range_result,
+                check_rows_by_date=check_rows_by_date,
+            )
+
+            manifest = json.loads(artifacts.manifest_path.read_text(encoding="utf-8"))
+            first_date_artifacts = artifacts.single_date_artifacts[0]
+            with first_date_artifacts.check_rows_csv_path.open(
+                newline="", encoding="utf-8"
+            ) as handle:
+                check_rows = list(csv.DictReader(handle))
+
+        self.assertEqual(artifacts.schema_version, RANGE_REPLAY_ARTIFACT_SCHEMA_VERSION)
+        self.assertEqual(artifacts.date_count, 2)
+        self.assertEqual(artifacts.manifest_path.name, RANGE_REPLAY_MANIFEST_FILENAME)
+        self.assertEqual(
+            artifacts.output_dir.name,
+            "2026-05-21_to_2026-05-22",
+        )
+        self.assertEqual(
+            manifest["schema_version"], RANGE_REPLAY_ARTIFACT_SCHEMA_VERSION
+        )
+        self.assertEqual(manifest["range_replay"]["date_count"], 2)
+        self.assertEqual(manifest["range_replay"]["total_row_count"], 2)
+        self.assertEqual(manifest["artifacts"]["date_count"], 2)
+        self.assertEqual(len(check_rows), 30)
+        self.assertEqual(first_date_artifacts.output_dir.parent.name, "single_date")
+        self.assertEqual(first_date_artifacts.output_dir.name, "2026-05-21")
+
+    def test_range_output_dir_is_stable(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            output_root = Path(tmp) / "calibration"
+            range_result = _range_result(tmp)
+
+            self.assertEqual(
+                range_replay_output_dir(output_root, range_result),
+                output_root / "range_replay" / "2026-05-21_to_2026-05-22",
+            )
+
+    def test_default_check_rows_use_asof_eligible_symbols(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            artifacts = write_range_replay_artifacts(
+                output_root=Path(tmp) / "calibration",
+                range_result=_range_result(tmp),
+            )
+            first_date_artifacts = artifacts.single_date_artifacts[0]
+
+            with first_date_artifacts.check_rows_csv_path.open(
+                newline="", encoding="utf-8"
+            ) as handle:
+                check_rows = list(csv.DictReader(handle))
+
+        self.assertEqual(len(check_rows), 90)
+        self.assertEqual({row["symbol"] for row in check_rows}, {"SPY"})
+
+    def test_writer_rejects_live_runtime_output_root(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaisesRegex(ValueError, "live runtime state"):
+                write_range_replay_artifacts(
+                    output_root=Path(tmp) / ".cache" / "jerboa" / "runtime",
+                    range_result=_range_result(tmp),
+                )
+
+
+def _range_result(tmp: str):
+    request = build_range_replay_request(
+        start_date=date(2026, 5, 21),
+        end_date=date(2026, 5, 22),
+        symbols=["SPY"],
+        lookback_rows=2,
+        output_root=Path(tmp) / "calibration",
+    )
+    return run_range_replay(
+        request=request,
+        price_rows=[
+            _row("SPY", date(2026, 5, 21), 101.0),
+            _row("SPY", date(2026, 5, 22), 102.0),
+            _row("SPY", date(2026, 5, 23), 200.0),
+        ],
+    )
+
+
+def _row(symbol: str, price_date: date, close: float) -> HistoricalPriceRow:
+    return HistoricalPriceRow(
+        symbol=symbol,
+        date=price_date,
+        open=close - 1.0,
+        high=close + 1.0,
+        low=close - 2.0,
+        close=close,
+        adjusted_close=close,
+        volume=1000,
+    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds M50 range replay artifact layout with a stable range output directory, range manifest, and nested per-date single-date replay artifacts.

Refs #444