### PR TITLE
Add range replay CLI entrypoint

### DIFF
--- a/market_health/calibration/cli.py
+++ b/market_health/calibration/cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+from datetime import date
 from pathlib import Path
 
 from market_health.calibration.defaults import (
@@ -9,6 +10,16 @@ from market_health.calibration.defaults import (
     default_output_root,
 )
 from market_health.calibration.engine_metadata import capture_engine_metadata
+from market_health.calibration.price_cache import read_historical_price_cache_csv
+from market_health.calibration.range_failure_accounting import (
+    run_range_replay_with_failure_accounting,
+)
+from market_health.calibration.range_progress import (
+    range_progress_path,
+    read_range_progress,
+    write_range_progress,
+)
+from market_health.calibration.range_request import build_range_replay_request
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -17,6 +28,20 @@ def build_parser() -> argparse.ArgumentParser:
 
     doctor = subparsers.add_parser("doctor", help="Validate replay scaffold defaults.")
     doctor.add_argument("--out", type=Path, default=default_output_root())
+
+    range_replay = subparsers.add_parser(
+        "range-replay",
+        help="Run fixture-backed range replay over a historical price cache.",
+    )
+    range_replay.add_argument("--price-cache", type=Path, required=True)
+    range_replay.add_argument("--start-date", type=_parse_date, required=True)
+    range_replay.add_argument("--end-date", type=_parse_date, required=True)
+    range_replay.add_argument("--symbols", nargs="+", required=True)
+    range_replay.add_argument("--lookback-rows", type=int, default=20)
+    range_replay.add_argument("--out", type=Path, default=default_output_root())
+    range_replay.add_argument("--run-id", default="range-replay")
+    range_replay.add_argument("--resume", action="store_true")
+    range_replay.add_argument("--fail-fast", action="store_true")
 
     return parser
 
@@ -35,7 +60,61 @@ def main(argv: list[str] | None = None) -> int:
         print(json.dumps(payload, indent=2, sort_keys=True))
         return 0
 
+    if args.command == "range-replay":
+        payload = _run_range_replay_command(args)
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0
+
     raise AssertionError(f"unhandled command: {args.command}")
+
+
+def _run_range_replay_command(args: argparse.Namespace) -> dict[str, object]:
+    output_root = args.out.expanduser()
+    assert_not_live_runtime_path(output_root)
+
+    price_cache_path = args.price_cache.expanduser()
+    price_cache = read_historical_price_cache_csv(
+        price_cache_path,
+        symbols=args.symbols,
+    )
+    request = build_range_replay_request(
+        start_date=args.start_date,
+        end_date=args.end_date,
+        symbols=args.symbols,
+        lookback_rows=args.lookback_rows,
+        output_root=output_root,
+    )
+
+    progress = None
+    progress_path = range_progress_path(output_root)
+    if args.resume and progress_path.exists():
+        progress = read_range_progress(output_root)
+
+    result = run_range_replay_with_failure_accounting(
+        request=request,
+        price_rows=price_cache.rows,
+        run_id=args.run_id,
+        progress=progress,
+        fail_fast=args.fail_fast,
+    )
+    written_progress_path = write_range_progress(output_root, result.progress)
+
+    return {
+        "status": "ok" if result.failed_date_count == 0 else "completed_with_failures",
+        "command": "range-replay",
+        "price_cache_path": str(price_cache_path),
+        "progress_path": str(written_progress_path),
+        "result": result.to_record(),
+    }
+
+
+def _parse_date(value: str) -> date:
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            f"expected YYYY-MM-DD date, got: {value}"
+        ) from exc
 
 
 if __name__ == "__main__":

--- a/tests/test_calibration_range_cli.py
+++ b/tests/test_calibration_range_cli.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import csv
+import io
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from datetime import date
+from pathlib import Path
+
+from market_health.calibration import cli
+from market_health.calibration.price_cache import (
+    HISTORICAL_PRICE_CACHE_COLUMNS,
+    HistoricalPriceRow,
+)
+from market_health.calibration.range_progress import read_range_progress
+
+
+class RangeReplayCliTest(unittest.TestCase):
+    def test_range_replay_command_writes_progress_and_outputs_json(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            output_root = Path(tmp) / "calibration"
+            price_cache_path = Path(tmp) / "prices.csv"
+            _write_price_cache(
+                price_cache_path,
+                [
+                    _row("SPY", date(2026, 5, 20), 100.0),
+                    _row("SPY", date(2026, 5, 21), 101.0),
+                    _row("SPY", date(2026, 5, 22), 102.0),
+                ],
+            )
+
+            payload = _run_cli_json(
+                [
+                    "range-replay",
+                    "--price-cache",
+                    str(price_cache_path),
+                    "--start-date",
+                    "2026-05-20",
+                    "--end-date",
+                    "2026-05-22",
+                    "--symbols",
+                    "spy",
+                    "--lookback-rows",
+                    "2",
+                    "--out",
+                    str(output_root),
+                    "--run-id",
+                    "cli-test",
+                ]
+            )
+            progress = read_range_progress(output_root)
+
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(payload["command"], "range-replay")
+        self.assertEqual(payload["result"]["completed_date_count"], 3)
+        self.assertEqual(payload["result"]["failed_date_count"], 0)
+        self.assertEqual(payload["result"]["rows_written"], 3)
+        self.assertEqual(progress.run_id, "cli-test")
+        self.assertEqual(
+            progress.completed_dates,
+            ("2026-05-20", "2026-05-21", "2026-05-22"),
+        )
+
+    def test_range_replay_resume_skips_completed_dates(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            output_root = Path(tmp) / "calibration"
+            price_cache_path = Path(tmp) / "prices.csv"
+            _write_price_cache(
+                price_cache_path,
+                [
+                    _row("SPY", date(2026, 5, 20), 100.0),
+                    _row("SPY", date(2026, 5, 21), 101.0),
+                ],
+            )
+
+            base_args = [
+                "range-replay",
+                "--price-cache",
+                str(price_cache_path),
+                "--start-date",
+                "2026-05-20",
+                "--end-date",
+                "2026-05-21",
+                "--symbols",
+                "SPY",
+                "--lookback-rows",
+                "1",
+                "--out",
+                str(output_root),
+                "--run-id",
+                "cli-test",
+            ]
+            _run_cli_json(base_args)
+            resumed = _run_cli_json([*base_args, "--resume"])
+            progress = read_range_progress(output_root)
+
+        self.assertEqual(resumed["status"], "ok")
+        self.assertEqual(resumed["result"]["skipped_date_count"], 2)
+        self.assertEqual(resumed["result"]["attempted_date_count"], 0)
+        self.assertEqual(resumed["result"]["rows_written"], 2)
+        self.assertEqual(progress.completed_dates, ("2026-05-20", "2026-05-21"))
+
+    def test_range_replay_rejects_bad_date(self) -> None:
+        with self.assertRaises(SystemExit):
+            cli.main(
+                [
+                    "range-replay",
+                    "--price-cache",
+                    "prices.csv",
+                    "--start-date",
+                    "2026/05/20",
+                    "--end-date",
+                    "2026-05-21",
+                    "--symbols",
+                    "SPY",
+                ]
+            )
+
+    def test_range_replay_help_is_registered(self) -> None:
+        parser = cli.build_parser()
+        with self.assertRaises(SystemExit) as ctx:
+            with redirect_stdout(io.StringIO()) as stdout:
+                parser.parse_args(["range-replay", "--help"])
+
+        self.assertEqual(ctx.exception.code, 0)
+        self.assertIn("--price-cache", stdout.getvalue())
+        self.assertIn("--resume", stdout.getvalue())
+
+
+def _run_cli_json(argv: list[str]) -> dict[str, object]:
+    stream = io.StringIO()
+    with redirect_stdout(stream):
+        status = cli.main(argv)
+
+    if status != 0:
+        raise AssertionError(f"unexpected CLI status: {status}")
+
+    return json.loads(stream.getvalue())
+
+
+def _write_price_cache(path: Path, rows: list[HistoricalPriceRow]) -> None:
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=HISTORICAL_PRICE_CACHE_COLUMNS)
+        writer.writeheader()
+        writer.writerows(row.to_record() for row in rows)
+
+
+def _row(symbol: str, price_date: date, close: float) -> HistoricalPriceRow:
+    return HistoricalPriceRow(
+        symbol=symbol,
+        date=price_date,
+        open=close - 1.0,
+        high=close + 1.0,
+        low=close - 2.0,
+        close=close,
+        adjusted_close=close,
+        volume=1000,
+    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds the M50 fixture-backed range replay CLI entrypoint with price-cache input, start/end dates, symbols, lookback rows, output root, run id, resume, fail-fast, JSON output, and persisted progress.

Refs #446