### PR TITLE
Build calibration adjustment candidates from review tables

### DIFF
--- a/market_health/calibration/calibration_adjustments.py
+++ b/market_health/calibration/calibration_adjustments.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import date
 
-from market_health.calibration.calibration_review import REVIEW_COLD, REVIEW_HOT
+from market_health.calibration.calibration_review import (
+    REVIEW_COLD,
+    REVIEW_HOT,
+    CalibrationGlyphReviewRow,
+    CalibrationNamedCheckReviewRow,
+)
 from market_health.calibration.residuals import VALID_HORIZONS
 
 CALIBRATION_ADJUSTMENT_CANDIDATE_SCHEMA_VERSION = "calibration_adjustment_candidate.v1"
@@ -33,6 +39,8 @@ CALIBRATION_ADJUSTMENT_CANDIDATE_REVIEW_CLASSIFICATIONS = (
     REVIEW_HOT,
     REVIEW_COLD,
 )
+
+DEFAULT_CALIBRATION_ADJUSTMENT_MIN_OBSERVATION_COUNT = 3
 
 CALIBRATION_ADJUSTMENT_CANDIDATE_COLUMNS = (
     "schema_version",
@@ -233,6 +241,194 @@ class CalibrationAdjustmentCandidateRow:
             "calibration_review_run_id": self.calibration_review_run_id,
             "dry_run_only": self.dry_run_only,
         }
+
+
+def build_calibration_adjustment_candidates_from_review_tables(
+    *,
+    glyph_review_rows: Iterable[CalibrationGlyphReviewRow] = (),
+    named_check_review_rows: Iterable[CalibrationNamedCheckReviewRow] = (),
+    calibration_review_run_id: str = "calibration-review",
+    min_observation_count: int = DEFAULT_CALIBRATION_ADJUSTMENT_MIN_OBSERVATION_COUNT,
+) -> tuple[CalibrationAdjustmentCandidateRow, ...]:
+    return tuple(
+        sorted(
+            (
+                *build_glyph_calibration_adjustment_candidates(
+                    glyph_review_rows,
+                    calibration_review_run_id=calibration_review_run_id,
+                    min_observation_count=min_observation_count,
+                ),
+                *build_named_check_calibration_adjustment_candidates(
+                    named_check_review_rows,
+                    calibration_review_run_id=calibration_review_run_id,
+                    min_observation_count=min_observation_count,
+                ),
+            ),
+            key=_candidate_sort_key,
+        )
+    )
+
+
+def build_glyph_calibration_adjustment_candidates(
+    rows: Iterable[CalibrationGlyphReviewRow],
+    *,
+    calibration_review_run_id: str = "calibration-review",
+    min_observation_count: int = DEFAULT_CALIBRATION_ADJUSTMENT_MIN_OBSERVATION_COUNT,
+) -> tuple[CalibrationAdjustmentCandidateRow, ...]:
+    _validate_candidate_builder_inputs(
+        calibration_review_run_id=calibration_review_run_id,
+        min_observation_count=min_observation_count,
+    )
+
+    candidates: list[CalibrationAdjustmentCandidateRow] = []
+    for row in sorted(rows, key=_glyph_review_row_sort_key):
+        if not _review_row_is_candidate_eligible(row, min_observation_count):
+            continue
+
+        candidates.append(
+            CalibrationAdjustmentCandidateRow(
+                candidate_scope=CALIBRATION_ADJUSTMENT_SCOPE_GLYPH,
+                source_review_table=CALIBRATION_ADJUSTMENT_SOURCE_TABLE_GLYPH_REVIEW,
+                horizon=row.horizon,
+                category=row.category,
+                slot=row.slot,
+                glyph=row.glyph,
+                review_classification=row.review_classification,
+                adjustment_direction=_adjustment_direction_for_review_classification(
+                    row.review_classification
+                ),
+                score_delta=_score_delta_for_mean_residual(row.mean_residual),
+                observation_count=row.observation_count,
+                mean_residual=row.mean_residual,
+                mean_abs_residual=row.mean_abs_residual,
+                residual_attribution_run_id=row.residual_attribution_run_id,
+                calibration_review_run_id=calibration_review_run_id,
+                window_label=row.window_label,
+                window_start_date=row.window_start_date,
+                window_end_date=row.window_end_date,
+            )
+        )
+
+    return tuple(candidates)
+
+
+def build_named_check_calibration_adjustment_candidates(
+    rows: Iterable[CalibrationNamedCheckReviewRow],
+    *,
+    calibration_review_run_id: str = "calibration-review",
+    min_observation_count: int = DEFAULT_CALIBRATION_ADJUSTMENT_MIN_OBSERVATION_COUNT,
+) -> tuple[CalibrationAdjustmentCandidateRow, ...]:
+    _validate_candidate_builder_inputs(
+        calibration_review_run_id=calibration_review_run_id,
+        min_observation_count=min_observation_count,
+    )
+
+    candidates: list[CalibrationAdjustmentCandidateRow] = []
+    for row in sorted(rows, key=_named_check_review_row_sort_key):
+        if not _review_row_is_candidate_eligible(row, min_observation_count):
+            continue
+
+        candidates.append(
+            CalibrationAdjustmentCandidateRow(
+                candidate_scope=CALIBRATION_ADJUSTMENT_SCOPE_NAMED_CHECK,
+                source_review_table=(
+                    CALIBRATION_ADJUSTMENT_SOURCE_TABLE_NAMED_CHECK_REVIEW
+                ),
+                horizon=row.horizon,
+                category=row.category,
+                slot=row.slot,
+                glyph=row.glyph,
+                named_check=row.named_check,
+                review_classification=row.review_classification,
+                adjustment_direction=_adjustment_direction_for_review_classification(
+                    row.review_classification
+                ),
+                score_delta=_score_delta_for_mean_residual(row.mean_residual),
+                observation_count=row.observation_count,
+                mean_residual=row.mean_residual,
+                mean_abs_residual=row.mean_abs_residual,
+                residual_attribution_run_id=row.residual_attribution_run_id,
+                calibration_review_run_id=calibration_review_run_id,
+                window_label=row.window_label,
+                window_start_date=row.window_start_date,
+                window_end_date=row.window_end_date,
+            )
+        )
+
+    return tuple(candidates)
+
+
+def _validate_candidate_builder_inputs(
+    *,
+    calibration_review_run_id: str,
+    min_observation_count: int,
+) -> None:
+    _normalize_required_text(calibration_review_run_id, "calibration_review_run_id")
+    if min_observation_count <= 0:
+        raise ValueError("min_observation_count must be positive")
+
+
+def _review_row_is_candidate_eligible(
+    row: CalibrationGlyphReviewRow | CalibrationNamedCheckReviewRow,
+    min_observation_count: int,
+) -> bool:
+    if row.review_classification not in (
+        CALIBRATION_ADJUSTMENT_CANDIDATE_REVIEW_CLASSIFICATIONS
+    ):
+        return False
+    if row.observation_count < min_observation_count:
+        return False
+    if row.observation_count < row.min_observation_count:
+        return False
+    return row.mean_residual != 0
+
+
+def _adjustment_direction_for_review_classification(
+    review_classification: str,
+) -> str:
+    if review_classification == REVIEW_HOT:
+        return CALIBRATION_ADJUSTMENT_DIRECTION_DECREASE_SCORE
+    if review_classification == REVIEW_COLD:
+        return CALIBRATION_ADJUSTMENT_DIRECTION_INCREASE_SCORE
+    raise ValueError(
+        "unsupported calibration adjustment candidate review classification: "
+        f"{review_classification}"
+    )
+
+
+def _score_delta_for_mean_residual(mean_residual: float) -> float:
+    return round(-mean_residual, 8)
+
+
+def _candidate_sort_key(row: CalibrationAdjustmentCandidateRow) -> str:
+    return row.candidate_id
+
+
+def _glyph_review_row_sort_key(row: CalibrationGlyphReviewRow) -> tuple[object, ...]:
+    return (
+        row.window_label,
+        _optional_date(row.window_start_date) or "",
+        _optional_date(row.window_end_date) or "",
+        row.horizon,
+        row.category,
+        row.slot,
+        row.glyph,
+    )
+
+
+def _named_check_review_row_sort_key(
+    row: CalibrationNamedCheckReviewRow,
+) -> tuple[object, ...]:
+    return (
+        row.window_label,
+        _optional_date(row.window_start_date) or "",
+        _optional_date(row.window_end_date) or "",
+        row.horizon,
+        row.named_check,
+        row.category or "",
+        row.slot or 0,
+        row.glyph or "",
+    )
 
 
 def _normalize_horizon(value: str) -> str:

--- a/tests/test_calibration_adjustment_candidates.py
+++ b/tests/test_calibration_adjustment_candidates.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import unittest
+from datetime import date
+
+from market_health.calibration.calibration_adjustments import (
+    CALIBRATION_ADJUSTMENT_DIRECTION_DECREASE_SCORE,
+    CALIBRATION_ADJUSTMENT_DIRECTION_INCREASE_SCORE,
+    CALIBRATION_ADJUSTMENT_SCOPE_GLYPH,
+    CALIBRATION_ADJUSTMENT_SCOPE_NAMED_CHECK,
+    CALIBRATION_ADJUSTMENT_SOURCE_TABLE_GLYPH_REVIEW,
+    CALIBRATION_ADJUSTMENT_SOURCE_TABLE_NAMED_CHECK_REVIEW,
+    build_calibration_adjustment_candidates_from_review_tables,
+    build_glyph_calibration_adjustment_candidates,
+    build_named_check_calibration_adjustment_candidates,
+)
+from market_health.calibration.calibration_review import (
+    CalibrationGlyphReviewRow,
+    CalibrationNamedCheckReviewRow,
+)
+
+
+class CalibrationAdjustmentCandidateBuilderTest(unittest.TestCase):
+    def test_builds_glyph_candidates_from_hot_and_cold_review_rows(self) -> None:
+        candidates = build_glyph_calibration_adjustment_candidates(
+            (
+                glyph_review_row(review_classification="hot", mean_residual=0.5),
+                glyph_review_row(
+                    category="C",
+                    slot=2,
+                    glyph="-",
+                    review_classification="cold",
+                    mean_residual=-0.25,
+                    mean_abs_residual=0.3,
+                ),
+                glyph_review_row(
+                    category="D",
+                    slot=3,
+                    glyph="F",
+                    observation_count=2,
+                    min_observation_count=3,
+                    review_classification="inconclusive",
+                    mean_residual=0.7,
+                ),
+            ),
+            calibration_review_run_id="review-test",
+            min_observation_count=3,
+        )
+
+        self.assertEqual(len(candidates), 2)
+        candidates_by_slot = {
+            candidate.category_slot: candidate for candidate in candidates
+        }
+        cold = candidates_by_slot["C2"]
+        hot = candidates_by_slot["B4"]
+
+        self.assertEqual(cold.candidate_scope, CALIBRATION_ADJUSTMENT_SCOPE_GLYPH)
+        self.assertEqual(
+            cold.source_review_table,
+            CALIBRATION_ADJUSTMENT_SOURCE_TABLE_GLYPH_REVIEW,
+        )
+        self.assertEqual(cold.category_slot, "C2")
+        self.assertEqual(cold.glyph, "-")
+        self.assertEqual(cold.review_classification, "cold")
+        self.assertEqual(
+            cold.adjustment_direction,
+            CALIBRATION_ADJUSTMENT_DIRECTION_INCREASE_SCORE,
+        )
+        self.assertEqual(cold.score_delta, 0.25)
+
+        self.assertEqual(hot.category_slot, "B4")
+        self.assertEqual(hot.glyph, "+")
+        self.assertEqual(hot.review_classification, "hot")
+        self.assertEqual(
+            hot.adjustment_direction,
+            CALIBRATION_ADJUSTMENT_DIRECTION_DECREASE_SCORE,
+        )
+        self.assertEqual(hot.score_delta, -0.5)
+        self.assertEqual(hot.window_label, "30d")
+        self.assertEqual(hot.window_start_date, date(2026, 4, 21))
+        self.assertEqual(hot.window_end_date, date(2026, 5, 20))
+        self.assertEqual(hot.residual_attribution_run_id, "residual-test")
+        self.assertEqual(hot.calibration_review_run_id, "review-test")
+
+    def test_builds_named_check_candidates_and_preserves_optional_context(
+        self,
+    ) -> None:
+        candidates = build_named_check_calibration_adjustment_candidates(
+            (
+                named_check_review_row(
+                    named_check="breadth_confirmed",
+                    category="C",
+                    slot=2,
+                    glyph="-",
+                    review_classification="cold",
+                    mean_residual=-0.4,
+                ),
+                named_check_review_row(
+                    named_check="trend_confirmed",
+                    category=None,
+                    slot=None,
+                    glyph=None,
+                    review_classification="hot",
+                    mean_residual=0.2,
+                ),
+                named_check_review_row(
+                    named_check="macro_filter",
+                    observation_count=1,
+                    min_observation_count=3,
+                    review_classification="inconclusive",
+                    mean_residual=-0.8,
+                ),
+            ),
+            calibration_review_run_id="review-test",
+            min_observation_count=3,
+        )
+
+        self.assertEqual(len(candidates), 2)
+        breadth, trend = candidates
+
+        self.assertEqual(
+            breadth.candidate_scope,
+            CALIBRATION_ADJUSTMENT_SCOPE_NAMED_CHECK,
+        )
+        self.assertEqual(
+            breadth.source_review_table,
+            CALIBRATION_ADJUSTMENT_SOURCE_TABLE_NAMED_CHECK_REVIEW,
+        )
+        self.assertEqual(breadth.named_check, "breadth_confirmed")
+        self.assertEqual(breadth.category_slot, "C2")
+        self.assertEqual(breadth.glyph, "-")
+        self.assertEqual(breadth.score_delta, 0.4)
+
+        self.assertEqual(trend.named_check, "trend_confirmed")
+        self.assertIsNone(trend.category)
+        self.assertIsNone(trend.slot)
+        self.assertIsNone(trend.category_slot)
+        self.assertIsNone(trend.glyph)
+        self.assertEqual(trend.score_delta, -0.2)
+
+    def test_combined_builder_sorts_candidates_deterministically(self) -> None:
+        candidates = build_calibration_adjustment_candidates_from_review_tables(
+            glyph_review_rows=(
+                glyph_review_row(
+                    category="C",
+                    slot=2,
+                    glyph="-",
+                    review_classification="cold",
+                    mean_residual=-0.25,
+                ),
+                glyph_review_row(review_classification="hot", mean_residual=0.5),
+            ),
+            named_check_review_rows=(
+                named_check_review_row(
+                    named_check="trend_confirmed",
+                    review_classification="hot",
+                    mean_residual=0.2,
+                ),
+            ),
+            calibration_review_run_id="review-test",
+            min_observation_count=3,
+        )
+
+        candidate_ids = [candidate.candidate_id for candidate in candidates]
+
+        self.assertEqual(candidate_ids, sorted(candidate_ids))
+
+    def test_skips_rows_below_builder_min_observation_count(self) -> None:
+        candidates = build_glyph_calibration_adjustment_candidates(
+            (
+                glyph_review_row(
+                    observation_count=3,
+                    min_observation_count=1,
+                    review_classification="hot",
+                    mean_residual=0.5,
+                ),
+            ),
+            min_observation_count=4,
+        )
+
+        self.assertEqual(candidates, ())
+
+    def test_rejects_invalid_builder_inputs(self) -> None:
+        with self.assertRaisesRegex(ValueError, "calibration_review_run_id"):
+            build_glyph_calibration_adjustment_candidates(
+                (),
+                calibration_review_run_id=" ",
+            )
+
+        with self.assertRaisesRegex(ValueError, "min_observation_count"):
+            build_named_check_calibration_adjustment_candidates(
+                (),
+                min_observation_count=0,
+            )
+
+
+def glyph_review_row(**overrides: object) -> CalibrationGlyphReviewRow:
+    values = {
+        "horizon": "H1",
+        "category": "B",
+        "slot": 4,
+        "glyph": "+",
+        "observation_count": 4,
+        "min_observation_count": 3,
+        "mean_residual": 0.5,
+        "median_residual": 0.4,
+        "mean_abs_residual": 0.6,
+        "hot_count": 4,
+        "cold_count": 0,
+        "neutral_count": 0,
+        "review_classification": "hot",
+        "residual_attribution_run_id": "residual-test",
+        "window_label": "30d",
+        "window_start_date": date(2026, 4, 21),
+        "window_end_date": date(2026, 5, 20),
+    }
+    values.update(overrides)
+    _balance_review_direction_counts(values)
+    return CalibrationGlyphReviewRow(**values)
+
+
+def named_check_review_row(**overrides: object) -> CalibrationNamedCheckReviewRow:
+    values = {
+        "horizon": "H1",
+        "named_check": "trend_confirmed",
+        "category": "B",
+        "slot": 4,
+        "glyph": "+",
+        "observation_count": 4,
+        "min_observation_count": 3,
+        "mean_residual": 0.5,
+        "median_residual": 0.4,
+        "mean_abs_residual": 0.6,
+        "hot_count": 4,
+        "cold_count": 0,
+        "neutral_count": 0,
+        "review_classification": "hot",
+        "residual_attribution_run_id": "residual-test",
+        "window_label": "30d",
+        "window_start_date": date(2026, 4, 21),
+        "window_end_date": date(2026, 5, 20),
+    }
+    values.update(overrides)
+    _balance_review_direction_counts(values)
+    return CalibrationNamedCheckReviewRow(**values)
+
+
+def _balance_review_direction_counts(values: dict[str, object]) -> None:
+    observation_count = int(values["observation_count"])
+    classification = values["review_classification"]
+    values["hot_count"] = observation_count if classification == "hot" else 0
+    values["cold_count"] = observation_count if classification == "cold" else 0
+    values["neutral_count"] = (
+        observation_count if classification == "inconclusive" else 0
+    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds M54 candidate builders for dry-run calibration simulation.

Includes glyph and named-check review table conversion, hot/cold to score-delta mapping, inconclusive and low-sample exclusion, preserved window and lineage metadata, deterministic combined sorting, builder input validation, and tests.

Refs #490