### PR TITLE
Add calibration review artifacts and CLI

### DIFF
--- a/market_health/calibration/calibration_review_artifacts.py
+++ b/market_health/calibration/calibration_review_artifacts.py
@@ -1,0 +1,368 @@
+from __future__ import annotations
+
+import json
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+
+from market_health.calibration.calibration_review import (
+    CALIBRATION_GLYPH_REVIEW_ROW_SCHEMA_VERSION,
+    CALIBRATION_NAMED_CHECK_REVIEW_ROW_SCHEMA_VERSION,
+    CALIBRATION_REVIEW_EXAMPLE_ROW_SCHEMA_VERSION,
+    CALIBRATION_REVIEW_WINDOW_SUMMARY_SCHEMA_VERSION,
+    REVIEW_COLD,
+    REVIEW_HOT,
+    REVIEW_INCONCLUSIVE,
+    CalibrationGlyphReviewRow,
+    CalibrationNamedCheckReviewRow,
+    CalibrationReviewExampleRow,
+    CalibrationReviewWindowedTables,
+)
+from market_health.calibration.calibration_review_export import (
+    CALIBRATION_GLYPH_REVIEW_EXAMPLES_TABLE,
+    CALIBRATION_GLYPH_REVIEW_ROWS_TABLE,
+    CALIBRATION_NAMED_CHECK_REVIEW_EXAMPLES_TABLE,
+    CALIBRATION_NAMED_CHECK_REVIEW_ROWS_TABLE,
+    CALIBRATION_REVIEW_WINDOW_SUMMARIES_TABLE,
+    write_calibration_review_examples_csv,
+    write_calibration_review_sqlite,
+    write_calibration_review_window_summaries_csv,
+    write_glyph_review_rows_csv,
+    write_named_check_review_rows_csv,
+)
+from market_health.calibration.defaults import assert_not_live_runtime_path
+
+CALIBRATION_REVIEW_ARTIFACT_SCHEMA_VERSION = "calibration_review_artifacts.v1"
+CALIBRATION_REVIEW_VALIDATION_SUMMARY_SCHEMA_VERSION = (
+    "calibration_review_validation_summary.v1"
+)
+
+CALIBRATION_GLYPH_REVIEW_ROWS_CSV_FILENAME = "glyph_review_rows.csv"
+CALIBRATION_NAMED_CHECK_REVIEW_ROWS_CSV_FILENAME = "named_check_review_rows.csv"
+CALIBRATION_GLYPH_REVIEW_EXAMPLES_CSV_FILENAME = "glyph_review_examples.csv"
+CALIBRATION_NAMED_CHECK_REVIEW_EXAMPLES_CSV_FILENAME = "named_check_review_examples.csv"
+CALIBRATION_REVIEW_WINDOW_SUMMARIES_CSV_FILENAME = "window_summaries.csv"
+CALIBRATION_REVIEW_SQLITE_FILENAME = "calibration_review.sqlite"
+CALIBRATION_REVIEW_VALIDATION_SUMMARY_FILENAME = "validation_summary.json"
+CALIBRATION_REVIEW_MANIFEST_FILENAME = "manifest.json"
+
+
+@dataclass(frozen=True)
+class CalibrationReviewValidationSummary:
+    window_count: int
+    residual_observation_count: int
+    glyph_review_row_count: int
+    named_check_review_row_count: int
+    glyph_example_row_count: int
+    named_check_example_row_count: int
+    window_labels: tuple[str, ...]
+    residual_attribution_run_ids: tuple[str, ...]
+    review_classification_counts: dict[str, int]
+    schema_versions: tuple[str, ...]
+    schema_version: str = CALIBRATION_REVIEW_VALIDATION_SUMMARY_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if self.schema_version != CALIBRATION_REVIEW_VALIDATION_SUMMARY_SCHEMA_VERSION:
+            raise ValueError(
+                "unsupported calibration review validation summary schema version: "
+                f"{self.schema_version}"
+            )
+        for field_name in (
+            "window_count",
+            "residual_observation_count",
+            "glyph_review_row_count",
+            "named_check_review_row_count",
+            "glyph_example_row_count",
+            "named_check_example_row_count",
+        ):
+            if getattr(self, field_name) < 0:
+                raise ValueError(f"calibration review {field_name} cannot be negative")
+        for classification in self.review_classification_counts:
+            if classification not in {REVIEW_HOT, REVIEW_COLD, REVIEW_INCONCLUSIVE}:
+                raise ValueError(
+                    "unsupported calibration review classification count: "
+                    f"{classification}"
+                )
+
+    def to_record(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "window_count": self.window_count,
+            "residual_observation_count": self.residual_observation_count,
+            "glyph_review_row_count": self.glyph_review_row_count,
+            "named_check_review_row_count": self.named_check_review_row_count,
+            "glyph_example_row_count": self.glyph_example_row_count,
+            "named_check_example_row_count": self.named_check_example_row_count,
+            "window_labels": list(self.window_labels),
+            "residual_attribution_run_ids": list(self.residual_attribution_run_ids),
+            "review_classification_counts": dict(self.review_classification_counts),
+            "schema_versions": list(self.schema_versions),
+        }
+
+
+@dataclass(frozen=True)
+class CalibrationReviewArtifacts:
+    output_dir: Path
+    manifest_path: Path
+    glyph_rows_csv_path: Path
+    named_check_rows_csv_path: Path
+    glyph_examples_csv_path: Path
+    named_check_examples_csv_path: Path
+    window_summaries_csv_path: Path
+    sqlite_path: Path
+    validation_summary_path: Path
+    validation_summary: CalibrationReviewValidationSummary
+    glyph_rows_table_name: str = CALIBRATION_GLYPH_REVIEW_ROWS_TABLE
+    named_check_rows_table_name: str = CALIBRATION_NAMED_CHECK_REVIEW_ROWS_TABLE
+    glyph_examples_table_name: str = CALIBRATION_GLYPH_REVIEW_EXAMPLES_TABLE
+    named_check_examples_table_name: str = CALIBRATION_NAMED_CHECK_REVIEW_EXAMPLES_TABLE
+    window_summaries_table_name: str = CALIBRATION_REVIEW_WINDOW_SUMMARIES_TABLE
+    schema_version: str = CALIBRATION_REVIEW_ARTIFACT_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if self.schema_version != CALIBRATION_REVIEW_ARTIFACT_SCHEMA_VERSION:
+            raise ValueError(
+                "unsupported calibration review artifact schema version: "
+                f"{self.schema_version}"
+            )
+
+    @property
+    def window_count(self) -> int:
+        return self.validation_summary.window_count
+
+    @property
+    def residual_observation_count(self) -> int:
+        return self.validation_summary.residual_observation_count
+
+    @property
+    def glyph_review_row_count(self) -> int:
+        return self.validation_summary.glyph_review_row_count
+
+    @property
+    def named_check_review_row_count(self) -> int:
+        return self.validation_summary.named_check_review_row_count
+
+    @property
+    def glyph_example_row_count(self) -> int:
+        return self.validation_summary.glyph_example_row_count
+
+    @property
+    def named_check_example_row_count(self) -> int:
+        return self.validation_summary.named_check_example_row_count
+
+    def to_record(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "output_dir": str(self.output_dir),
+            "manifest_path": str(self.manifest_path),
+            "glyph_rows_csv_path": str(self.glyph_rows_csv_path),
+            "named_check_rows_csv_path": str(self.named_check_rows_csv_path),
+            "glyph_examples_csv_path": str(self.glyph_examples_csv_path),
+            "named_check_examples_csv_path": str(self.named_check_examples_csv_path),
+            "window_summaries_csv_path": str(self.window_summaries_csv_path),
+            "sqlite_path": str(self.sqlite_path),
+            "validation_summary_path": str(self.validation_summary_path),
+            "glyph_rows_table_name": self.glyph_rows_table_name,
+            "named_check_rows_table_name": self.named_check_rows_table_name,
+            "glyph_examples_table_name": self.glyph_examples_table_name,
+            "named_check_examples_table_name": self.named_check_examples_table_name,
+            "window_summaries_table_name": self.window_summaries_table_name,
+            "window_count": self.window_count,
+            "residual_observation_count": self.residual_observation_count,
+            "glyph_review_row_count": self.glyph_review_row_count,
+            "named_check_review_row_count": self.named_check_review_row_count,
+            "glyph_example_row_count": self.glyph_example_row_count,
+            "named_check_example_row_count": self.named_check_example_row_count,
+            "validation_summary": self.validation_summary.to_record(),
+        }
+
+
+def calibration_review_output_dir(
+    output_root: Path,
+    calibration_review_run_id: str,
+) -> Path:
+    return (
+        output_root.expanduser()
+        / "calibration_review"
+        / _safe_calibration_review_run_id(calibration_review_run_id)
+    )
+
+
+def write_calibration_review_artifacts(
+    output_root: Path,
+    *,
+    windowed_tables: tuple[CalibrationReviewWindowedTables, ...],
+    calibration_review_run_id: str = "calibration-review",
+) -> CalibrationReviewArtifacts:
+    output_dir = calibration_review_output_dir(output_root, calibration_review_run_id)
+    assert_not_live_runtime_path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    glyph_rows = _flatten_glyph_rows(windowed_tables)
+    named_check_rows = _flatten_named_check_rows(windowed_tables)
+    glyph_examples = _flatten_glyph_examples(windowed_tables)
+    named_check_examples = _flatten_named_check_examples(windowed_tables)
+
+    glyph_rows_csv_path = output_dir / CALIBRATION_GLYPH_REVIEW_ROWS_CSV_FILENAME
+    named_check_rows_csv_path = (
+        output_dir / CALIBRATION_NAMED_CHECK_REVIEW_ROWS_CSV_FILENAME
+    )
+    glyph_examples_csv_path = (
+        output_dir / CALIBRATION_GLYPH_REVIEW_EXAMPLES_CSV_FILENAME
+    )
+    named_check_examples_csv_path = (
+        output_dir / CALIBRATION_NAMED_CHECK_REVIEW_EXAMPLES_CSV_FILENAME
+    )
+    window_summaries_csv_path = (
+        output_dir / CALIBRATION_REVIEW_WINDOW_SUMMARIES_CSV_FILENAME
+    )
+    sqlite_path = output_dir / CALIBRATION_REVIEW_SQLITE_FILENAME
+    validation_summary_path = (
+        output_dir / CALIBRATION_REVIEW_VALIDATION_SUMMARY_FILENAME
+    )
+    manifest_path = output_dir / CALIBRATION_REVIEW_MANIFEST_FILENAME
+
+    write_glyph_review_rows_csv(glyph_rows_csv_path, glyph_rows)
+    write_named_check_review_rows_csv(named_check_rows_csv_path, named_check_rows)
+    write_calibration_review_examples_csv(glyph_examples_csv_path, glyph_examples)
+    write_calibration_review_examples_csv(
+        named_check_examples_csv_path,
+        named_check_examples,
+    )
+    write_calibration_review_window_summaries_csv(
+        window_summaries_csv_path,
+        windowed_tables,
+    )
+    write_calibration_review_sqlite(
+        sqlite_path,
+        glyph_rows=glyph_rows,
+        named_check_rows=named_check_rows,
+        glyph_examples=glyph_examples,
+        named_check_examples=named_check_examples,
+        windowed_tables=windowed_tables,
+    )
+
+    validation_summary = build_calibration_review_validation_summary(windowed_tables)
+    artifacts = CalibrationReviewArtifacts(
+        output_dir=output_dir,
+        manifest_path=manifest_path,
+        glyph_rows_csv_path=glyph_rows_csv_path,
+        named_check_rows_csv_path=named_check_rows_csv_path,
+        glyph_examples_csv_path=glyph_examples_csv_path,
+        named_check_examples_csv_path=named_check_examples_csv_path,
+        window_summaries_csv_path=window_summaries_csv_path,
+        sqlite_path=sqlite_path,
+        validation_summary_path=validation_summary_path,
+        validation_summary=validation_summary,
+    )
+
+    write_calibration_review_validation_summary_json(
+        validation_summary_path,
+        validation_summary,
+    )
+    write_calibration_review_manifest_json(manifest_path, artifacts)
+
+    return artifacts
+
+
+def build_calibration_review_validation_summary(
+    windowed_tables: tuple[CalibrationReviewWindowedTables, ...],
+) -> CalibrationReviewValidationSummary:
+    glyph_rows = _flatten_glyph_rows(windowed_tables)
+    named_check_rows = _flatten_named_check_rows(windowed_tables)
+    glyph_examples = _flatten_glyph_examples(windowed_tables)
+    named_check_examples = _flatten_named_check_examples(windowed_tables)
+    classification_counts = Counter(
+        row.review_classification for row in (*glyph_rows, *named_check_rows)
+    )
+
+    run_ids = sorted(
+        {
+            table.residual_attribution_run_id
+            for table in windowed_tables
+            if table.residual_attribution_run_id is not None
+        }
+    )
+
+    return CalibrationReviewValidationSummary(
+        window_count=len(windowed_tables),
+        residual_observation_count=sum(
+            table.residual_observation_count for table in windowed_tables
+        ),
+        glyph_review_row_count=len(glyph_rows),
+        named_check_review_row_count=len(named_check_rows),
+        glyph_example_row_count=len(glyph_examples),
+        named_check_example_row_count=len(named_check_examples),
+        window_labels=tuple(sorted({table.window.label for table in windowed_tables})),
+        residual_attribution_run_ids=tuple(run_ids),
+        review_classification_counts={
+            REVIEW_HOT: classification_counts.get(REVIEW_HOT, 0),
+            REVIEW_COLD: classification_counts.get(REVIEW_COLD, 0),
+            REVIEW_INCONCLUSIVE: classification_counts.get(REVIEW_INCONCLUSIVE, 0),
+        },
+        schema_versions=(
+            CALIBRATION_GLYPH_REVIEW_ROW_SCHEMA_VERSION,
+            CALIBRATION_NAMED_CHECK_REVIEW_ROW_SCHEMA_VERSION,
+            CALIBRATION_REVIEW_EXAMPLE_ROW_SCHEMA_VERSION,
+            CALIBRATION_REVIEW_WINDOW_SUMMARY_SCHEMA_VERSION,
+        ),
+    )
+
+
+def write_calibration_review_validation_summary_json(
+    path: Path,
+    validation_summary: CalibrationReviewValidationSummary,
+) -> Path:
+    _write_json(path, validation_summary.to_record())
+    return path
+
+
+def write_calibration_review_manifest_json(
+    path: Path,
+    artifacts: CalibrationReviewArtifacts,
+) -> Path:
+    _write_json(path, artifacts.to_record())
+    return path
+
+
+def _flatten_glyph_rows(
+    windowed_tables: tuple[CalibrationReviewWindowedTables, ...],
+) -> tuple[CalibrationGlyphReviewRow, ...]:
+    return tuple(row for table in windowed_tables for row in table.glyph_review_rows)
+
+
+def _flatten_named_check_rows(
+    windowed_tables: tuple[CalibrationReviewWindowedTables, ...],
+) -> tuple[CalibrationNamedCheckReviewRow, ...]:
+    return tuple(
+        row for table in windowed_tables for row in table.named_check_review_rows
+    )
+
+
+def _flatten_glyph_examples(
+    windowed_tables: tuple[CalibrationReviewWindowedTables, ...],
+) -> tuple[CalibrationReviewExampleRow, ...]:
+    return tuple(row for table in windowed_tables for row in table.glyph_example_rows)
+
+
+def _flatten_named_check_examples(
+    windowed_tables: tuple[CalibrationReviewWindowedTables, ...],
+) -> tuple[CalibrationReviewExampleRow, ...]:
+    return tuple(
+        row for table in windowed_tables for row in table.named_check_example_rows
+    )
+
+
+def _safe_calibration_review_run_id(value: str) -> str:
+    if not value or "/" in value or "\\" in value or ".." in value:
+        raise ValueError(f"unsafe calibration review run id: {value}")
+    return value
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    assert_not_live_runtime_path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )

--- a/market_health/calibration/calibration_review_export.py
+++ b/market_health/calibration/calibration_review_export.py
@@ -1,0 +1,287 @@
+from __future__ import annotations
+
+import csv
+import sqlite3
+from collections.abc import Iterable
+from pathlib import Path
+
+from market_health.calibration.calibration_review import (
+    CALIBRATION_GLYPH_REVIEW_COLUMNS,
+    CALIBRATION_NAMED_CHECK_REVIEW_COLUMNS,
+    CALIBRATION_REVIEW_EXAMPLE_COLUMNS,
+    CALIBRATION_REVIEW_WINDOW_SUMMARY_COLUMNS,
+    CalibrationGlyphReviewRow,
+    CalibrationNamedCheckReviewRow,
+    CalibrationReviewExampleRow,
+    CalibrationReviewWindowedTables,
+)
+from market_health.calibration.defaults import assert_not_live_runtime_path
+
+CALIBRATION_GLYPH_REVIEW_ROWS_TABLE = "calibration_glyph_review_rows"
+CALIBRATION_NAMED_CHECK_REVIEW_ROWS_TABLE = "calibration_named_check_review_rows"
+CALIBRATION_GLYPH_REVIEW_EXAMPLES_TABLE = "calibration_glyph_review_examples"
+CALIBRATION_NAMED_CHECK_REVIEW_EXAMPLES_TABLE = (
+    "calibration_named_check_review_examples"
+)
+CALIBRATION_REVIEW_WINDOW_SUMMARIES_TABLE = "calibration_review_window_summaries"
+
+
+def glyph_review_rows_to_records(
+    rows: Iterable[CalibrationGlyphReviewRow],
+) -> tuple[dict[str, object], ...]:
+    return tuple(row.to_record() for row in sorted(rows, key=_glyph_row_sort_key))
+
+
+def named_check_review_rows_to_records(
+    rows: Iterable[CalibrationNamedCheckReviewRow],
+) -> tuple[dict[str, object], ...]:
+    return tuple(row.to_record() for row in sorted(rows, key=_named_check_row_sort_key))
+
+
+def calibration_review_examples_to_records(
+    rows: Iterable[CalibrationReviewExampleRow],
+) -> tuple[dict[str, object], ...]:
+    return tuple(row.to_record() for row in sorted(rows, key=_example_row_sort_key))
+
+
+def calibration_review_window_summaries_to_records(
+    tables: Iterable[CalibrationReviewWindowedTables],
+) -> tuple[dict[str, object], ...]:
+    return tuple(
+        table.to_summary_record()
+        for table in sorted(tables, key=_window_table_sort_key)
+    )
+
+
+def write_glyph_review_rows_csv(
+    path: Path,
+    rows: Iterable[CalibrationGlyphReviewRow],
+) -> None:
+    _write_csv(
+        path, glyph_review_rows_to_records(rows), CALIBRATION_GLYPH_REVIEW_COLUMNS
+    )
+
+
+def write_named_check_review_rows_csv(
+    path: Path,
+    rows: Iterable[CalibrationNamedCheckReviewRow],
+) -> None:
+    _write_csv(
+        path,
+        named_check_review_rows_to_records(rows),
+        CALIBRATION_NAMED_CHECK_REVIEW_COLUMNS,
+    )
+
+
+def write_calibration_review_examples_csv(
+    path: Path,
+    rows: Iterable[CalibrationReviewExampleRow],
+) -> None:
+    _write_csv(
+        path,
+        calibration_review_examples_to_records(rows),
+        CALIBRATION_REVIEW_EXAMPLE_COLUMNS,
+    )
+
+
+def write_calibration_review_window_summaries_csv(
+    path: Path,
+    tables: Iterable[CalibrationReviewWindowedTables],
+) -> None:
+    _write_csv(
+        path,
+        calibration_review_window_summaries_to_records(tables),
+        CALIBRATION_REVIEW_WINDOW_SUMMARY_COLUMNS,
+    )
+
+
+def write_calibration_review_sqlite(
+    path: Path,
+    *,
+    glyph_rows: Iterable[CalibrationGlyphReviewRow],
+    named_check_rows: Iterable[CalibrationNamedCheckReviewRow],
+    glyph_examples: Iterable[CalibrationReviewExampleRow],
+    named_check_examples: Iterable[CalibrationReviewExampleRow],
+    windowed_tables: Iterable[CalibrationReviewWindowedTables],
+    glyph_rows_table_name: str = CALIBRATION_GLYPH_REVIEW_ROWS_TABLE,
+    named_check_rows_table_name: str = CALIBRATION_NAMED_CHECK_REVIEW_ROWS_TABLE,
+    glyph_examples_table_name: str = CALIBRATION_GLYPH_REVIEW_EXAMPLES_TABLE,
+    named_check_examples_table_name: str = CALIBRATION_NAMED_CHECK_REVIEW_EXAMPLES_TABLE,
+    window_summaries_table_name: str = CALIBRATION_REVIEW_WINDOW_SUMMARIES_TABLE,
+) -> None:
+    assert_not_live_runtime_path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    glyph_records = glyph_review_rows_to_records(glyph_rows)
+    named_check_records = named_check_review_rows_to_records(named_check_rows)
+    glyph_example_records = calibration_review_examples_to_records(glyph_examples)
+    named_check_example_records = calibration_review_examples_to_records(
+        named_check_examples
+    )
+    window_summary_records = calibration_review_window_summaries_to_records(
+        windowed_tables
+    )
+
+    with sqlite3.connect(path) as connection:
+        _write_table(
+            connection,
+            table_name=glyph_rows_table_name,
+            columns=CALIBRATION_GLYPH_REVIEW_COLUMNS,
+            records=glyph_records,
+        )
+        _write_table(
+            connection,
+            table_name=named_check_rows_table_name,
+            columns=CALIBRATION_NAMED_CHECK_REVIEW_COLUMNS,
+            records=named_check_records,
+        )
+        _write_table(
+            connection,
+            table_name=glyph_examples_table_name,
+            columns=CALIBRATION_REVIEW_EXAMPLE_COLUMNS,
+            records=glyph_example_records,
+        )
+        _write_table(
+            connection,
+            table_name=named_check_examples_table_name,
+            columns=CALIBRATION_REVIEW_EXAMPLE_COLUMNS,
+            records=named_check_example_records,
+        )
+        _write_table(
+            connection,
+            table_name=window_summaries_table_name,
+            columns=CALIBRATION_REVIEW_WINDOW_SUMMARY_COLUMNS,
+            records=window_summary_records,
+        )
+
+
+def sqlite_type_for_calibration_review_column(column: str) -> str:
+    if column in {
+        "mean_residual",
+        "median_residual",
+        "mean_abs_residual",
+        "forecast_score",
+        "realized_current_score",
+        "residual",
+    }:
+        return "REAL"
+    if column in {
+        "slot",
+        "observation_count",
+        "min_observation_count",
+        "hot_count",
+        "cold_count",
+        "neutral_count",
+        "example_rank",
+        "residual_observation_count",
+        "glyph_review_row_count",
+        "named_check_review_row_count",
+        "glyph_example_row_count",
+        "named_check_example_row_count",
+    }:
+        return "INTEGER"
+    return "TEXT"
+
+
+def _write_csv(
+    path: Path,
+    records: tuple[dict[str, object], ...],
+    columns: tuple[str, ...],
+) -> None:
+    assert_not_live_runtime_path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=columns)
+        writer.writeheader()
+        for record in records:
+            writer.writerow(record)
+
+
+def _write_table(
+    connection: sqlite3.Connection,
+    *,
+    table_name: str,
+    columns: tuple[str, ...],
+    records: tuple[dict[str, object], ...],
+) -> None:
+    quoted_table = _quote_identifier(table_name)
+    connection.execute(f"DROP TABLE IF EXISTS {quoted_table}")
+    column_sql = ", ".join(
+        f"{_quote_identifier(column)} {sqlite_type_for_calibration_review_column(column)}"
+        for column in columns
+    )
+    connection.execute(f"CREATE TABLE {quoted_table} ({column_sql})")
+
+    if not records:
+        return
+
+    placeholders = ", ".join("?" for _ in columns)
+    quoted_columns = ", ".join(_quote_identifier(column) for column in columns)
+    connection.executemany(
+        f"INSERT INTO {quoted_table} ({quoted_columns}) VALUES ({placeholders})",
+        [[record[column] for column in columns] for record in records],
+    )
+
+
+def _quote_identifier(value: str) -> str:
+    escaped = value.replace('"', '""')
+    return f'"{escaped}"'
+
+
+def _optional_date_sort_key(value: object) -> str:
+    return "" if value is None else str(value)
+
+
+def _glyph_row_sort_key(row: CalibrationGlyphReviewRow) -> tuple[object, ...]:
+    return (
+        row.window_label,
+        _optional_date_sort_key(row.window_start_date),
+        _optional_date_sort_key(row.window_end_date),
+        row.horizon,
+        row.category,
+        row.slot,
+        row.glyph,
+    )
+
+
+def _named_check_row_sort_key(
+    row: CalibrationNamedCheckReviewRow,
+) -> tuple[object, ...]:
+    return (
+        row.window_label,
+        _optional_date_sort_key(row.window_start_date),
+        _optional_date_sort_key(row.window_end_date),
+        row.horizon,
+        row.named_check,
+        row.category or "",
+        row.slot if row.slot is not None else -1,
+        row.glyph or "",
+    )
+
+
+def _example_row_sort_key(row: CalibrationReviewExampleRow) -> tuple[object, ...]:
+    return (
+        row.window_label,
+        _optional_date_sort_key(row.window_start_date),
+        _optional_date_sort_key(row.window_end_date),
+        row.review_table,
+        row.horizon,
+        row.category,
+        row.slot,
+        row.glyph,
+        row.named_check,
+        row.example_rank,
+        row.replay_date.isoformat(),
+        row.symbol,
+    )
+
+
+def _window_table_sort_key(
+    table: CalibrationReviewWindowedTables,
+) -> tuple[str, str, str]:
+    return (
+        table.window.label,
+        _optional_date_sort_key(table.window.start_date),
+        _optional_date_sort_key(table.window.end_date),
+    )

--- a/market_health/calibration/cli.py
+++ b/market_health/calibration/cli.py
@@ -11,6 +11,16 @@ from market_health.calibration.authoritative_dataset_artifacts import (
 from market_health.calibration.authoritative_dataset_builder import (
     build_authoritative_replay_dataset_rows,
 )
+from market_health.calibration.calibration_review import (
+    DEFAULT_CALIBRATION_REVIEW_EXAMPLES_PER_GROUP,
+    DEFAULT_CALIBRATION_REVIEW_MIN_OBSERVATION_COUNT,
+    DEFAULT_CALIBRATION_REVIEW_WINDOW_DAY_COUNTS,
+    build_trailing_calibration_review_windows,
+    build_windowed_calibration_review_tables,
+)
+from market_health.calibration.calibration_review_artifacts import (
+    write_calibration_review_artifacts,
+)
 from market_health.calibration.check_output import (
     CheckReplayRow,
     build_fixture_check_replay_rows,
@@ -97,6 +107,46 @@ def build_parser() -> argparse.ArgumentParser:
         default="residual-attribution",
     )
 
+    calibration_review = subparsers.add_parser(
+        "calibration-review",
+        help="Build calibration review tables from residual attribution observations.",
+    )
+    calibration_review.add_argument("--price-cache", type=Path, required=True)
+    calibration_review.add_argument("--start-date", type=_parse_date, required=True)
+    calibration_review.add_argument("--end-date", type=_parse_date, required=True)
+    calibration_review.add_argument("--symbols", nargs="+", required=True)
+    calibration_review.add_argument("--lookback-rows", type=int, default=20)
+    calibration_review.add_argument("--out", type=Path, default=default_output_root())
+    calibration_review.add_argument(
+        "--dataset-run-id",
+        default="authoritative-replay-dataset",
+    )
+    calibration_review.add_argument(
+        "--residual-attribution-run-id",
+        default="residual-attribution",
+    )
+    calibration_review.add_argument(
+        "--calibration-review-run-id",
+        default="calibration-review",
+    )
+    calibration_review.add_argument(
+        "--min-observation-count",
+        type=int,
+        default=DEFAULT_CALIBRATION_REVIEW_MIN_OBSERVATION_COUNT,
+    )
+    calibration_review.add_argument(
+        "--max-examples-per-group",
+        type=int,
+        default=DEFAULT_CALIBRATION_REVIEW_EXAMPLES_PER_GROUP,
+    )
+    calibration_review.add_argument(
+        "--window-days",
+        nargs="*",
+        type=int,
+        default=list(DEFAULT_CALIBRATION_REVIEW_WINDOW_DAY_COUNTS),
+    )
+    calibration_review.add_argument("--no-full-window", action="store_true")
+
     return parser
 
 
@@ -126,6 +176,11 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "residual-attribution":
         payload = _run_residual_attribution_command(args)
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0
+
+    if args.command == "calibration-review":
+        payload = _run_calibration_review_command(args)
         print(json.dumps(payload, indent=2, sort_keys=True))
         return 0
 
@@ -263,6 +318,72 @@ def _run_residual_attribution_command(args: argparse.Namespace) -> dict[str, obj
         "dataset_row_count": len(dataset_rows),
         "observation_count": artifacts.observation_count,
         "summary_count": artifacts.summary_count,
+        "artifacts": artifacts.to_record(),
+    }
+
+
+def _run_calibration_review_command(args: argparse.Namespace) -> dict[str, object]:
+    output_root = args.out.expanduser()
+    assert_not_live_runtime_path(output_root)
+
+    price_cache_path = args.price_cache.expanduser()
+    price_cache = read_historical_price_cache_csv(
+        price_cache_path,
+        symbols=args.symbols,
+    )
+    range_request = build_range_replay_request(
+        start_date=args.start_date,
+        end_date=args.end_date,
+        symbols=args.symbols,
+        lookback_rows=args.lookback_rows,
+        output_root=output_root,
+    )
+    range_result = run_range_replay(
+        request=range_request,
+        price_rows=price_cache.rows,
+    )
+    check_rows = _build_authoritative_dataset_check_rows(range_result)
+    dataset_rows = build_authoritative_replay_dataset_rows(
+        range_result=range_result,
+        check_rows=check_rows,
+        price_rows=price_cache.rows,
+        dataset_run_id=args.dataset_run_id,
+    )
+    residual_rows = build_residual_attribution_rows(
+        dataset_rows,
+        residual_attribution_run_id=args.residual_attribution_run_id,
+    )
+    windows = build_trailing_calibration_review_windows(
+        residual_rows,
+        day_counts=args.window_days,
+        include_full_window=not args.no_full_window,
+    )
+    windowed_tables = build_windowed_calibration_review_tables(
+        residual_rows,
+        windows=windows,
+        min_observation_count=args.min_observation_count,
+        max_examples_per_group=args.max_examples_per_group,
+    )
+    artifacts = write_calibration_review_artifacts(
+        output_root,
+        windowed_tables=windowed_tables,
+        calibration_review_run_id=args.calibration_review_run_id,
+    )
+
+    return {
+        "status": "ok",
+        "command": "calibration-review",
+        "price_cache_path": str(price_cache_path),
+        "dataset_run_id": args.dataset_run_id,
+        "residual_attribution_run_id": args.residual_attribution_run_id,
+        "calibration_review_run_id": args.calibration_review_run_id,
+        "dataset_row_count": len(dataset_rows),
+        "residual_observation_count": len(residual_rows),
+        "window_count": artifacts.window_count,
+        "glyph_review_row_count": artifacts.glyph_review_row_count,
+        "named_check_review_row_count": artifacts.named_check_review_row_count,
+        "glyph_example_row_count": artifacts.glyph_example_row_count,
+        "named_check_example_row_count": artifacts.named_check_example_row_count,
         "artifacts": artifacts.to_record(),
     }
 

--- a/tests/test_calibration_review_artifacts.py
+++ b/tests/test_calibration_review_artifacts.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+import csv
+import json
+import sqlite3
+import tempfile
+import unittest
+from datetime import date
+from pathlib import Path
+
+from market_health.calibration.calibration_review import (
+    CalibrationReviewWindow,
+    build_windowed_calibration_review_tables,
+)
+from market_health.calibration.calibration_review_artifacts import (
+    CALIBRATION_GLYPH_REVIEW_EXAMPLES_CSV_FILENAME,
+    CALIBRATION_GLYPH_REVIEW_ROWS_CSV_FILENAME,
+    CALIBRATION_NAMED_CHECK_REVIEW_EXAMPLES_CSV_FILENAME,
+    CALIBRATION_NAMED_CHECK_REVIEW_ROWS_CSV_FILENAME,
+    CALIBRATION_REVIEW_MANIFEST_FILENAME,
+    CALIBRATION_REVIEW_SQLITE_FILENAME,
+    CALIBRATION_REVIEW_VALIDATION_SUMMARY_FILENAME,
+    CALIBRATION_REVIEW_WINDOW_SUMMARIES_CSV_FILENAME,
+    build_calibration_review_validation_summary,
+    calibration_review_output_dir,
+    write_calibration_review_artifacts,
+)
+from market_health.calibration.calibration_review_export import (
+    CALIBRATION_GLYPH_REVIEW_EXAMPLES_TABLE,
+    CALIBRATION_GLYPH_REVIEW_ROWS_TABLE,
+    CALIBRATION_NAMED_CHECK_REVIEW_EXAMPLES_TABLE,
+    CALIBRATION_NAMED_CHECK_REVIEW_ROWS_TABLE,
+    CALIBRATION_REVIEW_WINDOW_SUMMARIES_TABLE,
+)
+from market_health.calibration.residuals import ResidualAttributionRow
+
+
+class CalibrationReviewArtifactsTest(unittest.TestCase):
+    def test_validation_summary_has_stable_counts(self) -> None:
+        windowed_tables = build_windowed_calibration_review_tables(
+            residual_rows(),
+            windows=(CalibrationReviewWindow("full"),),
+            min_observation_count=1,
+            max_examples_per_group=1,
+        )
+
+        summary = build_calibration_review_validation_summary(windowed_tables)
+        record = summary.to_record()
+
+        self.assertEqual(record["window_count"], 1)
+        self.assertEqual(record["residual_observation_count"], 3)
+        self.assertEqual(record["glyph_review_row_count"], 2)
+        self.assertEqual(record["named_check_review_row_count"], 2)
+        self.assertEqual(record["glyph_example_row_count"], 2)
+        self.assertEqual(record["named_check_example_row_count"], 2)
+        self.assertEqual(record["window_labels"], ["full"])
+        self.assertEqual(record["residual_attribution_run_ids"], ["m53-test"])
+        self.assertEqual(
+            record["review_classification_counts"],
+            {"hot": 2, "cold": 2, "inconclusive": 0},
+        )
+
+    def test_output_dir_is_stable(self) -> None:
+        self.assertEqual(
+            calibration_review_output_dir(Path("/tmp/out"), "run-1"),
+            Path("/tmp/out/calibration_review/run-1"),
+        )
+
+    def test_invalid_run_id_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "unsafe"):
+            calibration_review_output_dir(Path("/tmp/out"), "../bad")
+
+    def test_write_calibration_review_artifacts_outputs_files(self) -> None:
+        windowed_tables = build_windowed_calibration_review_tables(
+            residual_rows(),
+            windows=(
+                CalibrationReviewWindow("full"),
+                CalibrationReviewWindow(
+                    "1d",
+                    start_date=date(2026, 5, 20),
+                    end_date=date(2026, 5, 20),
+                ),
+            ),
+            min_observation_count=1,
+            max_examples_per_group=1,
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            artifacts = write_calibration_review_artifacts(
+                Path(tmpdir),
+                windowed_tables=windowed_tables,
+                calibration_review_run_id="m53-test",
+            )
+
+            self.assertEqual(artifacts.window_count, 2)
+            self.assertEqual(artifacts.residual_observation_count, 6)
+            self.assertEqual(
+                artifacts.glyph_rows_csv_path.name,
+                CALIBRATION_GLYPH_REVIEW_ROWS_CSV_FILENAME,
+            )
+            self.assertEqual(
+                artifacts.named_check_rows_csv_path.name,
+                CALIBRATION_NAMED_CHECK_REVIEW_ROWS_CSV_FILENAME,
+            )
+            self.assertEqual(
+                artifacts.glyph_examples_csv_path.name,
+                CALIBRATION_GLYPH_REVIEW_EXAMPLES_CSV_FILENAME,
+            )
+            self.assertEqual(
+                artifacts.named_check_examples_csv_path.name,
+                CALIBRATION_NAMED_CHECK_REVIEW_EXAMPLES_CSV_FILENAME,
+            )
+            self.assertEqual(
+                artifacts.window_summaries_csv_path.name,
+                CALIBRATION_REVIEW_WINDOW_SUMMARIES_CSV_FILENAME,
+            )
+            self.assertEqual(
+                artifacts.sqlite_path.name, CALIBRATION_REVIEW_SQLITE_FILENAME
+            )
+            self.assertEqual(
+                artifacts.validation_summary_path.name,
+                CALIBRATION_REVIEW_VALIDATION_SUMMARY_FILENAME,
+            )
+            self.assertEqual(
+                artifacts.manifest_path.name, CALIBRATION_REVIEW_MANIFEST_FILENAME
+            )
+
+            with artifacts.glyph_rows_csv_path.open(
+                newline="", encoding="utf-8"
+            ) as handle:
+                glyph_rows = list(csv.DictReader(handle))
+            with artifacts.named_check_rows_csv_path.open(
+                newline="",
+                encoding="utf-8",
+            ) as handle:
+                named_check_rows = list(csv.DictReader(handle))
+            with artifacts.window_summaries_csv_path.open(
+                newline="",
+                encoding="utf-8",
+            ) as handle:
+                window_rows = list(csv.DictReader(handle))
+
+            validation_payload = json.loads(
+                artifacts.validation_summary_path.read_text(encoding="utf-8")
+            )
+            manifest_payload = json.loads(
+                artifacts.manifest_path.read_text(encoding="utf-8")
+            )
+
+            with sqlite3.connect(artifacts.sqlite_path) as connection:
+                glyph_count = connection.execute(
+                    f"SELECT COUNT(*) FROM {CALIBRATION_GLYPH_REVIEW_ROWS_TABLE}"
+                ).fetchone()[0]
+                named_check_count = connection.execute(
+                    f"SELECT COUNT(*) FROM {CALIBRATION_NAMED_CHECK_REVIEW_ROWS_TABLE}"
+                ).fetchone()[0]
+                glyph_example_count = connection.execute(
+                    f"SELECT COUNT(*) FROM {CALIBRATION_GLYPH_REVIEW_EXAMPLES_TABLE}"
+                ).fetchone()[0]
+                named_check_example_count = connection.execute(
+                    f"SELECT COUNT(*) FROM {CALIBRATION_NAMED_CHECK_REVIEW_EXAMPLES_TABLE}"
+                ).fetchone()[0]
+                window_count = connection.execute(
+                    f"SELECT COUNT(*) FROM {CALIBRATION_REVIEW_WINDOW_SUMMARIES_TABLE}"
+                ).fetchone()[0]
+
+        self.assertEqual(len(glyph_rows), artifacts.glyph_review_row_count)
+        self.assertEqual(len(named_check_rows), artifacts.named_check_review_row_count)
+        self.assertEqual(len(window_rows), artifacts.window_count)
+        self.assertEqual(glyph_count, artifacts.glyph_review_row_count)
+        self.assertEqual(named_check_count, artifacts.named_check_review_row_count)
+        self.assertEqual(glyph_example_count, artifacts.glyph_example_row_count)
+        self.assertEqual(
+            named_check_example_count,
+            artifacts.named_check_example_row_count,
+        )
+        self.assertEqual(window_count, artifacts.window_count)
+        self.assertEqual(validation_payload["window_count"], 2)
+        self.assertEqual(manifest_payload["window_count"], 2)
+        self.assertEqual(manifest_payload["residual_observation_count"], 6)
+
+
+def residual_rows() -> tuple[ResidualAttributionRow, ...]:
+    return (
+        residual_row(symbol="SPY", residual=0.5, residual_direction="hot"),
+        residual_row(
+            symbol="QQQ",
+            forecast_score=8.25,
+            realized_current_score=8.0,
+            residual=0.25,
+            residual_direction="hot",
+        ),
+        residual_row(
+            symbol="IWM",
+            category="C",
+            slot=2,
+            glyph="-",
+            named_check="breadth_confirmed",
+            forecast_score=7.25,
+            realized_current_score=8.0,
+            residual=-0.75,
+            residual_direction="cold",
+        ),
+    )
+
+
+def residual_row(
+    *,
+    symbol: str = "SPY",
+    replay_date: date = date(2026, 5, 20),
+    horizon: str = "H1",
+    category: str = "B",
+    slot: int = 4,
+    glyph: str = "+",
+    named_check: str = "trend_confirmed",
+    forecast_score: float = 8.5,
+    realized_current_score: float = 8.0,
+    residual: float = 0.5,
+    residual_direction: str = "hot",
+    residual_attribution_run_id: str = "m53-test",
+) -> ResidualAttributionRow:
+    return ResidualAttributionRow(
+        replay_date=replay_date,
+        symbol=symbol,
+        horizon=horizon,
+        target_date=date(2026, 5, 21),
+        forecast_score=forecast_score,
+        realized_current_score=realized_current_score,
+        residual=residual,
+        residual_direction=residual_direction,
+        realized_return=0.03,
+        category=category,
+        slot=slot,
+        glyph=glyph,
+        named_check=named_check,
+        check_score=4.1,
+        replayability_class="replayable",
+        measurement_status="measured",
+        source_module="fixture.module",
+        function_name="check_b4",
+        audit_token=f"single-date-asof:2026-05-20:{symbol}:1:100.0000",
+        dataset_run_id="dataset-test",
+        residual_attribution_run_id=residual_attribution_run_id,
+    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_calibration_review_cli.py
+++ b/tests/test_calibration_review_cli.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import csv
+import io
+import json
+import sqlite3
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from datetime import date
+from pathlib import Path
+
+from market_health.calibration.calibration_review_export import (
+    CALIBRATION_GLYPH_REVIEW_ROWS_TABLE,
+    CALIBRATION_NAMED_CHECK_REVIEW_ROWS_TABLE,
+    CALIBRATION_REVIEW_WINDOW_SUMMARIES_TABLE,
+)
+from market_health.calibration.cli import build_parser, main
+from market_health.calibration.price_cache import HISTORICAL_PRICE_CACHE_COLUMNS
+
+
+class CalibrationReviewCliTest(unittest.TestCase):
+    def test_calibration_review_help_is_registered(self) -> None:
+        parser = build_parser()
+        self.assertIn("calibration-review", parser.format_help())
+
+    def test_calibration_review_command_writes_artifacts_and_outputs_json(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            price_cache_path = tmp_path / "prices.csv"
+            output_root = tmp_path / "calibration"
+            _write_price_cache(price_cache_path)
+
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                exit_code = main(
+                    [
+                        "calibration-review",
+                        "--price-cache",
+                        str(price_cache_path),
+                        "--start-date",
+                        "2026-05-20",
+                        "--end-date",
+                        "2026-05-20",
+                        "--symbols",
+                        "SPY",
+                        "--lookback-rows",
+                        "1",
+                        "--out",
+                        str(output_root),
+                        "--dataset-run-id",
+                        "dataset-test",
+                        "--residual-attribution-run-id",
+                        "residual-test",
+                        "--calibration-review-run-id",
+                        "review-test",
+                        "--min-observation-count",
+                        "1",
+                        "--max-examples-per-group",
+                        "1",
+                        "--window-days",
+                        "1",
+                    ]
+                )
+
+            payload = json.loads(stdout.getvalue())
+            artifacts = payload["artifacts"]
+            glyph_rows_csv_path = Path(artifacts["glyph_rows_csv_path"])
+            named_check_rows_csv_path = Path(artifacts["named_check_rows_csv_path"])
+            glyph_examples_csv_path = Path(artifacts["glyph_examples_csv_path"])
+            named_check_examples_csv_path = Path(
+                artifacts["named_check_examples_csv_path"]
+            )
+            window_summaries_csv_path = Path(artifacts["window_summaries_csv_path"])
+            sqlite_path = Path(artifacts["sqlite_path"])
+            validation_summary_path = Path(artifacts["validation_summary_path"])
+            manifest_path = Path(artifacts["manifest_path"])
+
+            with glyph_rows_csv_path.open(newline="", encoding="utf-8") as handle:
+                glyph_rows = list(csv.DictReader(handle))
+            with named_check_rows_csv_path.open(newline="", encoding="utf-8") as handle:
+                named_check_rows = list(csv.DictReader(handle))
+            with glyph_examples_csv_path.open(newline="", encoding="utf-8") as handle:
+                glyph_examples = list(csv.DictReader(handle))
+            with named_check_examples_csv_path.open(
+                newline="",
+                encoding="utf-8",
+            ) as handle:
+                named_check_examples = list(csv.DictReader(handle))
+            with window_summaries_csv_path.open(newline="", encoding="utf-8") as handle:
+                window_summaries = list(csv.DictReader(handle))
+
+            with sqlite3.connect(sqlite_path) as connection:
+                sqlite_glyph_count = connection.execute(
+                    f"SELECT COUNT(*) FROM {CALIBRATION_GLYPH_REVIEW_ROWS_TABLE}"
+                ).fetchone()[0]
+                sqlite_named_check_count = connection.execute(
+                    f"SELECT COUNT(*) FROM {CALIBRATION_NAMED_CHECK_REVIEW_ROWS_TABLE}"
+                ).fetchone()[0]
+                sqlite_window_count = connection.execute(
+                    f"SELECT COUNT(*) FROM {CALIBRATION_REVIEW_WINDOW_SUMMARIES_TABLE}"
+                ).fetchone()[0]
+
+            validation_summary = json.loads(
+                validation_summary_path.read_text(encoding="utf-8")
+            )
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(payload["command"], "calibration-review")
+        self.assertEqual(payload["dataset_run_id"], "dataset-test")
+        self.assertEqual(payload["residual_attribution_run_id"], "residual-test")
+        self.assertEqual(payload["calibration_review_run_id"], "review-test")
+        self.assertEqual(payload["dataset_row_count"], 90)
+        self.assertEqual(payload["residual_observation_count"], 60)
+        self.assertEqual(payload["window_count"], 2)
+        self.assertGreater(payload["glyph_review_row_count"], 0)
+        self.assertGreater(payload["named_check_review_row_count"], 0)
+        self.assertGreater(payload["glyph_example_row_count"], 0)
+        self.assertGreater(payload["named_check_example_row_count"], 0)
+
+        self.assertEqual(len(glyph_rows), payload["glyph_review_row_count"])
+        self.assertEqual(len(named_check_rows), payload["named_check_review_row_count"])
+        self.assertEqual(len(glyph_examples), payload["glyph_example_row_count"])
+        self.assertEqual(
+            len(named_check_examples),
+            payload["named_check_example_row_count"],
+        )
+        self.assertEqual(len(window_summaries), payload["window_count"])
+        self.assertEqual(sqlite_glyph_count, payload["glyph_review_row_count"])
+        self.assertEqual(
+            sqlite_named_check_count, payload["named_check_review_row_count"]
+        )
+        self.assertEqual(sqlite_window_count, payload["window_count"])
+        self.assertEqual(validation_summary["window_count"], 2)
+        self.assertEqual(
+            validation_summary["residual_attribution_run_ids"],
+            ["residual-test"],
+        )
+        self.assertEqual(manifest["window_count"], 2)
+
+    def test_calibration_review_rejects_bad_date(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            price_cache_path = Path(tmp) / "prices.csv"
+            _write_price_cache(price_cache_path)
+
+            with self.assertRaises(SystemExit) as raised:
+                main(
+                    [
+                        "calibration-review",
+                        "--price-cache",
+                        str(price_cache_path),
+                        "--start-date",
+                        "2026/05/20",
+                        "--end-date",
+                        "2026-05-20",
+                        "--symbols",
+                        "SPY",
+                    ]
+                )
+
+        self.assertEqual(raised.exception.code, 2)
+
+
+def _write_price_cache(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    rows = [
+        _price_row(date(2026, 5, 20), 100.0),
+        _price_row(date(2026, 5, 21), 103.0),
+        _price_row(date(2026, 5, 22), 104.0),
+        _price_row(date(2026, 5, 26), 106.0),
+        _price_row(date(2026, 5, 27), 108.0),
+        _price_row(date(2026, 5, 28), 110.0),
+    ]
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=HISTORICAL_PRICE_CACHE_COLUMNS)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _price_row(price_date: date, close: float) -> dict[str, str]:
+    return {
+        "schema_version": "historical_price_cache.v1",
+        "source": "fixture",
+        "symbol": "SPY",
+        "date": price_date.isoformat(),
+        "open": str(close - 1.0),
+        "high": str(close + 1.0),
+        "low": str(close - 2.0),
+        "close": str(close),
+        "adjusted_close": str(close),
+        "volume": "1000",
+    }
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds M53 calibration review artifact export and CLI support.

Includes CSV and SQLite writers for glyph rows, named-check rows, review examples, and window summaries; validation summary and manifest JSON; calibration-review output directory handling; CLI generation from the historical price cache through residual attribution; and tests.

Refs #482