### PR TITLE
Add calibration review row schemas

### DIFF
--- a/market_health/calibration/calibration_review.py
+++ b/market_health/calibration/calibration_review.py
@@ -1,0 +1,330 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+
+from market_health.calibration.residuals import (
+    RESIDUAL_COLD,
+    RESIDUAL_HOT,
+    VALID_HORIZONS,
+)
+
+CALIBRATION_GLYPH_REVIEW_ROW_SCHEMA_VERSION = "calibration_glyph_review_row.v1"
+CALIBRATION_NAMED_CHECK_REVIEW_ROW_SCHEMA_VERSION = (
+    "calibration_named_check_review_row.v1"
+)
+
+REVIEW_HOT = RESIDUAL_HOT
+REVIEW_COLD = RESIDUAL_COLD
+REVIEW_INCONCLUSIVE = "inconclusive"
+REVIEW_CLASSIFICATIONS = (REVIEW_HOT, REVIEW_COLD, REVIEW_INCONCLUSIVE)
+
+CALIBRATION_GLYPH_REVIEW_COLUMNS = (
+    "schema_version",
+    "window_label",
+    "window_start_date",
+    "window_end_date",
+    "horizon",
+    "category",
+    "slot",
+    "category_slot",
+    "glyph",
+    "observation_count",
+    "min_observation_count",
+    "mean_residual",
+    "median_residual",
+    "mean_abs_residual",
+    "hot_count",
+    "cold_count",
+    "neutral_count",
+    "review_classification",
+    "residual_attribution_run_id",
+)
+
+CALIBRATION_NAMED_CHECK_REVIEW_COLUMNS = (
+    "schema_version",
+    "window_label",
+    "window_start_date",
+    "window_end_date",
+    "horizon",
+    "named_check",
+    "category",
+    "slot",
+    "category_slot",
+    "glyph",
+    "observation_count",
+    "min_observation_count",
+    "mean_residual",
+    "median_residual",
+    "mean_abs_residual",
+    "hot_count",
+    "cold_count",
+    "neutral_count",
+    "review_classification",
+    "residual_attribution_run_id",
+)
+
+
+@dataclass(frozen=True)
+class CalibrationGlyphReviewRow:
+    horizon: str
+    category: str
+    slot: int
+    glyph: str
+    observation_count: int
+    min_observation_count: int
+    mean_residual: float
+    median_residual: float
+    mean_abs_residual: float
+    hot_count: int
+    cold_count: int
+    neutral_count: int
+    review_classification: str
+    residual_attribution_run_id: str
+    window_label: str = "full"
+    window_start_date: date | None = None
+    window_end_date: date | None = None
+    schema_version: str = CALIBRATION_GLYPH_REVIEW_ROW_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if self.schema_version != CALIBRATION_GLYPH_REVIEW_ROW_SCHEMA_VERSION:
+            raise ValueError(
+                "unsupported calibration glyph review row schema version: "
+                f"{self.schema_version}"
+            )
+
+        horizon = _normalize_horizon(self.horizon)
+        category = _normalize_category(self.category)
+        _validate_slot(self.slot)
+        _validate_required_text(self.glyph, "glyph")
+        _validate_review_counts(
+            observation_count=self.observation_count,
+            min_observation_count=self.min_observation_count,
+            hot_count=self.hot_count,
+            cold_count=self.cold_count,
+            neutral_count=self.neutral_count,
+            review_classification=self.review_classification,
+        )
+        _validate_required_text(
+            self.residual_attribution_run_id,
+            "residual_attribution_run_id",
+        )
+        _validate_required_text(self.window_label, "window_label")
+        _validate_window_bounds(self.window_start_date, self.window_end_date)
+
+        object.__setattr__(self, "horizon", horizon)
+        object.__setattr__(self, "category", category)
+
+    @property
+    def category_slot(self) -> str:
+        return f"{self.category}{self.slot}"
+
+    def to_record(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "window_label": self.window_label,
+            "window_start_date": _optional_date(self.window_start_date),
+            "window_end_date": _optional_date(self.window_end_date),
+            "horizon": self.horizon,
+            "category": self.category,
+            "slot": self.slot,
+            "category_slot": self.category_slot,
+            "glyph": self.glyph,
+            "observation_count": self.observation_count,
+            "min_observation_count": self.min_observation_count,
+            "mean_residual": self.mean_residual,
+            "median_residual": self.median_residual,
+            "mean_abs_residual": self.mean_abs_residual,
+            "hot_count": self.hot_count,
+            "cold_count": self.cold_count,
+            "neutral_count": self.neutral_count,
+            "review_classification": self.review_classification,
+            "residual_attribution_run_id": self.residual_attribution_run_id,
+        }
+
+
+@dataclass(frozen=True)
+class CalibrationNamedCheckReviewRow:
+    horizon: str
+    named_check: str
+    observation_count: int
+    min_observation_count: int
+    mean_residual: float
+    median_residual: float
+    mean_abs_residual: float
+    hot_count: int
+    cold_count: int
+    neutral_count: int
+    review_classification: str
+    residual_attribution_run_id: str
+    category: str | None = None
+    slot: int | None = None
+    category_slot: str | None = None
+    glyph: str | None = None
+    window_label: str = "full"
+    window_start_date: date | None = None
+    window_end_date: date | None = None
+    schema_version: str = CALIBRATION_NAMED_CHECK_REVIEW_ROW_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if self.schema_version != CALIBRATION_NAMED_CHECK_REVIEW_ROW_SCHEMA_VERSION:
+            raise ValueError(
+                "unsupported calibration named-check review row schema version: "
+                f"{self.schema_version}"
+            )
+
+        horizon = _normalize_horizon(self.horizon)
+        category = None if self.category is None else _normalize_category(self.category)
+        if self.slot is not None:
+            _validate_slot(self.slot)
+        inferred_category_slot = _infer_category_slot(
+            category=category,
+            slot=self.slot,
+            category_slot=self.category_slot,
+        )
+
+        _validate_required_text(self.named_check, "named_check")
+        if self.glyph is not None:
+            _validate_required_text(self.glyph, "glyph")
+        _validate_review_counts(
+            observation_count=self.observation_count,
+            min_observation_count=self.min_observation_count,
+            hot_count=self.hot_count,
+            cold_count=self.cold_count,
+            neutral_count=self.neutral_count,
+            review_classification=self.review_classification,
+        )
+        _validate_required_text(
+            self.residual_attribution_run_id,
+            "residual_attribution_run_id",
+        )
+        _validate_required_text(self.window_label, "window_label")
+        _validate_window_bounds(self.window_start_date, self.window_end_date)
+
+        object.__setattr__(self, "horizon", horizon)
+        object.__setattr__(self, "category", category)
+        object.__setattr__(self, "category_slot", inferred_category_slot)
+
+    def to_record(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "window_label": self.window_label,
+            "window_start_date": _optional_date(self.window_start_date),
+            "window_end_date": _optional_date(self.window_end_date),
+            "horizon": self.horizon,
+            "named_check": self.named_check,
+            "category": self.category,
+            "slot": self.slot,
+            "category_slot": self.category_slot,
+            "glyph": self.glyph,
+            "observation_count": self.observation_count,
+            "min_observation_count": self.min_observation_count,
+            "mean_residual": self.mean_residual,
+            "median_residual": self.median_residual,
+            "mean_abs_residual": self.mean_abs_residual,
+            "hot_count": self.hot_count,
+            "cold_count": self.cold_count,
+            "neutral_count": self.neutral_count,
+            "review_classification": self.review_classification,
+            "residual_attribution_run_id": self.residual_attribution_run_id,
+        }
+
+
+def _normalize_horizon(value: str) -> str:
+    horizon = value.strip().upper()
+    if horizon not in VALID_HORIZONS:
+        raise ValueError(f"unsupported calibration review horizon: {value}")
+    return horizon
+
+
+def _normalize_category(value: str) -> str:
+    category = value.strip().upper()
+    if category not in {"A", "B", "C", "D", "E"}:
+        raise ValueError(f"unsupported calibration review category: {value}")
+    return category
+
+
+def _validate_slot(value: int) -> None:
+    if not 1 <= value <= 6:
+        raise ValueError(f"unsupported calibration review slot: {value}")
+
+
+def _validate_required_text(value: str, field_name: str) -> None:
+    if not value.strip():
+        raise ValueError(f"calibration review {field_name} is required")
+
+
+def _validate_review_counts(
+    *,
+    observation_count: int,
+    min_observation_count: int,
+    hot_count: int,
+    cold_count: int,
+    neutral_count: int,
+    review_classification: str,
+) -> None:
+    if observation_count <= 0:
+        raise ValueError("calibration review observation_count must be positive")
+    if min_observation_count <= 0:
+        raise ValueError("calibration review min_observation_count must be positive")
+    if hot_count < 0 or cold_count < 0 or neutral_count < 0:
+        raise ValueError("calibration review direction counts cannot be negative")
+    if hot_count + cold_count + neutral_count != observation_count:
+        raise ValueError(
+            "calibration review direction counts must equal observation_count"
+        )
+    if review_classification not in REVIEW_CLASSIFICATIONS:
+        raise ValueError(
+            f"unsupported calibration review classification: {review_classification}"
+        )
+    if (
+        observation_count < min_observation_count
+        and review_classification != REVIEW_INCONCLUSIVE
+    ):
+        raise ValueError(
+            "calibration review rows below min_observation_count must be inconclusive"
+        )
+
+
+def _infer_category_slot(
+    *,
+    category: str | None,
+    slot: int | None,
+    category_slot: str | None,
+) -> str | None:
+    if category_slot is not None and not category_slot.strip():
+        raise ValueError("calibration review category_slot cannot be blank")
+
+    inferred = None
+    if category is not None and slot is not None:
+        inferred = f"{category}{slot}"
+
+    if category_slot is None:
+        return inferred
+
+    normalized = category_slot.strip().upper()
+    if inferred is not None and normalized != inferred:
+        raise ValueError(
+            "calibration review category_slot must match category and slot"
+        )
+    return normalized
+
+
+def _validate_window_bounds(
+    window_start_date: date | None,
+    window_end_date: date | None,
+) -> None:
+    if (
+        window_start_date is not None
+        and window_end_date is not None
+        and window_start_date > window_end_date
+    ):
+        raise ValueError(
+            "calibration review window_start_date must be <= window_end_date"
+        )
+
+
+def _optional_date(value: date | None) -> str | None:
+    if value is None:
+        return None
+    return value.isoformat()

--- a/tests/test_calibration_review.py
+++ b/tests/test_calibration_review.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import unittest
+from datetime import date
+
+from market_health.calibration.calibration_review import (
+    CALIBRATION_GLYPH_REVIEW_COLUMNS,
+    CALIBRATION_GLYPH_REVIEW_ROW_SCHEMA_VERSION,
+    CALIBRATION_NAMED_CHECK_REVIEW_COLUMNS,
+    CALIBRATION_NAMED_CHECK_REVIEW_ROW_SCHEMA_VERSION,
+    REVIEW_COLD,
+    REVIEW_HOT,
+    REVIEW_INCONCLUSIVE,
+    CalibrationGlyphReviewRow,
+    CalibrationNamedCheckReviewRow,
+)
+
+
+class CalibrationGlyphReviewRowTest(unittest.TestCase):
+    def test_record_has_stable_shape(self) -> None:
+        row = glyph_review_row()
+
+        record = row.to_record()
+
+        self.assertEqual(tuple(record.keys()), CALIBRATION_GLYPH_REVIEW_COLUMNS)
+        self.assertEqual(
+            record["schema_version"],
+            CALIBRATION_GLYPH_REVIEW_ROW_SCHEMA_VERSION,
+        )
+        self.assertEqual(record["window_label"], "full")
+        self.assertIsNone(record["window_start_date"])
+        self.assertIsNone(record["window_end_date"])
+        self.assertEqual(record["horizon"], "H1")
+        self.assertEqual(record["category"], "B")
+        self.assertEqual(record["slot"], 4)
+        self.assertEqual(record["category_slot"], "B4")
+        self.assertEqual(record["glyph"], "+")
+        self.assertEqual(record["observation_count"], 5)
+        self.assertEqual(record["min_observation_count"], 3)
+        self.assertEqual(record["mean_residual"], 0.32)
+        self.assertEqual(record["median_residual"], 0.25)
+        self.assertEqual(record["mean_abs_residual"], 0.44)
+        self.assertEqual(record["hot_count"], 4)
+        self.assertEqual(record["cold_count"], 1)
+        self.assertEqual(record["neutral_count"], 0)
+        self.assertEqual(record["review_classification"], REVIEW_HOT)
+        self.assertEqual(record["residual_attribution_run_id"], "m53-test")
+
+    def test_normalizes_horizon_and_category(self) -> None:
+        row = glyph_review_row(horizon=" h5 ", category=" b ")
+
+        self.assertEqual(row.horizon, "H5")
+        self.assertEqual(row.category, "B")
+        self.assertEqual(row.category_slot, "B4")
+
+    def test_rejects_direction_count_mismatch(self) -> None:
+        with self.assertRaisesRegex(ValueError, "direction counts"):
+            glyph_review_row(
+                observation_count=5, hot_count=3, cold_count=1, neutral_count=0
+            )
+
+    def test_low_sample_rows_must_be_inconclusive(self) -> None:
+        with self.assertRaisesRegex(ValueError, "inconclusive"):
+            glyph_review_row(
+                observation_count=2,
+                min_observation_count=3,
+                hot_count=2,
+                cold_count=0,
+                neutral_count=0,
+                review_classification=REVIEW_HOT,
+            )
+
+        row = glyph_review_row(
+            observation_count=2,
+            min_observation_count=3,
+            hot_count=2,
+            cold_count=0,
+            neutral_count=0,
+            review_classification=REVIEW_INCONCLUSIVE,
+        )
+        self.assertEqual(row.review_classification, REVIEW_INCONCLUSIVE)
+
+    def test_rejects_bad_window_bounds(self) -> None:
+        with self.assertRaisesRegex(ValueError, "window_start_date"):
+            glyph_review_row(
+                window_start_date=date(2026, 5, 22),
+                window_end_date=date(2026, 5, 20),
+            )
+
+
+class CalibrationNamedCheckReviewRowTest(unittest.TestCase):
+    def test_record_has_stable_shape(self) -> None:
+        row = named_check_review_row()
+
+        record = row.to_record()
+
+        self.assertEqual(tuple(record.keys()), CALIBRATION_NAMED_CHECK_REVIEW_COLUMNS)
+        self.assertEqual(
+            record["schema_version"],
+            CALIBRATION_NAMED_CHECK_REVIEW_ROW_SCHEMA_VERSION,
+        )
+        self.assertEqual(record["window_label"], "full")
+        self.assertEqual(record["horizon"], "H1")
+        self.assertEqual(record["named_check"], "trend_confirmed")
+        self.assertEqual(record["category"], "B")
+        self.assertEqual(record["slot"], 4)
+        self.assertEqual(record["category_slot"], "B4")
+        self.assertEqual(record["glyph"], "+")
+        self.assertEqual(record["review_classification"], REVIEW_COLD)
+
+    def test_infers_category_slot_when_category_and_slot_are_available(self) -> None:
+        row = named_check_review_row(category_slot=None)
+
+        self.assertEqual(row.category_slot, "B4")
+
+    def test_rejects_category_slot_mismatch(self) -> None:
+        with self.assertRaisesRegex(ValueError, "category_slot"):
+            named_check_review_row(category_slot="B5")
+
+    def test_allows_named_check_without_category_context(self) -> None:
+        row = named_check_review_row(
+            category=None, slot=None, category_slot=None, glyph=None
+        )
+
+        self.assertIsNone(row.category)
+        self.assertIsNone(row.slot)
+        self.assertIsNone(row.category_slot)
+        self.assertIsNone(row.glyph)
+
+    def test_rejects_invalid_schema_version(self) -> None:
+        with self.assertRaisesRegex(ValueError, "schema version"):
+            named_check_review_row(schema_version="bad")
+
+
+def glyph_review_row(
+    *,
+    horizon: str = "H1",
+    category: str = "B",
+    slot: int = 4,
+    glyph: str = "+",
+    observation_count: int = 5,
+    min_observation_count: int = 3,
+    mean_residual: float = 0.32,
+    median_residual: float = 0.25,
+    mean_abs_residual: float = 0.44,
+    hot_count: int = 4,
+    cold_count: int = 1,
+    neutral_count: int = 0,
+    review_classification: str = REVIEW_HOT,
+    residual_attribution_run_id: str = "m53-test",
+    window_label: str = "full",
+    window_start_date: date | None = None,
+    window_end_date: date | None = None,
+    schema_version: str = CALIBRATION_GLYPH_REVIEW_ROW_SCHEMA_VERSION,
+) -> CalibrationGlyphReviewRow:
+    return CalibrationGlyphReviewRow(
+        horizon=horizon,
+        category=category,
+        slot=slot,
+        glyph=glyph,
+        observation_count=observation_count,
+        min_observation_count=min_observation_count,
+        mean_residual=mean_residual,
+        median_residual=median_residual,
+        mean_abs_residual=mean_abs_residual,
+        hot_count=hot_count,
+        cold_count=cold_count,
+        neutral_count=neutral_count,
+        review_classification=review_classification,
+        residual_attribution_run_id=residual_attribution_run_id,
+        window_label=window_label,
+        window_start_date=window_start_date,
+        window_end_date=window_end_date,
+        schema_version=schema_version,
+    )
+
+
+def named_check_review_row(
+    *,
+    horizon: str = "H1",
+    named_check: str = "trend_confirmed",
+    category: str | None = "B",
+    slot: int | None = 4,
+    category_slot: str | None = "B4",
+    glyph: str | None = "+",
+    observation_count: int = 4,
+    min_observation_count: int = 3,
+    mean_residual: float = -0.3,
+    median_residual: float = -0.25,
+    mean_abs_residual: float = 0.4,
+    hot_count: int = 1,
+    cold_count: int = 3,
+    neutral_count: int = 0,
+    review_classification: str = REVIEW_COLD,
+    residual_attribution_run_id: str = "m53-test",
+    window_label: str = "full",
+    window_start_date: date | None = None,
+    window_end_date: date | None = None,
+    schema_version: str = CALIBRATION_NAMED_CHECK_REVIEW_ROW_SCHEMA_VERSION,
+) -> CalibrationNamedCheckReviewRow:
+    return CalibrationNamedCheckReviewRow(
+        horizon=horizon,
+        named_check=named_check,
+        category=category,
+        slot=slot,
+        category_slot=category_slot,
+        glyph=glyph,
+        observation_count=observation_count,
+        min_observation_count=min_observation_count,
+        mean_residual=mean_residual,
+        median_residual=median_residual,
+        mean_abs_residual=mean_abs_residual,
+        hot_count=hot_count,
+        cold_count=cold_count,
+        neutral_count=neutral_count,
+        review_classification=review_classification,
+        residual_attribution_run_id=residual_attribution_run_id,
+        window_label=window_label,
+        window_start_date=window_start_date,
+        window_end_date=window_end_date,
+        schema_version=schema_version,
+    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds M53 calibration review row contracts for glyph and named-check review tables, including stable column order, window metadata, residual summary fields, min-N validation, and hot/cold/inconclusive classification.

Refs #477