### PR TITLE
Add range replay failure accounting

### DIFF
--- a/market_health/calibration/range_failure_accounting.py
+++ b/market_health/calibration/range_failure_accounting.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Callable, Iterable
+
+from market_health.calibration.asof_inputs import build_asof_input_bundle
+from market_health.calibration.engine_metadata import EngineMetadata
+from market_health.calibration.price_cache import HistoricalPriceRow
+from market_health.calibration.range_progress import (
+    RangeReplayProgress,
+    mark_range_date_completed,
+    mark_range_date_failed,
+    mark_range_date_started,
+    new_range_replay_progress,
+    pending_replay_dates,
+    should_skip_replay_date,
+)
+from market_health.calibration.range_request import RangeReplayRequest
+from market_health.calibration.single_date_replay import (
+    SingleDateReplayResult,
+    build_single_date_replay_rows,
+)
+
+RANGE_REPLAY_ACCOUNTING_SCHEMA_VERSION = "calibration_range_replay_accounting.v1"
+
+DateReplayFunction = Callable[
+    [RangeReplayRequest, date, tuple[HistoricalPriceRow, ...], EngineMetadata | None],
+    SingleDateReplayResult,
+]
+
+
+@dataclass(frozen=True)
+class RangeReplayDateFailure:
+    replay_date: date
+    message: str
+
+    def to_record(self) -> dict[str, str]:
+        return {
+            "replay_date": self.replay_date.isoformat(),
+            "message": self.message,
+        }
+
+
+@dataclass(frozen=True)
+class RangeReplayAccountingResult:
+    request: RangeReplayRequest
+    progress: RangeReplayProgress
+    results: tuple[SingleDateReplayResult, ...]
+    failures: tuple[RangeReplayDateFailure, ...]
+    skipped_dates: tuple[date, ...]
+    schema_version: str = RANGE_REPLAY_ACCOUNTING_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if self.schema_version != RANGE_REPLAY_ACCOUNTING_SCHEMA_VERSION:
+            raise ValueError(
+                f"unsupported range replay accounting schema version: {self.schema_version}"
+            )
+        object.__setattr__(self, "results", tuple(self.results))
+        object.__setattr__(self, "failures", tuple(self.failures))
+        object.__setattr__(self, "skipped_dates", tuple(self.skipped_dates))
+
+    @property
+    def date_count(self) -> int:
+        return self.request.date_count
+
+    @property
+    def completed_date_count(self) -> int:
+        return self.progress.completed_date_count
+
+    @property
+    def failed_date_count(self) -> int:
+        return self.progress.failed_date_count
+
+    @property
+    def pending_date_count(self) -> int:
+        return self.progress.pending_date_count
+
+    @property
+    def skipped_date_count(self) -> int:
+        return len(self.skipped_dates)
+
+    @property
+    def attempted_date_count(self) -> int:
+        return len(self.results) + len(self.failures)
+
+    @property
+    def rows_written(self) -> int:
+        return self.progress.rows_written
+
+    def to_record(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "request": self.request.to_record(),
+            "progress": self.progress.to_record(),
+            "date_count": self.date_count,
+            "completed_date_count": self.completed_date_count,
+            "failed_date_count": self.failed_date_count,
+            "pending_date_count": self.pending_date_count,
+            "skipped_date_count": self.skipped_date_count,
+            "attempted_date_count": self.attempted_date_count,
+            "rows_written": self.rows_written,
+            "skipped_dates": [item.isoformat() for item in self.skipped_dates],
+            "failures": [failure.to_record() for failure in self.failures],
+            "results": [result.to_record() for result in self.results],
+        }
+
+
+def run_range_replay_with_failure_accounting(
+    *,
+    request: RangeReplayRequest,
+    price_rows: Iterable[HistoricalPriceRow],
+    run_id: str = "range-replay",
+    progress: RangeReplayProgress | None = None,
+    engine_metadata: EngineMetadata | None = None,
+    date_replay_function: DateReplayFunction | None = None,
+    fail_fast: bool = False,
+) -> RangeReplayAccountingResult:
+    source_rows = tuple(price_rows)
+    working_progress = progress or new_range_replay_progress(
+        request=request,
+        run_id=run_id,
+    )
+    skipped_dates = tuple(
+        replay_date
+        for replay_date in request.replay_dates
+        if should_skip_replay_date(working_progress, replay_date)
+    )
+    replay_one_date = date_replay_function or _default_date_replay_function
+
+    results: list[SingleDateReplayResult] = []
+    failures: list[RangeReplayDateFailure] = []
+
+    for replay_date in pending_replay_dates(request, working_progress):
+        working_progress = mark_range_date_started(working_progress, replay_date)
+
+        try:
+            result = replay_one_date(
+                request,
+                replay_date,
+                source_rows,
+                engine_metadata,
+            )
+        except Exception as exc:
+            message = _failure_message(exc)
+            failures.append(
+                RangeReplayDateFailure(
+                    replay_date=replay_date,
+                    message=message,
+                )
+            )
+            working_progress = mark_range_date_failed(
+                working_progress,
+                replay_date,
+                message=message,
+            )
+            if fail_fast:
+                break
+            continue
+
+        results.append(result)
+        working_progress = mark_range_date_completed(
+            working_progress,
+            replay_date,
+            rows_written=result.row_count,
+        )
+
+    return RangeReplayAccountingResult(
+        request=request,
+        progress=working_progress,
+        results=tuple(results),
+        failures=tuple(failures),
+        skipped_dates=skipped_dates,
+    )
+
+
+def _default_date_replay_function(
+    request: RangeReplayRequest,
+    replay_date: date,
+    price_rows: tuple[HistoricalPriceRow, ...],
+    engine_metadata: EngineMetadata | None,
+) -> SingleDateReplayResult:
+    bundle = build_asof_input_bundle(
+        replay_date=replay_date,
+        symbols=request.symbols,
+        price_rows=price_rows,
+        lookback_rows=request.lookback_rows,
+    )
+    return build_single_date_replay_rows(
+        bundle,
+        engine_metadata=engine_metadata,
+    )
+
+
+def _failure_message(exc: Exception) -> str:
+    message = str(exc).strip()
+    if message:
+        return message
+    return exc.__class__.__name__

--- a/tests/test_calibration_range_failure_accounting.py
+++ b/tests/test_calibration_range_failure_accounting.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from datetime import date
+from pathlib import Path
+
+from market_health.calibration.asof_inputs import build_asof_input_bundle
+from market_health.calibration.price_cache import HistoricalPriceRow
+from market_health.calibration.range_failure_accounting import (
+    RANGE_REPLAY_ACCOUNTING_SCHEMA_VERSION,
+    RangeReplayDateFailure,
+    run_range_replay_with_failure_accounting,
+)
+from market_health.calibration.range_progress import (
+    mark_range_date_completed,
+    mark_range_date_failed,
+    new_range_replay_progress,
+)
+from market_health.calibration.range_request import (
+    RangeReplayRequest,
+    build_range_replay_request,
+)
+from market_health.calibration.single_date_replay import (
+    SingleDateReplayResult,
+    build_single_date_replay_rows,
+)
+
+
+class RangeReplayFailureAccountingTest(unittest.TestCase):
+    def test_successful_range_replay_accounting_summary(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            request = _request(tmp)
+            result = run_range_replay_with_failure_accounting(
+                request=request,
+                price_rows=_price_rows(),
+                run_id="run-1",
+            )
+
+        self.assertEqual(result.schema_version, RANGE_REPLAY_ACCOUNTING_SCHEMA_VERSION)
+        self.assertEqual(result.date_count, 3)
+        self.assertEqual(result.completed_date_count, 3)
+        self.assertEqual(result.failed_date_count, 0)
+        self.assertEqual(result.pending_date_count, 0)
+        self.assertEqual(result.skipped_date_count, 0)
+        self.assertEqual(result.attempted_date_count, 3)
+        self.assertEqual(result.rows_written, 3)
+        self.assertEqual(
+            result.progress.completed_dates,
+            ("2026-05-20", "2026-05-21", "2026-05-22"),
+        )
+
+    def test_date_failure_is_recorded_and_later_dates_continue(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            request = _request(tmp)
+            result = run_range_replay_with_failure_accounting(
+                request=request,
+                price_rows=_price_rows(),
+                run_id="run-1",
+                date_replay_function=_fail_on_2026_05_21,
+            )
+
+        self.assertEqual(result.completed_date_count, 2)
+        self.assertEqual(result.failed_date_count, 1)
+        self.assertEqual(result.pending_date_count, 0)
+        self.assertEqual(result.attempted_date_count, 3)
+        self.assertEqual(result.rows_written, 2)
+        self.assertEqual(
+            [item.replay_date for item in result.results],
+            [date(2026, 5, 20), date(2026, 5, 22)],
+        )
+        self.assertEqual(
+            result.failures[0].to_record(),
+            {"replay_date": "2026-05-21", "message": "fixture failure"},
+        )
+        self.assertIn("2026-05-21: fixture failure", result.progress.errors)
+
+    def test_fail_fast_records_failure_and_leaves_later_date_pending(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            request = _request(tmp)
+            result = run_range_replay_with_failure_accounting(
+                request=request,
+                price_rows=_price_rows(),
+                run_id="run-1",
+                date_replay_function=_fail_on_2026_05_21,
+                fail_fast=True,
+            )
+
+        self.assertEqual(result.completed_date_count, 1)
+        self.assertEqual(result.failed_date_count, 1)
+        self.assertEqual(result.pending_date_count, 1)
+        self.assertEqual(result.attempted_date_count, 2)
+        self.assertEqual(result.rows_written, 1)
+        self.assertEqual(
+            [item.replay_date for item in result.results], [date(2026, 5, 20)]
+        )
+        self.assertEqual(result.failures[0].replay_date, date(2026, 5, 21))
+
+    def test_resume_skips_previously_completed_and_failed_dates(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            request = _request(tmp)
+            progress = new_range_replay_progress(request=request, run_id="run-1")
+            progress = mark_range_date_completed(
+                progress,
+                date(2026, 5, 20),
+                rows_written=1,
+            )
+            progress = mark_range_date_failed(
+                progress,
+                date(2026, 5, 21),
+                message="previous failure",
+            )
+
+            result = run_range_replay_with_failure_accounting(
+                request=request,
+                price_rows=_price_rows(),
+                progress=progress,
+            )
+
+        self.assertEqual(result.skipped_dates, (date(2026, 5, 20), date(2026, 5, 21)))
+        self.assertEqual(result.skipped_date_count, 2)
+        self.assertEqual(result.attempted_date_count, 1)
+        self.assertEqual(result.completed_date_count, 2)
+        self.assertEqual(result.failed_date_count, 1)
+        self.assertEqual(result.pending_date_count, 0)
+        self.assertEqual(result.rows_written, 2)
+        self.assertEqual(
+            [item.replay_date for item in result.results], [date(2026, 5, 22)]
+        )
+
+    def test_accounting_record_has_stable_shape(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            request = _request(tmp)
+            result = run_range_replay_with_failure_accounting(
+                request=request,
+                price_rows=_price_rows(),
+                run_id="run-1",
+                date_replay_function=_fail_on_2026_05_21,
+            )
+
+        record = result.to_record()
+
+        self.assertEqual(
+            tuple(record),
+            (
+                "schema_version",
+                "request",
+                "progress",
+                "date_count",
+                "completed_date_count",
+                "failed_date_count",
+                "pending_date_count",
+                "skipped_date_count",
+                "attempted_date_count",
+                "rows_written",
+                "skipped_dates",
+                "failures",
+                "results",
+            ),
+        )
+        self.assertEqual(record["failed_date_count"], 1)
+        self.assertEqual(
+            record["failures"],
+            [{"replay_date": "2026-05-21", "message": "fixture failure"}],
+        )
+
+    def test_empty_failure_message_uses_exception_class_name(self) -> None:
+        failure = RangeReplayDateFailure(
+            replay_date=date(2026, 5, 21), message="RuntimeError"
+        )
+        self.assertEqual(
+            failure.to_record(),
+            {"replay_date": "2026-05-21", "message": "RuntimeError"},
+        )
+
+
+def _request(tmp: str):
+    return build_range_replay_request(
+        start_date=date(2026, 5, 20),
+        end_date=date(2026, 5, 22),
+        symbols=["SPY"],
+        lookback_rows=2,
+        output_root=Path(tmp) / "calibration",
+    )
+
+
+def _price_rows() -> tuple[HistoricalPriceRow, ...]:
+    return (
+        _row("SPY", date(2026, 5, 20), 100.0),
+        _row("SPY", date(2026, 5, 21), 101.0),
+        _row("SPY", date(2026, 5, 22), 102.0),
+    )
+
+
+def _row(symbol: str, price_date: date, close: float) -> HistoricalPriceRow:
+    return HistoricalPriceRow(
+        symbol=symbol,
+        date=price_date,
+        open=close - 1.0,
+        high=close + 1.0,
+        low=close - 2.0,
+        close=close,
+        adjusted_close=close,
+        volume=1000,
+    )
+
+
+def _fail_on_2026_05_21(
+    request: RangeReplayRequest,
+    replay_date: date,
+    price_rows: tuple[HistoricalPriceRow, ...],
+    engine_metadata,
+) -> SingleDateReplayResult:
+    if replay_date == date(2026, 5, 21):
+        raise RuntimeError("fixture failure")
+
+    bundle = build_asof_input_bundle(
+        replay_date=replay_date,
+        symbols=request.symbols,
+        price_rows=price_rows,
+        lookback_rows=request.lookback_rows,
+    )
+    return build_single_date_replay_rows(
+        bundle,
+        engine_metadata=engine_metadata,
+    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds M50 range replay failure accounting with completed, failed, skipped, pending, attempted, and row-count summary coverage.

Refs #445