### PR TITLE
Generate named-check calibration review table

### DIFF
--- a/market_health/calibration/calibration_review.py
+++ b/market_health/calibration/calibration_review.py
@@ -318,13 +318,90 @@ def _build_glyph_review_row(
     )
 
 
+def build_named_check_calibration_review_rows(
+    rows: Iterable[ResidualAttributionRow],
+    *,
+    min_observation_count: int = DEFAULT_CALIBRATION_REVIEW_MIN_OBSERVATION_COUNT,
+    window_label: str = "full",
+    window_start_date: date | None = None,
+    window_end_date: date | None = None,
+) -> tuple[CalibrationNamedCheckReviewRow, ...]:
+    buckets: dict[tuple[str, str], list[ResidualAttributionRow]] = defaultdict(list)
+
+    for row in rows:
+        buckets[(row.horizon, row.named_check)].append(row)
+
+    return tuple(
+        _build_named_check_review_row(
+            key,
+            bucket,
+            min_observation_count=min_observation_count,
+            window_label=window_label,
+            window_start_date=window_start_date,
+            window_end_date=window_end_date,
+        )
+        for key, bucket in sorted(buckets.items(), key=lambda item: item[0])
+    )
+
+
+def _build_named_check_review_row(
+    key: tuple[str, str],
+    bucket: Sequence[ResidualAttributionRow],
+    *,
+    min_observation_count: int,
+    window_label: str,
+    window_start_date: date | None,
+    window_end_date: date | None,
+) -> CalibrationNamedCheckReviewRow:
+    horizon, named_check = key
+    residuals = [row.residual for row in bucket]
+    count = len(residuals)
+    mean_residual = round(sum(residuals) / count, 8)
+
+    category = _single_value_or_none(row.category for row in bucket)
+    slot = _single_value_or_none(row.slot for row in bucket)
+    glyph = _single_value_or_none(row.glyph for row in bucket)
+
+    return CalibrationNamedCheckReviewRow(
+        horizon=horizon,
+        named_check=named_check,
+        category=category,
+        slot=slot,
+        glyph=glyph,
+        observation_count=count,
+        min_observation_count=min_observation_count,
+        mean_residual=mean_residual,
+        median_residual=round(float(median(residuals)), 8),
+        mean_abs_residual=round(sum(abs(value) for value in residuals) / count, 8),
+        hot_count=sum(row.residual_direction == RESIDUAL_HOT for row in bucket),
+        cold_count=sum(row.residual_direction == RESIDUAL_COLD for row in bucket),
+        neutral_count=sum(row.residual_direction == RESIDUAL_NEUTRAL for row in bucket),
+        review_classification=calibration_review_classification(
+            observation_count=count,
+            min_observation_count=min_observation_count,
+            mean_residual=mean_residual,
+        ),
+        residual_attribution_run_id=_single_residual_attribution_run_id(bucket),
+        window_label=window_label,
+        window_start_date=window_start_date,
+        window_end_date=window_end_date,
+    )
+
+
+def _single_value_or_none(values: Iterable[object]) -> object | None:
+    unique_values = sorted(set(values), key=lambda value: str(value))
+    if len(unique_values) == 1:
+        return unique_values[0]
+    return None
+
+
 def _single_residual_attribution_run_id(
     rows: Sequence[ResidualAttributionRow],
 ) -> str:
     run_ids = sorted({row.residual_attribution_run_id for row in rows})
     if len(run_ids) != 1:
         raise ValueError(
-            "calibration review glyph rows require exactly one "
+            "calibration review rows require exactly one "
             "residual_attribution_run_id per group"
         )
     return run_ids[0]

--- a/tests/test_calibration_named_check_review.py
+++ b/tests/test_calibration_named_check_review.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import unittest
+from datetime import date
+
+from market_health.calibration.calibration_review import (
+    REVIEW_COLD,
+    REVIEW_HOT,
+    REVIEW_INCONCLUSIVE,
+    build_named_check_calibration_review_rows,
+)
+from market_health.calibration.residuals import ResidualAttributionRow
+
+
+class CalibrationNamedCheckReviewBuilderTest(unittest.TestCase):
+    def test_builds_named_check_review_rows(self) -> None:
+        rows = (
+            residual_row(symbol="SPY", residual=0.5, residual_direction="hot"),
+            residual_row(
+                symbol="QQQ",
+                forecast_score=8.25,
+                realized_current_score=8.0,
+                residual=0.25,
+                residual_direction="hot",
+            ),
+            residual_row(
+                symbol="IWM",
+                forecast_score=7.75,
+                realized_current_score=8.0,
+                residual=-0.25,
+                residual_direction="cold",
+            ),
+            residual_row(
+                symbol="DIA",
+                named_check="breadth_confirmed",
+                category="C",
+                slot=2,
+                glyph="-",
+                forecast_score=7.25,
+                realized_current_score=7.75,
+                residual=-0.5,
+                residual_direction="cold",
+            ),
+            residual_row(
+                symbol="XLK",
+                named_check="breadth_confirmed",
+                category="C",
+                slot=2,
+                glyph="-",
+                forecast_score=7.0,
+                realized_current_score=7.25,
+                residual=-0.25,
+                residual_direction="cold",
+            ),
+            residual_row(
+                symbol="XLF",
+                named_check="macro_filter",
+                category="D",
+                slot=3,
+                glyph="F",
+                forecast_score=6.0,
+                realized_current_score=6.0,
+                residual=0.0,
+                residual_direction="neutral",
+            ),
+        )
+
+        review_rows = build_named_check_calibration_review_rows(
+            rows,
+            min_observation_count=2,
+        )
+
+        self.assertEqual(
+            [(row.horizon, row.named_check) for row in review_rows],
+            [
+                ("H1", "breadth_confirmed"),
+                ("H1", "macro_filter"),
+                ("H1", "trend_confirmed"),
+            ],
+        )
+
+        cold = review_rows[0]
+        inconclusive = review_rows[1]
+        hot = review_rows[2]
+
+        self.assertEqual(cold.category, "C")
+        self.assertEqual(cold.slot, 2)
+        self.assertEqual(cold.category_slot, "C2")
+        self.assertEqual(cold.glyph, "-")
+        self.assertEqual(cold.observation_count, 2)
+        self.assertEqual(cold.mean_residual, -0.375)
+        self.assertEqual(cold.median_residual, -0.375)
+        self.assertEqual(cold.hot_count, 0)
+        self.assertEqual(cold.cold_count, 2)
+        self.assertEqual(cold.neutral_count, 0)
+        self.assertEqual(cold.review_classification, REVIEW_COLD)
+
+        self.assertEqual(inconclusive.category, "D")
+        self.assertEqual(inconclusive.slot, 3)
+        self.assertEqual(inconclusive.category_slot, "D3")
+        self.assertEqual(inconclusive.glyph, "F")
+        self.assertEqual(inconclusive.observation_count, 1)
+        self.assertEqual(inconclusive.neutral_count, 1)
+        self.assertEqual(inconclusive.review_classification, REVIEW_INCONCLUSIVE)
+
+        self.assertEqual(hot.category, "B")
+        self.assertEqual(hot.slot, 4)
+        self.assertEqual(hot.category_slot, "B4")
+        self.assertEqual(hot.glyph, "+")
+        self.assertEqual(hot.observation_count, 3)
+        self.assertEqual(hot.mean_residual, round((0.5 + 0.25 - 0.25) / 3, 8))
+        self.assertEqual(hot.mean_abs_residual, round((0.5 + 0.25 + 0.25) / 3, 8))
+        self.assertEqual(hot.review_classification, REVIEW_HOT)
+
+    def test_omits_ambiguous_category_context_for_repeated_named_check(self) -> None:
+        review_rows = build_named_check_calibration_review_rows(
+            (
+                residual_row(),
+                residual_row(
+                    symbol="QQQ",
+                    category="C",
+                    slot=2,
+                    glyph="-",
+                    forecast_score=8.25,
+                    realized_current_score=8.0,
+                    residual=0.25,
+                ),
+            ),
+            min_observation_count=1,
+        )
+
+        self.assertEqual(len(review_rows), 1)
+        row = review_rows[0]
+        self.assertEqual(row.named_check, "trend_confirmed")
+        self.assertIsNone(row.category)
+        self.assertIsNone(row.slot)
+        self.assertIsNone(row.category_slot)
+        self.assertIsNone(row.glyph)
+
+    def test_preserves_window_metadata(self) -> None:
+        review_rows = build_named_check_calibration_review_rows(
+            (
+                residual_row(),
+                residual_row(
+                    symbol="QQQ",
+                    forecast_score=8.25,
+                    realized_current_score=8.0,
+                    residual=0.25,
+                ),
+            ),
+            min_observation_count=1,
+            window_label="60d",
+            window_start_date=date(2026, 4, 1),
+            window_end_date=date(2026, 5, 30),
+        )
+
+        self.assertEqual(len(review_rows), 1)
+        self.assertEqual(review_rows[0].window_label, "60d")
+        self.assertEqual(review_rows[0].window_start_date, date(2026, 4, 1))
+        self.assertEqual(review_rows[0].window_end_date, date(2026, 5, 30))
+
+    def test_rejects_mixed_run_ids_in_same_named_check_bucket(self) -> None:
+        with self.assertRaisesRegex(ValueError, "residual_attribution_run_id"):
+            build_named_check_calibration_review_rows(
+                (
+                    residual_row(residual_attribution_run_id="run-a"),
+                    residual_row(symbol="QQQ", residual_attribution_run_id="run-b"),
+                )
+            )
+
+
+def residual_row(
+    *,
+    symbol: str = "SPY",
+    replay_date: date = date(2026, 5, 20),
+    horizon: str = "H1",
+    category: str = "B",
+    slot: int = 4,
+    glyph: str = "+",
+    named_check: str = "trend_confirmed",
+    forecast_score: float = 8.5,
+    realized_current_score: float = 8.0,
+    residual: float = 0.5,
+    residual_direction: str = "hot",
+    residual_attribution_run_id: str = "m53-test",
+) -> ResidualAttributionRow:
+    return ResidualAttributionRow(
+        replay_date=replay_date,
+        symbol=symbol,
+        horizon=horizon,
+        target_date=date(2026, 5, 21),
+        forecast_score=forecast_score,
+        realized_current_score=realized_current_score,
+        residual=residual,
+        residual_direction=residual_direction,
+        realized_return=0.03,
+        category=category,
+        slot=slot,
+        glyph=glyph,
+        named_check=named_check,
+        check_score=4.1,
+        replayability_class="replayable",
+        measurement_status="measured",
+        source_module="fixture.module",
+        function_name="check_b4",
+        audit_token=f"single-date-asof:2026-05-20:{symbol}:1:100.0000",
+        dataset_run_id="dataset-test",
+        residual_attribution_run_id=residual_attribution_run_id,
+    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds the M53 named-check calibration review table builder from residual attribution rows.

Includes deterministic grouping by horizon/named_check, residual statistics, hot/cold/neutral counts, min-N classification, window metadata propagation, unambiguous category context preservation, and tests.

Refs #479