### PR TITLE
Add authoritative replay dataset row schema

### DIFF
--- a/market_health/calibration/authoritative_dataset.py
+++ b/market_health/calibration/authoritative_dataset.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+
+from market_health.calibration.check_inventory import REPLAYABILITY_CLASSES
+from market_health.calibration.check_output import (
+    CHECK_REPLAY_ROW_SCHEMA_VERSION,
+    MEASUREMENT_STATUSES,
+    VALID_HORIZONS,
+)
+from market_health.calibration.range_runner import RANGE_REPLAY_RESULT_SCHEMA_VERSION
+from market_health.calibration.single_date_replay import (
+    SINGLE_DATE_REPLAY_SCHEMA_VERSION,
+)
+
+AUTHORITATIVE_REPLAY_DATASET_SCHEMA_VERSION = (
+    "calibration_authoritative_replay_dataset.v1"
+)
+
+REALIZED_OUTCOME_AVAILABLE = "available"
+REALIZED_OUTCOME_MISSING = "missing"
+REALIZED_OUTCOME_NOT_APPLICABLE = "not_applicable"
+
+REALIZED_OUTCOME_STATUSES = (
+    REALIZED_OUTCOME_AVAILABLE,
+    REALIZED_OUTCOME_MISSING,
+    REALIZED_OUTCOME_NOT_APPLICABLE,
+)
+
+AUTHORITATIVE_REPLAY_DATASET_COLUMNS = (
+    "schema_version",
+    "replay_date",
+    "symbol",
+    "current_score",
+    "h1_score",
+    "h5_score",
+    "blend_score",
+    "state",
+    "horizon",
+    "target_date",
+    "realized_current_score",
+    "realized_return",
+    "realized_outcome_status",
+    "category",
+    "slot",
+    "category_slot",
+    "glyph",
+    "named_check",
+    "check_score",
+    "replayability_class",
+    "measurement_status",
+    "source_module",
+    "function_name",
+    "replay_row_schema_version",
+    "check_row_schema_version",
+    "single_date_replay_schema_version",
+    "range_replay_schema_version",
+    "audit_token",
+    "dataset_run_id",
+)
+
+
+@dataclass(frozen=True)
+class AuthoritativeReplayDatasetRow:
+    replay_date: date
+    symbol: str
+    current_score: float
+    h1_score: float
+    h5_score: float
+    blend_score: float
+    state: str
+    horizon: str
+    category: str
+    slot: int
+    glyph: str
+    named_check: str
+    check_score: float
+    replayability_class: str
+    measurement_status: str
+    source_module: str
+    function_name: str
+    audit_token: str
+    target_date: date | None = None
+    realized_current_score: float | None = None
+    realized_return: float | None = None
+    realized_outcome_status: str = REALIZED_OUTCOME_NOT_APPLICABLE
+    replay_row_schema_version: str = "calibration_replay_artifact_row.v1"
+    check_row_schema_version: str = CHECK_REPLAY_ROW_SCHEMA_VERSION
+    single_date_replay_schema_version: str = SINGLE_DATE_REPLAY_SCHEMA_VERSION
+    range_replay_schema_version: str = RANGE_REPLAY_RESULT_SCHEMA_VERSION
+    dataset_run_id: str = "authoritative-replay-dataset"
+    schema_version: str = AUTHORITATIVE_REPLAY_DATASET_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if self.schema_version != AUTHORITATIVE_REPLAY_DATASET_SCHEMA_VERSION:
+            raise ValueError(
+                "unsupported authoritative replay dataset schema version: "
+                f"{self.schema_version}"
+            )
+
+        symbol = self.symbol.strip().upper()
+        category = self.category.strip().upper()
+        horizon = self.horizon.strip().upper()
+        state = self.state.strip().upper()
+
+        if not symbol:
+            raise ValueError("authoritative replay dataset row symbol is required")
+        if category not in {"A", "B", "C", "D", "E"}:
+            raise ValueError(f"unsupported check category: {self.category}")
+        if not 1 <= self.slot <= 6:
+            raise ValueError(f"unsupported check slot: {self.slot}")
+        if horizon not in VALID_HORIZONS:
+            raise ValueError(f"unsupported dataset horizon: {self.horizon}")
+        if not state:
+            raise ValueError("authoritative replay dataset row state is required")
+        if self.replayability_class not in REPLAYABILITY_CLASSES:
+            raise ValueError(
+                f"unsupported replayability class: {self.replayability_class}"
+            )
+        if self.measurement_status not in MEASUREMENT_STATUSES:
+            raise ValueError(
+                f"unsupported measurement status: {self.measurement_status}"
+            )
+        if self.realized_outcome_status not in REALIZED_OUTCOME_STATUSES:
+            raise ValueError(
+                f"unsupported realized outcome status: {self.realized_outcome_status}"
+            )
+
+        if self.realized_outcome_status == REALIZED_OUTCOME_AVAILABLE:
+            if self.target_date is None:
+                raise ValueError("available realized outcome requires target_date")
+            if self.realized_current_score is None:
+                raise ValueError(
+                    "available realized outcome requires realized_current_score"
+                )
+            if self.realized_return is None:
+                raise ValueError("available realized outcome requires realized_return")
+
+        if self.realized_outcome_status == REALIZED_OUTCOME_NOT_APPLICABLE:
+            if self.target_date is not None:
+                raise ValueError(
+                    "not_applicable realized outcome cannot set target_date"
+                )
+            if self.realized_current_score is not None:
+                raise ValueError(
+                    "not_applicable realized outcome cannot set realized_current_score"
+                )
+            if self.realized_return is not None:
+                raise ValueError(
+                    "not_applicable realized outcome cannot set realized_return"
+                )
+
+        for field_name in (
+            "glyph",
+            "named_check",
+            "source_module",
+            "function_name",
+            "audit_token",
+            "replay_row_schema_version",
+            "check_row_schema_version",
+            "single_date_replay_schema_version",
+            "range_replay_schema_version",
+            "dataset_run_id",
+        ):
+            if not str(getattr(self, field_name)).strip():
+                raise ValueError(f"authoritative dataset {field_name} is required")
+
+        object.__setattr__(self, "symbol", symbol)
+        object.__setattr__(self, "category", category)
+        object.__setattr__(self, "horizon", horizon)
+        object.__setattr__(self, "state", state)
+
+    @property
+    def category_slot(self) -> str:
+        return f"{self.category}{self.slot}"
+
+    def to_record(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "replay_date": self.replay_date.isoformat(),
+            "symbol": self.symbol,
+            "current_score": self.current_score,
+            "h1_score": self.h1_score,
+            "h5_score": self.h5_score,
+            "blend_score": self.blend_score,
+            "state": self.state,
+            "horizon": self.horizon,
+            "target_date": _optional_date(self.target_date),
+            "realized_current_score": self.realized_current_score,
+            "realized_return": self.realized_return,
+            "realized_outcome_status": self.realized_outcome_status,
+            "category": self.category,
+            "slot": self.slot,
+            "category_slot": self.category_slot,
+            "glyph": self.glyph,
+            "named_check": self.named_check,
+            "check_score": self.check_score,
+            "replayability_class": self.replayability_class,
+            "measurement_status": self.measurement_status,
+            "source_module": self.source_module,
+            "function_name": self.function_name,
+            "replay_row_schema_version": self.replay_row_schema_version,
+            "check_row_schema_version": self.check_row_schema_version,
+            "single_date_replay_schema_version": self.single_date_replay_schema_version,
+            "range_replay_schema_version": self.range_replay_schema_version,
+            "audit_token": self.audit_token,
+            "dataset_run_id": self.dataset_run_id,
+        }
+
+
+def _optional_date(value: date | None) -> str | None:
+    if value is None:
+        return None
+    return value.isoformat()

--- a/tests/test_calibration_authoritative_dataset.py
+++ b/tests/test_calibration_authoritative_dataset.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import unittest
+from datetime import date
+
+from market_health.calibration.authoritative_dataset import (
+    AUTHORITATIVE_REPLAY_DATASET_COLUMNS,
+    AUTHORITATIVE_REPLAY_DATASET_SCHEMA_VERSION,
+    REALIZED_OUTCOME_AVAILABLE,
+    REALIZED_OUTCOME_MISSING,
+    REALIZED_OUTCOME_NOT_APPLICABLE,
+    AuthoritativeReplayDatasetRow,
+)
+from market_health.calibration.check_output import (
+    CHECK_REPLAY_ROW_SCHEMA_VERSION,
+    MEASUREMENT_MEASURED,
+)
+from market_health.calibration.range_runner import RANGE_REPLAY_RESULT_SCHEMA_VERSION
+from market_health.calibration.single_date_replay import (
+    SINGLE_DATE_REPLAY_SCHEMA_VERSION,
+)
+
+
+class AuthoritativeReplayDatasetRowTest(unittest.TestCase):
+    def test_record_has_stable_shape(self) -> None:
+        row = _row()
+
+        self.assertEqual(
+            tuple(row.to_record().keys()),
+            AUTHORITATIVE_REPLAY_DATASET_COLUMNS,
+        )
+        self.assertEqual(
+            row.to_record()["schema_version"],
+            AUTHORITATIVE_REPLAY_DATASET_SCHEMA_VERSION,
+        )
+        self.assertEqual(row.to_record()["replay_date"], "2026-05-20")
+        self.assertEqual(row.to_record()["symbol"], "SPY")
+        self.assertEqual(row.to_record()["current_score"], 5.1)
+        self.assertEqual(row.to_record()["h1_score"], 5.2)
+        self.assertEqual(row.to_record()["h5_score"], 5.3)
+        self.assertEqual(row.to_record()["blend_score"], 5.2)
+        self.assertEqual(row.to_record()["state"], "YELLOW")
+        self.assertEqual(row.to_record()["horizon"], "H1")
+        self.assertIsNone(row.to_record()["target_date"])
+        self.assertIsNone(row.to_record()["realized_current_score"])
+        self.assertIsNone(row.to_record()["realized_return"])
+        self.assertEqual(
+            row.to_record()["realized_outcome_status"],
+            REALIZED_OUTCOME_NOT_APPLICABLE,
+        )
+        self.assertEqual(row.to_record()["category"], "A")
+        self.assertEqual(row.to_record()["slot"], 1)
+        self.assertEqual(row.to_record()["category_slot"], "A1")
+        self.assertEqual(row.to_record()["glyph"], "h1")
+        self.assertEqual(row.to_record()["named_check"], "Trend Confirmation")
+        self.assertEqual(row.to_record()["check_score"], 1.1)
+        self.assertEqual(row.to_record()["replayability_class"], "replayable")
+        self.assertEqual(row.to_record()["measurement_status"], MEASUREMENT_MEASURED)
+        self.assertEqual(row.to_record()["source_module"], "fixture.module")
+        self.assertEqual(row.to_record()["function_name"], "fixture_check")
+        self.assertEqual(
+            row.to_record()["replay_row_schema_version"],
+            "calibration_replay_artifact_row.v1",
+        )
+        self.assertEqual(
+            row.to_record()["check_row_schema_version"],
+            CHECK_REPLAY_ROW_SCHEMA_VERSION,
+        )
+        self.assertEqual(
+            row.to_record()["single_date_replay_schema_version"],
+            SINGLE_DATE_REPLAY_SCHEMA_VERSION,
+        )
+        self.assertEqual(
+            row.to_record()["range_replay_schema_version"],
+            RANGE_REPLAY_RESULT_SCHEMA_VERSION,
+        )
+        self.assertEqual(
+            row.to_record()["audit_token"],
+            "single-date-asof:2026-05-20:SPY:2:101.0000",
+        )
+        self.assertEqual(
+            row.to_record()["dataset_run_id"],
+            "authoritative-replay-dataset",
+        )
+
+    def test_normalizes_symbol_category_horizon_and_state(self) -> None:
+        row = _row(symbol=" spy ", category=" a ", horizon=" h5 ", state=" yellow ")
+
+        self.assertEqual(row.symbol, "SPY")
+        self.assertEqual(row.category, "A")
+        self.assertEqual(row.horizon, "H5")
+        self.assertEqual(row.state, "YELLOW")
+        self.assertEqual(row.category_slot, "A1")
+
+    def test_available_realized_outcome_requires_all_outcome_fields(self) -> None:
+        with self.assertRaisesRegex(ValueError, "requires target_date"):
+            _row(realized_outcome_status=REALIZED_OUTCOME_AVAILABLE)
+
+        with self.assertRaisesRegex(ValueError, "requires realized_current_score"):
+            _row(
+                realized_outcome_status=REALIZED_OUTCOME_AVAILABLE,
+                target_date=date(2026, 5, 21),
+            )
+
+        with self.assertRaisesRegex(ValueError, "requires realized_return"):
+            _row(
+                realized_outcome_status=REALIZED_OUTCOME_AVAILABLE,
+                target_date=date(2026, 5, 21),
+                realized_current_score=5.7,
+            )
+
+    def test_available_realized_outcome_serializes_target_fields(self) -> None:
+        record = _row(
+            realized_outcome_status=REALIZED_OUTCOME_AVAILABLE,
+            target_date=date(2026, 5, 21),
+            realized_current_score=5.7,
+            realized_return=0.015,
+        ).to_record()
+
+        self.assertEqual(record["target_date"], "2026-05-21")
+        self.assertEqual(record["realized_current_score"], 5.7)
+        self.assertEqual(record["realized_return"], 0.015)
+        self.assertEqual(record["realized_outcome_status"], REALIZED_OUTCOME_AVAILABLE)
+
+    def test_missing_realized_outcome_can_record_target_date_without_values(
+        self,
+    ) -> None:
+        record = _row(
+            realized_outcome_status=REALIZED_OUTCOME_MISSING,
+            target_date=date(2026, 5, 25),
+        ).to_record()
+
+        self.assertEqual(record["target_date"], "2026-05-25")
+        self.assertIsNone(record["realized_current_score"])
+        self.assertIsNone(record["realized_return"])
+        self.assertEqual(record["realized_outcome_status"], REALIZED_OUTCOME_MISSING)
+
+    def test_not_applicable_rejects_outcome_values(self) -> None:
+        with self.assertRaisesRegex(ValueError, "cannot set target_date"):
+            _row(target_date=date(2026, 5, 21))
+
+        with self.assertRaisesRegex(ValueError, "cannot set realized_current_score"):
+            _row(realized_current_score=5.0)
+
+        with self.assertRaisesRegex(ValueError, "cannot set realized_return"):
+            _row(realized_return=0.01)
+
+    def test_rejects_invalid_schema_version(self) -> None:
+        with self.assertRaisesRegex(ValueError, "unsupported authoritative"):
+            _row(schema_version="bad")
+
+
+def _row(**overrides: object) -> AuthoritativeReplayDatasetRow:
+    values = {
+        "replay_date": date(2026, 5, 20),
+        "symbol": "SPY",
+        "current_score": 5.1,
+        "h1_score": 5.2,
+        "h5_score": 5.3,
+        "blend_score": 5.2,
+        "state": "YELLOW",
+        "horizon": "H1",
+        "category": "A",
+        "slot": 1,
+        "glyph": "h1",
+        "named_check": "Trend Confirmation",
+        "check_score": 1.1,
+        "replayability_class": "replayable",
+        "measurement_status": MEASUREMENT_MEASURED,
+        "source_module": "fixture.module",
+        "function_name": "fixture_check",
+        "audit_token": "single-date-asof:2026-05-20:SPY:2:101.0000",
+    }
+    values.update(overrides)
+    return AuthoritativeReplayDatasetRow(**values)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_calibration_future_data_exclusion.py
+++ b/tests/test_calibration_future_data_exclusion.py
@@ -38,7 +38,9 @@ class FutureDataExclusionTest(unittest.TestCase):
     def test_replay_record_contains_only_asof_price_rows(self) -> None:
         bundle = _bundle_with_future_rows()
         replay_result = build_single_date_replay_rows(bundle)
-        record_text = json.dumps(replay_result.to_record(), sort_keys=True)
+        record = replay_result.to_record()
+        record.pop("engine_metadata", None)
+        record_text = json.dumps(record, sort_keys=True)
 
         self.assertEqual(
             replay_result.asof_input_record["excluded_future_row_count"],
@@ -84,6 +86,8 @@ class FutureDataExclusionTest(unittest.TestCase):
 
             manifest_text = artifacts.manifest_path.read_text(encoding="utf-8")
             manifest = json.loads(manifest_text)
+            manifest["replay"].pop("engine_metadata", None)
+            manifest_text = json.dumps(manifest, sort_keys=True)
 
             with artifacts.replay_rows_csv_path.open(newline="", encoding="utf-8") as h:
                 replay_csv_rows = list(csv.DictReader(h))


### PR DESCRIPTION
Adds the M51 authoritative replay dataset row contract with stable columns, schema versioning, replay/check metadata, realized outcome fields, and validation coverage.

Also narrows future-data exclusion assertions to avoid matching provenance metadata timestamps.

Refs #453