### PR TITLE
Build residual attribution rows

### DIFF
--- a/market_health/calibration/residuals.py
+++ b/market_health/calibration/residuals.py
@@ -7,6 +7,8 @@ from datetime import date
 
 from market_health.calibration.authoritative_dataset import (
     AUTHORITATIVE_REPLAY_DATASET_SCHEMA_VERSION,
+    REALIZED_OUTCOME_AVAILABLE,
+    AuthoritativeReplayDatasetRow,
 )
 from market_health.calibration.check_inventory import REPLAYABILITY_CLASSES
 from market_health.calibration.check_output import MEASUREMENT_STATUSES
@@ -264,6 +266,87 @@ def build_residual_observation(
         slot=slot,
         glyph=glyph,
         named_check=named_check,
+    )
+
+
+def forecast_score_for_authoritative_row(
+    row: AuthoritativeReplayDatasetRow,
+) -> float:
+    horizon = row.horizon.upper()
+    if horizon == "H1":
+        return row.h1_score
+    if horizon == "H5":
+        return row.h5_score
+    raise ValueError(f"unsupported residual attribution horizon: {row.horizon}")
+
+
+def build_residual_attribution_rows(
+    authoritative_rows: Iterable[AuthoritativeReplayDatasetRow],
+    *,
+    residual_attribution_run_id: str = "residual-attribution",
+) -> tuple[ResidualAttributionRow, ...]:
+    residual_rows: list[ResidualAttributionRow] = []
+
+    for row in sorted(authoritative_rows, key=_authoritative_residual_sort_key):
+        if row.realized_outcome_status != REALIZED_OUTCOME_AVAILABLE:
+            continue
+
+        if row.target_date is None:
+            raise ValueError("available residual attribution row requires target_date")
+        if row.realized_current_score is None:
+            raise ValueError(
+                "available residual attribution row requires realized_current_score"
+            )
+        if row.realized_return is None:
+            raise ValueError(
+                "available residual attribution row requires realized_return"
+            )
+
+        forecast_score = forecast_score_for_authoritative_row(row)
+        residual = round(forecast_score - row.realized_current_score, 8)
+
+        residual_rows.append(
+            ResidualAttributionRow(
+                replay_date=row.replay_date,
+                symbol=row.symbol,
+                horizon=row.horizon,
+                target_date=row.target_date,
+                forecast_score=forecast_score,
+                realized_current_score=row.realized_current_score,
+                residual=residual,
+                residual_direction=residual_direction(residual),
+                realized_return=row.realized_return,
+                category=row.category,
+                slot=row.slot,
+                glyph=row.glyph,
+                named_check=row.named_check,
+                check_score=row.check_score,
+                replayability_class=row.replayability_class,
+                measurement_status=row.measurement_status,
+                source_module=row.source_module,
+                function_name=row.function_name,
+                audit_token=row.audit_token,
+                dataset_run_id=row.dataset_run_id,
+                authoritative_dataset_schema_version=row.schema_version,
+                residual_attribution_run_id=residual_attribution_run_id,
+            )
+        )
+
+    return tuple(residual_rows)
+
+
+def _authoritative_residual_sort_key(
+    row: AuthoritativeReplayDatasetRow,
+) -> tuple[str, str, str, int, str, str, str]:
+    target_date = "" if row.target_date is None else row.target_date.isoformat()
+    return (
+        row.replay_date.isoformat(),
+        row.symbol,
+        row.category,
+        row.slot,
+        row.horizon,
+        target_date,
+        row.named_check,
     )
 
 

--- a/tests/test_calibration_residuals.py
+++ b/tests/test_calibration_residuals.py
@@ -3,11 +3,18 @@ from __future__ import annotations
 import unittest
 from datetime import date
 
+from market_health.calibration.authoritative_dataset import (
+    REALIZED_OUTCOME_AVAILABLE,
+    REALIZED_OUTCOME_MISSING,
+    REALIZED_OUTCOME_NOT_APPLICABLE,
+    AuthoritativeReplayDatasetRow,
+)
 from market_health.calibration.residuals import (
     RESIDUAL_ATTRIBUTION_COLUMNS,
     RESIDUAL_ATTRIBUTION_SCHEMA_VERSION,
     RESIDUAL_SCHEMA_VERSION,
     ResidualAttributionRow,
+    build_residual_attribution_rows,
     build_residual_observation,
     forecast_score_for_horizon,
     residual_direction,
@@ -250,6 +257,160 @@ def residual_attribution_row(
         dataset_run_id="dataset-test",
         residual_attribution_run_id="m52-test",
         schema_version=schema_version,
+    )
+
+
+class ResidualAttributionBuilderTest(unittest.TestCase):
+    def test_builds_rows_from_available_authoritative_rows(self) -> None:
+        rows = build_residual_attribution_rows(
+            [
+                authoritative_dataset_row(
+                    horizon="H1",
+                    h1_score=8.5,
+                    realized_current_score=8.0,
+                    realized_return=0.03,
+                )
+            ],
+            residual_attribution_run_id="m52-builder-test",
+        )
+
+        self.assertEqual(len(rows), 1)
+        residual_row = rows[0]
+        self.assertEqual(residual_row.symbol, "SPY")
+        self.assertEqual(residual_row.horizon, "H1")
+        self.assertEqual(residual_row.forecast_score, 8.5)
+        self.assertEqual(residual_row.realized_current_score, 8.0)
+        self.assertEqual(residual_row.residual, 0.5)
+        self.assertEqual(residual_row.residual_direction, "hot")
+        self.assertEqual(residual_row.realized_return, 0.03)
+        self.assertEqual(residual_row.category_slot, "B4")
+        self.assertEqual(residual_row.dataset_run_id, "dataset-test")
+        self.assertEqual(residual_row.residual_attribution_run_id, "m52-builder-test")
+
+    def test_uses_h5_score_for_h5_rows(self) -> None:
+        rows = build_residual_attribution_rows(
+            [
+                authoritative_dataset_row(
+                    horizon="H5",
+                    h5_score=6.5,
+                    realized_current_score=7.0,
+                    realized_return=0.05,
+                )
+            ]
+        )
+
+        self.assertEqual(rows[0].forecast_score, 6.5)
+        self.assertEqual(rows[0].residual, -0.5)
+        self.assertEqual(rows[0].residual_direction, "cold")
+
+    def test_excludes_missing_and_not_applicable_outcomes(self) -> None:
+        rows = build_residual_attribution_rows(
+            [
+                authoritative_dataset_row(
+                    horizon="H1",
+                    realized_outcome_status=REALIZED_OUTCOME_MISSING,
+                    target_date=date(2026, 5, 21),
+                    realized_current_score=None,
+                    realized_return=None,
+                ),
+                authoritative_dataset_row(
+                    horizon="C",
+                    realized_outcome_status=REALIZED_OUTCOME_NOT_APPLICABLE,
+                    target_date=None,
+                    realized_current_score=None,
+                    realized_return=None,
+                ),
+                authoritative_dataset_row(
+                    horizon="H5",
+                    realized_outcome_status=REALIZED_OUTCOME_AVAILABLE,
+                    target_date=date(2026, 5, 27),
+                    h5_score=7.5,
+                    realized_current_score=7.5,
+                    realized_return=0.01,
+                ),
+            ]
+        )
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0].horizon, "H5")
+        self.assertEqual(rows[0].residual_direction, "neutral")
+
+    def test_rows_are_sorted_deterministically(self) -> None:
+        rows = build_residual_attribution_rows(
+            [
+                authoritative_dataset_row(
+                    symbol="QQQ",
+                    category="C",
+                    slot=2,
+                    horizon="H1",
+                ),
+                authoritative_dataset_row(
+                    symbol="SPY",
+                    category="B",
+                    slot=4,
+                    horizon="H5",
+                    target_date=date(2026, 5, 27),
+                ),
+                authoritative_dataset_row(
+                    symbol="SPY",
+                    category="A",
+                    slot=1,
+                    horizon="H1",
+                ),
+            ]
+        )
+
+        self.assertEqual(
+            [(row.symbol, row.category, row.slot, row.horizon) for row in rows],
+            [
+                ("QQQ", "C", 2, "H1"),
+                ("SPY", "A", 1, "H1"),
+                ("SPY", "B", 4, "H5"),
+            ],
+        )
+
+
+def authoritative_dataset_row(
+    *,
+    replay_date: date = date(2026, 5, 20),
+    symbol: str = "SPY",
+    current_score: float = 8.0,
+    h1_score: float = 8.5,
+    h5_score: float = 7.5,
+    blend_score: float = 8.0,
+    state: str = "GREEN",
+    horizon: str = "H1",
+    target_date: date | None = date(2026, 5, 21),
+    realized_current_score: float | None = 8.0,
+    realized_return: float | None = 0.03,
+    realized_outcome_status: str = REALIZED_OUTCOME_AVAILABLE,
+    category: str = "B",
+    slot: int = 4,
+) -> AuthoritativeReplayDatasetRow:
+    return AuthoritativeReplayDatasetRow(
+        replay_date=replay_date,
+        symbol=symbol,
+        current_score=current_score,
+        h1_score=h1_score,
+        h5_score=h5_score,
+        blend_score=blend_score,
+        state=state,
+        horizon=horizon,
+        target_date=target_date,
+        realized_current_score=realized_current_score,
+        realized_return=realized_return,
+        realized_outcome_status=realized_outcome_status,
+        category=category,
+        slot=slot,
+        glyph="+",
+        named_check="trend_confirmed",
+        check_score=4.1,
+        replayability_class="replayable",
+        measurement_status="measured",
+        source_module="fixture.module",
+        function_name="check_b4",
+        audit_token="single-date-asof:2026-05-20:SPY:1:100.0000",
+        dataset_run_id="dataset-test",
     )
 
 


### PR DESCRIPTION
Builds M52 residual attribution rows from authoritative replay dataset rows with available realized outcomes, preserving deterministic ordering, score lineage, residual direction, and dataset run lineage.

Refs #466