### PR TITLE
Add authoritative dataset CLI command

### DIFF
--- a/market_health/calibration/cli.py
+++ b/market_health/calibration/cli.py
@@ -5,6 +5,16 @@ import json
 from datetime import date
 from pathlib import Path
 
+from market_health.calibration.authoritative_dataset_artifacts import (
+    write_authoritative_dataset_artifacts,
+)
+from market_health.calibration.authoritative_dataset_builder import (
+    build_authoritative_replay_dataset_rows,
+)
+from market_health.calibration.check_output import (
+    CheckReplayRow,
+    build_fixture_check_replay_rows,
+)
 from market_health.calibration.defaults import (
     assert_not_live_runtime_path,
     default_output_root,
@@ -20,6 +30,7 @@ from market_health.calibration.range_progress import (
     write_range_progress,
 )
 from market_health.calibration.range_request import build_range_replay_request
+from market_health.calibration.range_runner import RangeReplayResult, run_range_replay
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -43,6 +54,23 @@ def build_parser() -> argparse.ArgumentParser:
     range_replay.add_argument("--resume", action="store_true")
     range_replay.add_argument("--fail-fast", action="store_true")
 
+    authoritative_dataset = subparsers.add_parser(
+        "authoritative-dataset",
+        help="Build the authoritative replay dataset from a historical price cache.",
+    )
+    authoritative_dataset.add_argument("--price-cache", type=Path, required=True)
+    authoritative_dataset.add_argument("--start-date", type=_parse_date, required=True)
+    authoritative_dataset.add_argument("--end-date", type=_parse_date, required=True)
+    authoritative_dataset.add_argument("--symbols", nargs="+", required=True)
+    authoritative_dataset.add_argument("--lookback-rows", type=int, default=20)
+    authoritative_dataset.add_argument(
+        "--out", type=Path, default=default_output_root()
+    )
+    authoritative_dataset.add_argument(
+        "--dataset-run-id",
+        default="authoritative-replay-dataset",
+    )
+
     return parser
 
 
@@ -62,6 +90,11 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "range-replay":
         payload = _run_range_replay_command(args)
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0
+
+    if args.command == "authoritative-dataset":
+        payload = _run_authoritative_dataset_command(args)
         print(json.dumps(payload, indent=2, sort_keys=True))
         return 0
 
@@ -106,6 +139,70 @@ def _run_range_replay_command(args: argparse.Namespace) -> dict[str, object]:
         "progress_path": str(written_progress_path),
         "result": result.to_record(),
     }
+
+
+def _run_authoritative_dataset_command(args: argparse.Namespace) -> dict[str, object]:
+    output_root = args.out.expanduser()
+    assert_not_live_runtime_path(output_root)
+
+    price_cache_path = args.price_cache.expanduser()
+    price_cache = read_historical_price_cache_csv(
+        price_cache_path,
+        symbols=args.symbols,
+    )
+    range_request = build_range_replay_request(
+        start_date=args.start_date,
+        end_date=args.end_date,
+        symbols=args.symbols,
+        lookback_rows=args.lookback_rows,
+        output_root=output_root,
+    )
+    range_result = run_range_replay(
+        request=range_request,
+        price_rows=price_cache.rows,
+    )
+    check_rows = _build_authoritative_dataset_check_rows(range_result)
+    dataset_rows = build_authoritative_replay_dataset_rows(
+        range_result=range_result,
+        check_rows=check_rows,
+        price_rows=price_cache.rows,
+        dataset_run_id=args.dataset_run_id,
+    )
+    artifacts = write_authoritative_dataset_artifacts(
+        output_root=output_root,
+        rows=dataset_rows,
+        dataset_run_id=args.dataset_run_id,
+    )
+
+    return {
+        "status": "ok",
+        "command": "authoritative-dataset",
+        "price_cache_path": str(price_cache_path),
+        "dataset_run_id": args.dataset_run_id,
+        "row_count": artifacts.row_count,
+        "artifacts": artifacts.to_record(),
+    }
+
+
+def _build_authoritative_dataset_check_rows(
+    range_result: RangeReplayResult,
+) -> tuple[CheckReplayRow, ...]:
+    rows: list[CheckReplayRow] = []
+    for result in range_result.results:
+        eligible_symbols = result.asof_input_record.get("eligible_symbols")
+        if isinstance(eligible_symbols, list | tuple):
+            symbols = tuple(str(symbol) for symbol in eligible_symbols)
+        else:
+            symbols = tuple(row.symbol for row in result.rows)
+
+        rows.extend(
+            build_fixture_check_replay_rows(
+                replay_date=result.replay_date,
+                symbols=symbols,
+            )
+        )
+
+    return tuple(rows)
 
 
 def _parse_date(value: str) -> date:

--- a/tests/test_calibration_authoritative_dataset_cli.py
+++ b/tests/test_calibration_authoritative_dataset_cli.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import csv
+import io
+import json
+import sqlite3
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from datetime import date
+from pathlib import Path
+
+from market_health.calibration.authoritative_dataset_export import (
+    AUTHORITATIVE_REPLAY_DATASET_ROWS_TABLE,
+)
+from market_health.calibration.cli import build_parser, main
+from market_health.calibration.price_cache import HISTORICAL_PRICE_CACHE_COLUMNS
+
+
+class AuthoritativeDatasetCliTest(unittest.TestCase):
+    def test_authoritative_dataset_help_is_registered(self) -> None:
+        parser = build_parser()
+        self.assertIn("authoritative-dataset", parser.format_help())
+
+    def test_authoritative_dataset_command_writes_artifacts_and_outputs_json(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            price_cache_path = tmp_path / "prices.csv"
+            output_root = tmp_path / "calibration"
+            _write_price_cache(price_cache_path)
+
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                exit_code = main(
+                    [
+                        "authoritative-dataset",
+                        "--price-cache",
+                        str(price_cache_path),
+                        "--start-date",
+                        "2026-05-20",
+                        "--end-date",
+                        "2026-05-20",
+                        "--symbols",
+                        "SPY",
+                        "--lookback-rows",
+                        "1",
+                        "--out",
+                        str(output_root),
+                        "--dataset-run-id",
+                        "dataset-test",
+                    ]
+                )
+
+            payload = json.loads(stdout.getvalue())
+            artifacts = payload["artifacts"]
+            csv_path = Path(artifacts["dataset_csv_path"])
+            sqlite_path = Path(artifacts["dataset_sqlite_path"])
+            validation_summary_path = Path(artifacts["validation_summary_path"])
+            manifest_path = Path(artifacts["manifest_path"])
+
+            with csv_path.open(newline="", encoding="utf-8") as handle:
+                csv_rows = list(csv.DictReader(handle))
+
+            with sqlite3.connect(sqlite_path) as conn:
+                sqlite_count = conn.execute(
+                    f"SELECT COUNT(*) FROM {AUTHORITATIVE_REPLAY_DATASET_ROWS_TABLE}"
+                ).fetchone()[0]
+
+            validation_summary = json.loads(
+                validation_summary_path.read_text(encoding="utf-8")
+            )
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(payload["command"], "authoritative-dataset")
+        self.assertEqual(payload["dataset_run_id"], "dataset-test")
+        self.assertEqual(payload["row_count"], 90)
+        self.assertEqual(len(csv_rows), 90)
+        self.assertEqual(sqlite_count, 90)
+        self.assertEqual(validation_summary["row_count"], 90)
+        self.assertEqual(manifest["artifacts"]["row_count"], 90)
+        self.assertEqual(
+            validation_summary["realized_outcome_status_counts"],
+            {"available": 60, "missing": 0, "not_applicable": 30},
+        )
+
+    def test_authoritative_dataset_rejects_bad_date(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            price_cache_path = Path(tmp) / "prices.csv"
+            _write_price_cache(price_cache_path)
+
+            with self.assertRaises(SystemExit) as raised:
+                main(
+                    [
+                        "authoritative-dataset",
+                        "--price-cache",
+                        str(price_cache_path),
+                        "--start-date",
+                        "2026/05/20",
+                        "--end-date",
+                        "2026-05-20",
+                        "--symbols",
+                        "SPY",
+                    ]
+                )
+
+        self.assertEqual(raised.exception.code, 2)
+
+
+def _write_price_cache(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    rows = [
+        _price_row(date(2026, 5, 20), 100.0),
+        _price_row(date(2026, 5, 21), 103.0),
+        _price_row(date(2026, 5, 22), 104.0),
+        _price_row(date(2026, 5, 26), 106.0),
+        _price_row(date(2026, 5, 27), 108.0),
+        _price_row(date(2026, 5, 28), 110.0),
+    ]
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=HISTORICAL_PRICE_CACHE_COLUMNS)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _price_row(price_date: date, close: float) -> dict[str, str]:
+    return {
+        "schema_version": "historical_price_cache.v1",
+        "source": "fixture",
+        "symbol": "SPY",
+        "date": price_date.isoformat(),
+        "open": str(close - 1.0),
+        "high": str(close + 1.0),
+        "low": str(close - 2.0),
+        "close": str(close),
+        "adjusted_close": str(close),
+        "volume": "1000",
+    }
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds the M51 authoritative-dataset CLI command, wiring historical price cache loading, range replay, fixture check row generation, authoritative dataset row building, artifact writing, and JSON command output.

Refs #458