### PR TITLE
Add residual attribution export writers

### DIFF
--- a/market_health/calibration/residual_attribution_export.py
+++ b/market_health/calibration/residual_attribution_export.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import csv
+import sqlite3
+from collections.abc import Iterable
+from pathlib import Path
+
+from market_health.calibration.defaults import assert_not_live_runtime_path
+from market_health.calibration.residuals import (
+    RESIDUAL_ATTRIBUTION_COLUMNS,
+    RESIDUAL_ATTRIBUTION_SUMMARY_COLUMNS,
+    ResidualAttributionRow,
+    ResidualAttributionSummaryRow,
+)
+
+RESIDUAL_ATTRIBUTION_ROWS_TABLE = "calibration_residual_attribution_rows"
+RESIDUAL_ATTRIBUTION_SUMMARIES_TABLE = "calibration_residual_attribution_summaries"
+
+
+def residual_attribution_rows_to_records(
+    rows: Iterable[ResidualAttributionRow],
+) -> tuple[dict[str, object], ...]:
+    return tuple(row.to_record() for row in sorted(rows, key=_row_sort_key))
+
+
+def residual_attribution_summaries_to_records(
+    rows: Iterable[ResidualAttributionSummaryRow],
+) -> tuple[dict[str, object], ...]:
+    return tuple(row.to_record() for row in sorted(rows, key=_summary_sort_key))
+
+
+def write_residual_attribution_rows_csv(
+    path: Path,
+    rows: Iterable[ResidualAttributionRow],
+) -> None:
+    records = residual_attribution_rows_to_records(rows)
+    _write_csv(path, records, RESIDUAL_ATTRIBUTION_COLUMNS)
+
+
+def write_residual_attribution_summaries_csv(
+    path: Path,
+    rows: Iterable[ResidualAttributionSummaryRow],
+) -> None:
+    records = residual_attribution_summaries_to_records(rows)
+    _write_csv(path, records, RESIDUAL_ATTRIBUTION_SUMMARY_COLUMNS)
+
+
+def write_residual_attribution_sqlite(
+    path: Path,
+    *,
+    rows: Iterable[ResidualAttributionRow],
+    summaries: Iterable[ResidualAttributionSummaryRow],
+    rows_table_name: str = RESIDUAL_ATTRIBUTION_ROWS_TABLE,
+    summaries_table_name: str = RESIDUAL_ATTRIBUTION_SUMMARIES_TABLE,
+) -> None:
+    assert_not_live_runtime_path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    row_records = residual_attribution_rows_to_records(rows)
+    summary_records = residual_attribution_summaries_to_records(summaries)
+
+    with sqlite3.connect(path) as connection:
+        _write_table(
+            connection,
+            table_name=rows_table_name,
+            columns=RESIDUAL_ATTRIBUTION_COLUMNS,
+            records=row_records,
+        )
+        _write_table(
+            connection,
+            table_name=summaries_table_name,
+            columns=RESIDUAL_ATTRIBUTION_SUMMARY_COLUMNS,
+            records=summary_records,
+        )
+
+
+def sqlite_type_for_residual_attribution_column(column: str) -> str:
+    if column in {
+        "forecast_score",
+        "realized_current_score",
+        "residual",
+        "realized_return",
+        "mean_residual",
+        "mean_abs_residual",
+    }:
+        return "REAL"
+    if column in {
+        "slot",
+        "observation_count",
+        "hot_count",
+        "cold_count",
+        "neutral_count",
+    }:
+        return "INTEGER"
+    return "TEXT"
+
+
+def _write_csv(
+    path: Path,
+    records: tuple[dict[str, object], ...],
+    columns: tuple[str, ...],
+) -> None:
+    assert_not_live_runtime_path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=columns)
+        writer.writeheader()
+        for record in records:
+            writer.writerow(record)
+
+
+def _write_table(
+    connection: sqlite3.Connection,
+    *,
+    table_name: str,
+    columns: tuple[str, ...],
+    records: tuple[dict[str, object], ...],
+) -> None:
+    quoted_table = _quote_identifier(table_name)
+    connection.execute(f"DROP TABLE IF EXISTS {quoted_table}")
+    column_sql = ", ".join(
+        f"{_quote_identifier(column)} {sqlite_type_for_residual_attribution_column(column)}"
+        for column in columns
+    )
+    connection.execute(f"CREATE TABLE {quoted_table} ({column_sql})")
+
+    if not records:
+        return
+
+    placeholders = ", ".join("?" for _ in columns)
+    quoted_columns = ", ".join(_quote_identifier(column) for column in columns)
+    connection.executemany(
+        f"INSERT INTO {quoted_table} ({quoted_columns}) VALUES ({placeholders})",
+        [[record[column] for column in columns] for record in records],
+    )
+
+
+def _quote_identifier(value: str) -> str:
+    escaped = value.replace('"', '""')
+    return f'"{escaped}"'
+
+
+def _row_sort_key(row: ResidualAttributionRow) -> tuple[str, str, str, int, str, str]:
+    return (
+        row.replay_date.isoformat(),
+        row.symbol,
+        row.category,
+        row.slot,
+        row.horizon,
+        row.named_check,
+    )
+
+
+def _summary_sort_key(
+    row: ResidualAttributionSummaryRow,
+) -> tuple[str, str, str | None, str | None, str | None]:
+    return (
+        row.group_name,
+        row.group_value,
+        row.horizon,
+        row.category_slot,
+        row.named_check,
+    )

--- a/tests/test_calibration_residual_attribution_export.py
+++ b/tests/test_calibration_residual_attribution_export.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import csv
+import sqlite3
+import tempfile
+import unittest
+from datetime import date
+from pathlib import Path
+
+from market_health.calibration.residual_attribution_export import (
+    RESIDUAL_ATTRIBUTION_ROWS_TABLE,
+    RESIDUAL_ATTRIBUTION_SUMMARIES_TABLE,
+    residual_attribution_rows_to_records,
+    residual_attribution_summaries_to_records,
+    sqlite_type_for_residual_attribution_column,
+    write_residual_attribution_rows_csv,
+    write_residual_attribution_sqlite,
+    write_residual_attribution_summaries_csv,
+)
+from market_health.calibration.residuals import (
+    RESIDUAL_ATTRIBUTION_COLUMNS,
+    RESIDUAL_ATTRIBUTION_SUMMARY_COLUMNS,
+    ResidualAttributionRow,
+    ResidualAttributionSummaryRow,
+)
+
+
+class ResidualAttributionExportTest(unittest.TestCase):
+    def test_rows_to_records_sorts_deterministically(self) -> None:
+        records = residual_attribution_rows_to_records(
+            [
+                row(symbol="SPY", category="B", slot=4, horizon="H5"),
+                row(symbol="QQQ", category="A", slot=1, horizon="H1"),
+            ]
+        )
+
+        self.assertEqual([record["symbol"] for record in records], ["QQQ", "SPY"])
+
+    def test_summaries_to_records_sorts_deterministically(self) -> None:
+        records = residual_attribution_summaries_to_records(
+            [
+                summary(group_name="horizon+category", group_value="H1|B"),
+                summary(group_name="horizon", group_value="H1"),
+            ]
+        )
+
+        self.assertEqual(
+            [(record["group_name"], record["group_value"]) for record in records],
+            [("horizon", "H1"), ("horizon+category", "H1|B")],
+        )
+
+    def test_write_residual_attribution_rows_csv(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "rows.csv"
+
+            write_residual_attribution_rows_csv(path, [row()])
+
+            with path.open(newline="", encoding="utf-8") as handle:
+                rows = list(csv.DictReader(handle))
+
+        self.assertEqual(tuple(rows[0].keys()), RESIDUAL_ATTRIBUTION_COLUMNS)
+        self.assertEqual(rows[0]["symbol"], "SPY")
+        self.assertEqual(rows[0]["residual"], "0.5")
+
+    def test_write_residual_attribution_summaries_csv(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "summaries.csv"
+
+            write_residual_attribution_summaries_csv(path, [summary()])
+
+            with path.open(newline="", encoding="utf-8") as handle:
+                rows = list(csv.DictReader(handle))
+
+        self.assertEqual(tuple(rows[0].keys()), RESIDUAL_ATTRIBUTION_SUMMARY_COLUMNS)
+        self.assertEqual(rows[0]["group_name"], "horizon")
+        self.assertEqual(rows[0]["observation_count"], "2")
+
+    def test_write_residual_attribution_sqlite(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "residuals.sqlite"
+
+            write_residual_attribution_sqlite(
+                path,
+                rows=[
+                    row(),
+                    row(
+                        symbol="QQQ",
+                        forecast_score=7.25,
+                        realized_current_score=7.5,
+                        residual=-0.25,
+                        residual_direction="cold",
+                    ),
+                ],
+                summaries=[summary()],
+            )
+
+            with sqlite3.connect(path) as connection:
+                row_count = connection.execute(
+                    f"SELECT COUNT(*) FROM {RESIDUAL_ATTRIBUTION_ROWS_TABLE}"
+                ).fetchone()[0]
+                summary_count = connection.execute(
+                    f"SELECT COUNT(*) FROM {RESIDUAL_ATTRIBUTION_SUMMARIES_TABLE}"
+                ).fetchone()[0]
+                residual_sum = connection.execute(
+                    f"SELECT ROUND(SUM(residual), 2) FROM {RESIDUAL_ATTRIBUTION_ROWS_TABLE}"
+                ).fetchone()[0]
+
+        self.assertEqual(row_count, 2)
+        self.assertEqual(summary_count, 1)
+        self.assertEqual(residual_sum, 0.25)
+
+    def test_sqlite_type_mapping(self) -> None:
+        self.assertEqual(
+            sqlite_type_for_residual_attribution_column("residual"), "REAL"
+        )
+        self.assertEqual(
+            sqlite_type_for_residual_attribution_column("observation_count"),
+            "INTEGER",
+        )
+        self.assertEqual(sqlite_type_for_residual_attribution_column("symbol"), "TEXT")
+
+
+def row(
+    *,
+    symbol: str = "SPY",
+    horizon: str = "H1",
+    category: str = "B",
+    slot: int = 4,
+    forecast_score: float = 8.5,
+    realized_current_score: float = 8.0,
+    residual: float = 0.5,
+    residual_direction: str = "hot",
+) -> ResidualAttributionRow:
+    return ResidualAttributionRow(
+        replay_date=date(2026, 5, 20),
+        symbol=symbol,
+        horizon=horizon,
+        target_date=date(2026, 5, 21),
+        forecast_score=forecast_score,
+        realized_current_score=realized_current_score,
+        residual=residual,
+        residual_direction=residual_direction,
+        realized_return=0.03,
+        category=category,
+        slot=slot,
+        glyph="+",
+        named_check="trend_confirmed",
+        check_score=4.1,
+        replayability_class="replayable",
+        measurement_status="measured",
+        source_module="fixture.module",
+        function_name="check_b4",
+        audit_token="single-date-asof:2026-05-20:SPY:1:100.0000",
+        dataset_run_id="dataset-test",
+        residual_attribution_run_id="m52-test",
+    )
+
+
+def summary(
+    *,
+    group_name: str = "horizon",
+    group_value: str = "H1",
+) -> ResidualAttributionSummaryRow:
+    return ResidualAttributionSummaryRow(
+        group_name=group_name,
+        group_value=group_value,
+        horizon="H1",
+        observation_count=2,
+        mean_residual=0.125,
+        mean_abs_residual=0.375,
+        hot_count=1,
+        cold_count=1,
+        neutral_count=0,
+        residual_attribution_run_id="m52-test",
+    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds M52 residual attribution CSV and SQLite writers for observation rows and summary rows, with deterministic record ordering, stable table names, and column type mapping.

Refs #468