### PR TITLE
Add calibration review example rows

### DIFF
--- a/market_health/calibration/calibration_review.py
+++ b/market_health/calibration/calibration_review.py
@@ -70,6 +70,36 @@ CALIBRATION_NAMED_CHECK_REVIEW_COLUMNS = (
     "residual_attribution_run_id",
 )
 
+CALIBRATION_REVIEW_EXAMPLE_ROW_SCHEMA_VERSION = "calibration_review_example_row.v1"
+REVIEW_TABLE_GLYPH = "glyph"
+REVIEW_TABLE_NAMED_CHECK = "named_check"
+REVIEW_TABLES = (REVIEW_TABLE_GLYPH, REVIEW_TABLE_NAMED_CHECK)
+DEFAULT_CALIBRATION_REVIEW_EXAMPLES_PER_GROUP = 3
+
+CALIBRATION_REVIEW_EXAMPLE_COLUMNS = (
+    "schema_version",
+    "review_table",
+    "window_label",
+    "window_start_date",
+    "window_end_date",
+    "horizon",
+    "category",
+    "slot",
+    "category_slot",
+    "glyph",
+    "named_check",
+    "example_rank",
+    "replay_date",
+    "target_date",
+    "symbol",
+    "forecast_score",
+    "realized_current_score",
+    "residual",
+    "residual_direction",
+    "audit_token",
+    "residual_attribution_run_id",
+)
+
 
 @dataclass(frozen=True)
 class CalibrationGlyphReviewRow:
@@ -236,6 +266,99 @@ class CalibrationNamedCheckReviewRow:
         }
 
 
+@dataclass(frozen=True)
+class CalibrationReviewExampleRow:
+    review_table: str
+    horizon: str
+    category: str
+    slot: int
+    glyph: str
+    named_check: str
+    example_rank: int
+    replay_date: date
+    target_date: date
+    symbol: str
+    forecast_score: float
+    realized_current_score: float
+    residual: float
+    residual_direction: str
+    audit_token: str
+    residual_attribution_run_id: str
+    window_label: str = "full"
+    window_start_date: date | None = None
+    window_end_date: date | None = None
+    schema_version: str = CALIBRATION_REVIEW_EXAMPLE_ROW_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if self.schema_version != CALIBRATION_REVIEW_EXAMPLE_ROW_SCHEMA_VERSION:
+            raise ValueError(
+                "unsupported calibration review example row schema version: "
+                f"{self.schema_version}"
+            )
+        if self.review_table not in REVIEW_TABLES:
+            raise ValueError(
+                f"unsupported calibration review example table: {self.review_table}"
+            )
+
+        horizon = _normalize_horizon(self.horizon)
+        category = _normalize_category(self.category)
+        _validate_slot(self.slot)
+        _validate_required_text(self.glyph, "glyph")
+        _validate_required_text(self.named_check, "named_check")
+        _validate_required_text(self.symbol, "symbol")
+        _validate_required_text(self.audit_token, "audit_token")
+        _validate_required_text(
+            self.residual_attribution_run_id,
+            "residual_attribution_run_id",
+        )
+        _validate_required_text(self.window_label, "window_label")
+        _validate_window_bounds(self.window_start_date, self.window_end_date)
+        if self.example_rank <= 0:
+            raise ValueError("calibration review example_rank must be positive")
+        if self.residual_direction not in (
+            RESIDUAL_HOT,
+            RESIDUAL_COLD,
+            RESIDUAL_NEUTRAL,
+        ):
+            raise ValueError(
+                "unsupported calibration review example residual direction: "
+                f"{self.residual_direction}"
+            )
+
+        object.__setattr__(self, "horizon", horizon)
+        object.__setattr__(self, "category", category)
+        object.__setattr__(self, "symbol", self.symbol.strip().upper())
+
+    @property
+    def category_slot(self) -> str:
+        return f"{self.category}{self.slot}"
+
+    def to_record(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "review_table": self.review_table,
+            "window_label": self.window_label,
+            "window_start_date": _optional_date(self.window_start_date),
+            "window_end_date": _optional_date(self.window_end_date),
+            "horizon": self.horizon,
+            "category": self.category,
+            "slot": self.slot,
+            "category_slot": self.category_slot,
+            "glyph": self.glyph,
+            "named_check": self.named_check,
+            "example_rank": self.example_rank,
+            "replay_date": self.replay_date.isoformat(),
+            "target_date": self.target_date.isoformat(),
+            "symbol": self.symbol,
+            "forecast_score": self.forecast_score,
+            "realized_current_score": self.realized_current_score,
+            "residual": self.residual,
+            "residual_direction": self.residual_direction,
+            "audit_token": self.audit_token,
+            "residual_attribution_run_id": self.residual_attribution_run_id,
+        }
+
+
 def build_glyph_calibration_review_rows(
     rows: Iterable[ResidualAttributionRow],
     *,
@@ -393,6 +516,113 @@ def _single_value_or_none(values: Iterable[object]) -> object | None:
     if len(unique_values) == 1:
         return unique_values[0]
     return None
+
+
+def build_glyph_calibration_review_example_rows(
+    rows: Iterable[ResidualAttributionRow],
+    *,
+    max_examples_per_group: int = DEFAULT_CALIBRATION_REVIEW_EXAMPLES_PER_GROUP,
+    window_label: str = "full",
+    window_start_date: date | None = None,
+    window_end_date: date | None = None,
+) -> tuple[CalibrationReviewExampleRow, ...]:
+    buckets: dict[tuple[str, str, int, str], list[ResidualAttributionRow]] = (
+        defaultdict(list)
+    )
+
+    for row in rows:
+        buckets[(row.horizon, row.category, row.slot, row.glyph)].append(row)
+
+    return _build_calibration_review_example_rows(
+        buckets=sorted(buckets.items(), key=lambda item: item[0]),
+        review_table=REVIEW_TABLE_GLYPH,
+        max_examples_per_group=max_examples_per_group,
+        window_label=window_label,
+        window_start_date=window_start_date,
+        window_end_date=window_end_date,
+    )
+
+
+def build_named_check_calibration_review_example_rows(
+    rows: Iterable[ResidualAttributionRow],
+    *,
+    max_examples_per_group: int = DEFAULT_CALIBRATION_REVIEW_EXAMPLES_PER_GROUP,
+    window_label: str = "full",
+    window_start_date: date | None = None,
+    window_end_date: date | None = None,
+) -> tuple[CalibrationReviewExampleRow, ...]:
+    buckets: dict[tuple[str, str], list[ResidualAttributionRow]] = defaultdict(list)
+
+    for row in rows:
+        buckets[(row.horizon, row.named_check)].append(row)
+
+    return _build_calibration_review_example_rows(
+        buckets=sorted(buckets.items(), key=lambda item: item[0]),
+        review_table=REVIEW_TABLE_NAMED_CHECK,
+        max_examples_per_group=max_examples_per_group,
+        window_label=window_label,
+        window_start_date=window_start_date,
+        window_end_date=window_end_date,
+    )
+
+
+def _build_calibration_review_example_rows(
+    *,
+    buckets: Sequence[tuple[object, list[ResidualAttributionRow]]],
+    review_table: str,
+    max_examples_per_group: int,
+    window_label: str,
+    window_start_date: date | None,
+    window_end_date: date | None,
+) -> tuple[CalibrationReviewExampleRow, ...]:
+    if max_examples_per_group <= 0:
+        raise ValueError("max_examples_per_group must be positive")
+
+    example_rows: list[CalibrationReviewExampleRow] = []
+    for _, bucket in buckets:
+        for rank, row in enumerate(
+            sorted(bucket, key=_example_sort_key)[:max_examples_per_group],
+            start=1,
+        ):
+            example_rows.append(
+                CalibrationReviewExampleRow(
+                    review_table=review_table,
+                    horizon=row.horizon,
+                    category=row.category,
+                    slot=row.slot,
+                    glyph=row.glyph,
+                    named_check=row.named_check,
+                    example_rank=rank,
+                    replay_date=row.replay_date,
+                    target_date=row.target_date,
+                    symbol=row.symbol,
+                    forecast_score=row.forecast_score,
+                    realized_current_score=row.realized_current_score,
+                    residual=row.residual,
+                    residual_direction=row.residual_direction,
+                    audit_token=row.audit_token,
+                    residual_attribution_run_id=row.residual_attribution_run_id,
+                    window_label=window_label,
+                    window_start_date=window_start_date,
+                    window_end_date=window_end_date,
+                )
+            )
+
+    return tuple(example_rows)
+
+
+def _example_sort_key(row: ResidualAttributionRow) -> tuple[object, ...]:
+    return (
+        -abs(row.residual),
+        row.replay_date.isoformat(),
+        row.target_date.isoformat(),
+        row.symbol,
+        row.category,
+        row.slot,
+        row.glyph,
+        row.named_check,
+        row.audit_token,
+    )
 
 
 def _single_residual_attribution_run_id(

--- a/tests/test_calibration_review_examples.py
+++ b/tests/test_calibration_review_examples.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+import unittest
+from datetime import date
+
+from market_health.calibration.calibration_review import (
+    CALIBRATION_REVIEW_EXAMPLE_COLUMNS,
+    CALIBRATION_REVIEW_EXAMPLE_ROW_SCHEMA_VERSION,
+    REVIEW_TABLE_GLYPH,
+    REVIEW_TABLE_NAMED_CHECK,
+    CalibrationReviewExampleRow,
+    build_glyph_calibration_review_example_rows,
+    build_named_check_calibration_review_example_rows,
+)
+from market_health.calibration.residuals import ResidualAttributionRow
+
+
+class CalibrationReviewExampleRowTest(unittest.TestCase):
+    def test_record_has_stable_shape(self) -> None:
+        row = example_row()
+
+        record = row.to_record()
+
+        self.assertEqual(tuple(record.keys()), CALIBRATION_REVIEW_EXAMPLE_COLUMNS)
+        self.assertEqual(
+            record["schema_version"],
+            CALIBRATION_REVIEW_EXAMPLE_ROW_SCHEMA_VERSION,
+        )
+        self.assertEqual(record["review_table"], REVIEW_TABLE_GLYPH)
+        self.assertEqual(record["window_label"], "full")
+        self.assertIsNone(record["window_start_date"])
+        self.assertIsNone(record["window_end_date"])
+        self.assertEqual(record["horizon"], "H1")
+        self.assertEqual(record["category"], "B")
+        self.assertEqual(record["slot"], 4)
+        self.assertEqual(record["category_slot"], "B4")
+        self.assertEqual(record["glyph"], "+")
+        self.assertEqual(record["named_check"], "trend_confirmed")
+        self.assertEqual(record["example_rank"], 1)
+        self.assertEqual(record["replay_date"], "2026-05-20")
+        self.assertEqual(record["target_date"], "2026-05-21")
+        self.assertEqual(record["symbol"], "SPY")
+        self.assertEqual(record["forecast_score"], 8.5)
+        self.assertEqual(record["realized_current_score"], 8.0)
+        self.assertEqual(record["residual"], 0.5)
+        self.assertEqual(record["residual_direction"], "hot")
+        self.assertEqual(record["audit_token"], "audit-spy")
+        self.assertEqual(record["residual_attribution_run_id"], "m53-test")
+
+    def test_normalizes_symbol_horizon_and_category(self) -> None:
+        row = example_row(
+            symbol=" spy ",
+            horizon=" h5 ",
+            category=" b ",
+            slot=5,
+        )
+
+        self.assertEqual(row.symbol, "SPY")
+        self.assertEqual(row.horizon, "H5")
+        self.assertEqual(row.category, "B")
+        self.assertEqual(row.category_slot, "B5")
+
+    def test_rejects_invalid_table(self) -> None:
+        with self.assertRaisesRegex(ValueError, "table"):
+            example_row(review_table="bad")
+
+    def test_rejects_non_positive_rank(self) -> None:
+        with self.assertRaisesRegex(ValueError, "example_rank"):
+            example_row(example_rank=0)
+
+
+class CalibrationReviewExampleBuilderTest(unittest.TestCase):
+    def test_builds_glyph_examples_by_absolute_residual(self) -> None:
+        rows = (
+            residual_row(symbol="SPY", residual=0.5, residual_direction="hot"),
+            residual_row(
+                symbol="QQQ",
+                forecast_score=8.25,
+                realized_current_score=8.0,
+                residual=0.25,
+                residual_direction="hot",
+            ),
+            residual_row(
+                symbol="IWM",
+                forecast_score=7.25,
+                realized_current_score=8.0,
+                residual=-0.75,
+                residual_direction="cold",
+            ),
+            residual_row(
+                symbol="DIA",
+                category="C",
+                slot=2,
+                glyph="-",
+                forecast_score=7.25,
+                realized_current_score=7.75,
+                residual=-0.5,
+                residual_direction="cold",
+            ),
+            residual_row(
+                symbol="XLK",
+                category="C",
+                slot=2,
+                glyph="-",
+                forecast_score=7.0,
+                realized_current_score=7.25,
+                residual=-0.25,
+                residual_direction="cold",
+            ),
+        )
+
+        examples = build_glyph_calibration_review_example_rows(
+            rows,
+            max_examples_per_group=2,
+        )
+
+        self.assertEqual(
+            [
+                (
+                    row.review_table,
+                    row.category_slot,
+                    row.glyph,
+                    row.example_rank,
+                    row.symbol,
+                )
+                for row in examples
+            ],
+            [
+                (REVIEW_TABLE_GLYPH, "B4", "+", 1, "IWM"),
+                (REVIEW_TABLE_GLYPH, "B4", "+", 2, "SPY"),
+                (REVIEW_TABLE_GLYPH, "C2", "-", 1, "DIA"),
+                (REVIEW_TABLE_GLYPH, "C2", "-", 2, "XLK"),
+            ],
+        )
+        self.assertEqual(examples[0].residual, -0.75)
+        self.assertEqual(examples[1].residual, 0.5)
+
+    def test_builds_named_check_examples_by_absolute_residual(self) -> None:
+        rows = (
+            residual_row(symbol="SPY", residual=0.5, residual_direction="hot"),
+            residual_row(
+                symbol="QQQ",
+                forecast_score=8.25,
+                realized_current_score=8.0,
+                residual=0.25,
+                residual_direction="hot",
+            ),
+            residual_row(
+                symbol="IWM",
+                named_check="breadth_confirmed",
+                category="C",
+                slot=2,
+                glyph="-",
+                forecast_score=7.25,
+                realized_current_score=8.0,
+                residual=-0.75,
+                residual_direction="cold",
+            ),
+        )
+
+        examples = build_named_check_calibration_review_example_rows(
+            rows,
+            max_examples_per_group=1,
+        )
+
+        self.assertEqual(
+            [
+                (row.review_table, row.named_check, row.example_rank, row.symbol)
+                for row in examples
+            ],
+            [
+                (REVIEW_TABLE_NAMED_CHECK, "breadth_confirmed", 1, "IWM"),
+                (REVIEW_TABLE_NAMED_CHECK, "trend_confirmed", 1, "SPY"),
+            ],
+        )
+
+    def test_preserves_window_metadata(self) -> None:
+        examples = build_glyph_calibration_review_example_rows(
+            (residual_row(),),
+            window_label="30d",
+            window_start_date=date(2026, 5, 1),
+            window_end_date=date(2026, 5, 30),
+        )
+
+        self.assertEqual(len(examples), 1)
+        self.assertEqual(examples[0].window_label, "30d")
+        self.assertEqual(examples[0].window_start_date, date(2026, 5, 1))
+        self.assertEqual(examples[0].window_end_date, date(2026, 5, 30))
+
+    def test_rejects_non_positive_example_limit(self) -> None:
+        with self.assertRaisesRegex(ValueError, "max_examples_per_group"):
+            build_glyph_calibration_review_example_rows(
+                (residual_row(),),
+                max_examples_per_group=0,
+            )
+
+
+def example_row(
+    *,
+    review_table: str = REVIEW_TABLE_GLYPH,
+    horizon: str = "H1",
+    category: str = "B",
+    slot: int = 4,
+    glyph: str = "+",
+    named_check: str = "trend_confirmed",
+    example_rank: int = 1,
+    replay_date: date = date(2026, 5, 20),
+    target_date: date = date(2026, 5, 21),
+    symbol: str = "SPY",
+    forecast_score: float = 8.5,
+    realized_current_score: float = 8.0,
+    residual: float = 0.5,
+    residual_direction: str = "hot",
+    audit_token: str = "audit-spy",
+    residual_attribution_run_id: str = "m53-test",
+) -> CalibrationReviewExampleRow:
+    return CalibrationReviewExampleRow(
+        review_table=review_table,
+        horizon=horizon,
+        category=category,
+        slot=slot,
+        glyph=glyph,
+        named_check=named_check,
+        example_rank=example_rank,
+        replay_date=replay_date,
+        target_date=target_date,
+        symbol=symbol,
+        forecast_score=forecast_score,
+        realized_current_score=realized_current_score,
+        residual=residual,
+        residual_direction=residual_direction,
+        audit_token=audit_token,
+        residual_attribution_run_id=residual_attribution_run_id,
+    )
+
+
+def residual_row(
+    *,
+    symbol: str = "SPY",
+    replay_date: date = date(2026, 5, 20),
+    horizon: str = "H1",
+    category: str = "B",
+    slot: int = 4,
+    glyph: str = "+",
+    named_check: str = "trend_confirmed",
+    forecast_score: float = 8.5,
+    realized_current_score: float = 8.0,
+    residual: float = 0.5,
+    residual_direction: str = "hot",
+    residual_attribution_run_id: str = "m53-test",
+) -> ResidualAttributionRow:
+    return ResidualAttributionRow(
+        replay_date=replay_date,
+        symbol=symbol,
+        horizon=horizon,
+        target_date=date(2026, 5, 21),
+        forecast_score=forecast_score,
+        realized_current_score=realized_current_score,
+        residual=residual,
+        residual_direction=residual_direction,
+        realized_return=0.03,
+        category=category,
+        slot=slot,
+        glyph=glyph,
+        named_check=named_check,
+        check_score=4.1,
+        replayability_class="replayable",
+        measurement_status="measured",
+        source_module="fixture.module",
+        function_name="check_b4",
+        audit_token=f"audit-{symbol.lower()}",
+        dataset_run_id="dataset-test",
+        residual_attribution_run_id=residual_attribution_run_id,
+    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds M53 calibration review example rows for glyph and named-check review tables.

Includes a stable example row contract, deterministic selection by absolute residual with tie-breakers, per-group example limits, window metadata propagation, and tests.

Refs #480