### PR TITLE
Add residual attribution row schema

### DIFF
--- a/market_health/calibration/residuals.py
+++ b/market_health/calibration/residuals.py
@@ -5,11 +5,48 @@ from collections.abc import Iterable, Sequence
 from dataclasses import asdict, dataclass
 from datetime import date
 
+from market_health.calibration.authoritative_dataset import (
+    AUTHORITATIVE_REPLAY_DATASET_SCHEMA_VERSION,
+)
+from market_health.calibration.check_inventory import REPLAYABILITY_CLASSES
+from market_health.calibration.check_output import MEASUREMENT_STATUSES
 from market_health.calibration.schema import ReplayArtifactRow
 
 RESIDUAL_SCHEMA_VERSION = "calibration_forecast_residual.v1"
+RESIDUAL_ATTRIBUTION_SCHEMA_VERSION = "calibration_residual_attribution.v1"
 
 VALID_HORIZONS = ("H1", "H5")
+RESIDUAL_HOT = "hot"
+RESIDUAL_COLD = "cold"
+RESIDUAL_NEUTRAL = "neutral"
+RESIDUAL_DIRECTIONS = (RESIDUAL_HOT, RESIDUAL_COLD, RESIDUAL_NEUTRAL)
+
+RESIDUAL_ATTRIBUTION_COLUMNS = (
+    "schema_version",
+    "replay_date",
+    "symbol",
+    "horizon",
+    "target_date",
+    "forecast_score",
+    "realized_current_score",
+    "residual",
+    "residual_direction",
+    "realized_return",
+    "category",
+    "slot",
+    "category_slot",
+    "glyph",
+    "named_check",
+    "check_score",
+    "replayability_class",
+    "measurement_status",
+    "source_module",
+    "function_name",
+    "audit_token",
+    "dataset_run_id",
+    "authoritative_dataset_schema_version",
+    "residual_attribution_run_id",
+)
 
 
 @dataclass(frozen=True)
@@ -30,6 +67,140 @@ class ResidualObservation:
 
     def to_record(self) -> dict[str, object]:
         return asdict(self)
+
+
+@dataclass(frozen=True)
+class ResidualAttributionRow:
+    replay_date: date
+    symbol: str
+    horizon: str
+    target_date: date
+    forecast_score: float
+    realized_current_score: float
+    residual: float
+    residual_direction: str
+    category: str
+    slot: int
+    glyph: str
+    named_check: str
+    check_score: float
+    replayability_class: str
+    measurement_status: str
+    source_module: str
+    function_name: str
+    audit_token: str
+    dataset_run_id: str
+    realized_return: float | None = None
+    authoritative_dataset_schema_version: str = (
+        AUTHORITATIVE_REPLAY_DATASET_SCHEMA_VERSION
+    )
+    residual_attribution_run_id: str = "residual-attribution"
+    schema_version: str = RESIDUAL_ATTRIBUTION_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if self.schema_version != RESIDUAL_ATTRIBUTION_SCHEMA_VERSION:
+            raise ValueError(
+                f"unsupported residual attribution schema version: {self.schema_version}"
+            )
+        if (
+            self.authoritative_dataset_schema_version
+            != AUTHORITATIVE_REPLAY_DATASET_SCHEMA_VERSION
+        ):
+            raise ValueError(
+                "unsupported authoritative dataset schema version for residual "
+                f"attribution: {self.authoritative_dataset_schema_version}"
+            )
+
+        symbol = self.symbol.strip().upper()
+        horizon = self.horizon.strip().upper()
+        category = self.category.strip().upper()
+
+        if not symbol:
+            raise ValueError("residual attribution symbol is required")
+        if horizon not in VALID_HORIZONS:
+            raise ValueError(
+                f"unsupported residual attribution horizon: {self.horizon}"
+            )
+        if category not in {"A", "B", "C", "D", "E"}:
+            raise ValueError(
+                f"unsupported residual attribution category: {self.category}"
+            )
+        if not 1 <= self.slot <= 6:
+            raise ValueError(f"unsupported residual attribution slot: {self.slot}")
+        if self.residual_direction not in RESIDUAL_DIRECTIONS:
+            raise ValueError(
+                f"unsupported residual attribution direction: {self.residual_direction}"
+            )
+        if self.residual_direction != residual_direction(self.residual):
+            raise ValueError(
+                "residual attribution direction does not match residual sign"
+            )
+        if round(self.residual, 8) != round(
+            self.forecast_score - self.realized_current_score,
+            8,
+        ):
+            raise ValueError(
+                "residual attribution residual must equal forecast_score minus "
+                "realized_current_score"
+            )
+        if self.replayability_class not in REPLAYABILITY_CLASSES:
+            raise ValueError(
+                f"unsupported residual replayability class: {self.replayability_class}"
+            )
+        if self.measurement_status not in MEASUREMENT_STATUSES:
+            raise ValueError(
+                f"unsupported residual measurement status: {self.measurement_status}"
+            )
+
+        for field_name in (
+            "glyph",
+            "named_check",
+            "source_module",
+            "function_name",
+            "audit_token",
+            "dataset_run_id",
+            "residual_attribution_run_id",
+        ):
+            if not str(getattr(self, field_name)).strip():
+                raise ValueError(f"residual attribution {field_name} is required")
+
+        object.__setattr__(self, "symbol", symbol)
+        object.__setattr__(self, "horizon", horizon)
+        object.__setattr__(self, "category", category)
+
+    @property
+    def category_slot(self) -> str:
+        return f"{self.category}{self.slot}"
+
+    def to_record(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "replay_date": self.replay_date.isoformat(),
+            "symbol": self.symbol,
+            "horizon": self.horizon,
+            "target_date": self.target_date.isoformat(),
+            "forecast_score": self.forecast_score,
+            "realized_current_score": self.realized_current_score,
+            "residual": self.residual,
+            "residual_direction": self.residual_direction,
+            "realized_return": self.realized_return,
+            "category": self.category,
+            "slot": self.slot,
+            "category_slot": self.category_slot,
+            "glyph": self.glyph,
+            "named_check": self.named_check,
+            "check_score": self.check_score,
+            "replayability_class": self.replayability_class,
+            "measurement_status": self.measurement_status,
+            "source_module": self.source_module,
+            "function_name": self.function_name,
+            "audit_token": self.audit_token,
+            "dataset_run_id": self.dataset_run_id,
+            "authoritative_dataset_schema_version": (
+                self.authoritative_dataset_schema_version
+            ),
+            "residual_attribution_run_id": self.residual_attribution_run_id,
+        }
 
 
 @dataclass(frozen=True)

--- a/tests/test_calibration_residuals.py
+++ b/tests/test_calibration_residuals.py
@@ -4,7 +4,10 @@ import unittest
 from datetime import date
 
 from market_health.calibration.residuals import (
+    RESIDUAL_ATTRIBUTION_COLUMNS,
+    RESIDUAL_ATTRIBUTION_SCHEMA_VERSION,
     RESIDUAL_SCHEMA_VERSION,
+    ResidualAttributionRow,
     build_residual_observation,
     forecast_score_for_horizon,
     residual_direction,
@@ -148,6 +151,106 @@ class CalibrationResidualsTest(unittest.TestCase):
         self.assertEqual(summary.count, 2)
         self.assertEqual(summary.mean_residual, 0.5)
         self.assertEqual(summary.hot_count, 2)
+
+
+class ResidualAttributionRowTest(unittest.TestCase):
+    def test_record_has_stable_shape(self) -> None:
+        residual_row = residual_attribution_row()
+
+        record = residual_row.to_record()
+
+        self.assertEqual(tuple(record.keys()), RESIDUAL_ATTRIBUTION_COLUMNS)
+        self.assertEqual(record["schema_version"], RESIDUAL_ATTRIBUTION_SCHEMA_VERSION)
+        self.assertEqual(record["replay_date"], "2026-05-20")
+        self.assertEqual(record["symbol"], "SPY")
+        self.assertEqual(record["horizon"], "H1")
+        self.assertEqual(record["target_date"], "2026-05-21")
+        self.assertEqual(record["forecast_score"], 8.5)
+        self.assertEqual(record["realized_current_score"], 8.0)
+        self.assertEqual(record["residual"], 0.5)
+        self.assertEqual(record["residual_direction"], "hot")
+        self.assertEqual(record["category_slot"], "B4")
+        self.assertEqual(record["dataset_run_id"], "dataset-test")
+        self.assertEqual(record["residual_attribution_run_id"], "m52-test")
+
+    def test_normalizes_symbol_horizon_and_category(self) -> None:
+        residual_row = residual_attribution_row(
+            symbol=" spy ",
+            horizon=" h5 ",
+            category=" b ",
+            slot=5,
+            forecast_score=7.0,
+            realized_current_score=7.5,
+            residual=-0.5,
+            residual_direction="cold",
+        )
+
+        self.assertEqual(residual_row.symbol, "SPY")
+        self.assertEqual(residual_row.horizon, "H5")
+        self.assertEqual(residual_row.category, "B")
+        self.assertEqual(residual_row.category_slot, "B5")
+
+    def test_rejects_invalid_horizon(self) -> None:
+        with self.assertRaisesRegex(ValueError, "horizon"):
+            residual_attribution_row(horizon="C")
+
+    def test_rejects_direction_that_does_not_match_residual_sign(self) -> None:
+        with self.assertRaisesRegex(ValueError, "direction"):
+            residual_attribution_row(
+                residual=0.5,
+                residual_direction="cold",
+            )
+
+    def test_rejects_residual_that_does_not_match_scores(self) -> None:
+        with self.assertRaisesRegex(ValueError, "forecast_score minus"):
+            residual_attribution_row(
+                forecast_score=8.5,
+                realized_current_score=8.0,
+                residual=0.25,
+                residual_direction="hot",
+            )
+
+    def test_rejects_invalid_schema_version(self) -> None:
+        with self.assertRaisesRegex(ValueError, "schema version"):
+            residual_attribution_row(schema_version="bad.version")
+
+
+def residual_attribution_row(
+    *,
+    symbol: str = "SPY",
+    horizon: str = "H1",
+    category: str = "B",
+    slot: int = 4,
+    forecast_score: float = 8.5,
+    realized_current_score: float = 8.0,
+    residual: float = 0.5,
+    residual_direction: str = "hot",
+    schema_version: str = RESIDUAL_ATTRIBUTION_SCHEMA_VERSION,
+) -> ResidualAttributionRow:
+    return ResidualAttributionRow(
+        replay_date=date(2026, 5, 20),
+        symbol=symbol,
+        horizon=horizon,
+        target_date=date(2026, 5, 21),
+        forecast_score=forecast_score,
+        realized_current_score=realized_current_score,
+        residual=residual,
+        residual_direction=residual_direction,
+        realized_return=0.03,
+        category=category,
+        slot=slot,
+        glyph="+",
+        named_check="trend_confirmed",
+        check_score=4.1,
+        replayability_class="replayable",
+        measurement_status="measured",
+        source_module="fixture.module",
+        function_name="check_b4",
+        audit_token="single-date-asof:2026-05-20:SPY:1:100.0000",
+        dataset_run_id="dataset-test",
+        residual_attribution_run_id="m52-test",
+        schema_version=schema_version,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds the M52 residual attribution row schema with stable columns, validation, deterministic serialization, residual direction checks, and authoritative dataset lineage fields.

Refs #465