### PR TITLE
Add dry-run calibration artifacts

### DIFF
--- a/market_health/calibration/calibration_adjustment_artifacts.py
+++ b/market_health/calibration/calibration_adjustment_artifacts.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+import json
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+
+from market_health.calibration.calibration_adjustment_export import (
+    CALIBRATION_ADJUSTMENT_CANDIDATES_TABLE,
+    CALIBRATION_DRY_RUN_COMPARISON_ROWS_TABLE,
+    CALIBRATION_DRY_RUN_SIMULATION_ROWS_TABLE,
+    write_calibration_adjustment_candidates_csv,
+    write_calibration_dry_run_comparison_rows_csv,
+    write_calibration_dry_run_simulation_rows_csv,
+    write_calibration_dry_run_sqlite,
+)
+from market_health.calibration.calibration_adjustments import (
+    CALIBRATION_ADJUSTMENT_CANDIDATE_SCHEMA_VERSION,
+    CALIBRATION_DRY_RUN_COMPARISON_SCHEMA_VERSION,
+    CALIBRATION_DRY_RUN_SIMULATION_SCHEMA_VERSION,
+    CalibrationAdjustmentCandidateRow,
+    CalibrationDryRunComparisonRow,
+    CalibrationDryRunSimulationRow,
+)
+from market_health.calibration.defaults import assert_not_live_runtime_path
+
+CALIBRATION_DRY_RUN_ARTIFACT_SCHEMA_VERSION = "calibration_dry_run_artifacts.v1"
+CALIBRATION_DRY_RUN_VALIDATION_SUMMARY_SCHEMA_VERSION = (
+    "calibration_dry_run_validation_summary.v1"
+)
+
+CALIBRATION_ADJUSTMENT_CANDIDATES_CSV_FILENAME = "adjustment_candidates.csv"
+CALIBRATION_DRY_RUN_SIMULATION_ROWS_CSV_FILENAME = "dry_run_simulation_rows.csv"
+CALIBRATION_DRY_RUN_COMPARISON_ROWS_CSV_FILENAME = "dry_run_comparison_rows.csv"
+CALIBRATION_DRY_RUN_SQLITE_FILENAME = "calibration_dry_run.sqlite"
+CALIBRATION_DRY_RUN_VALIDATION_SUMMARY_FILENAME = "validation_summary.json"
+CALIBRATION_DRY_RUN_MANIFEST_FILENAME = "manifest.json"
+
+
+@dataclass(frozen=True)
+class CalibrationDryRunValidationSummary:
+    candidate_count: int
+    simulation_row_count: int
+    comparison_row_count: int
+    unique_applied_candidate_count: int
+    symbols: tuple[str, ...]
+    horizons: tuple[str, ...]
+    category_slots: tuple[str, ...]
+    candidate_scope_counts: dict[str, int]
+    comparison_group_counts: dict[str, int]
+    residual_attribution_run_ids: tuple[str, ...]
+    calibration_review_run_ids: tuple[str, ...]
+    dry_run_simulation_run_ids: tuple[str, ...]
+    candidate_schema_versions: tuple[str, ...]
+    simulation_schema_versions: tuple[str, ...]
+    comparison_schema_versions: tuple[str, ...]
+    schema_version: str = CALIBRATION_DRY_RUN_VALIDATION_SUMMARY_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if self.schema_version != CALIBRATION_DRY_RUN_VALIDATION_SUMMARY_SCHEMA_VERSION:
+            raise ValueError(
+                "unsupported calibration dry-run validation summary schema version: "
+                f"{self.schema_version}"
+            )
+        for field_name in (
+            "candidate_count",
+            "simulation_row_count",
+            "comparison_row_count",
+            "unique_applied_candidate_count",
+        ):
+            if getattr(self, field_name) < 0:
+                raise ValueError(f"calibration dry-run {field_name} cannot be negative")
+
+    @property
+    def symbol_count(self) -> int:
+        return len(self.symbols)
+
+    def to_record(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "candidate_count": self.candidate_count,
+            "simulation_row_count": self.simulation_row_count,
+            "comparison_row_count": self.comparison_row_count,
+            "unique_applied_candidate_count": self.unique_applied_candidate_count,
+            "symbols": list(self.symbols),
+            "symbol_count": self.symbol_count,
+            "horizons": list(self.horizons),
+            "category_slots": list(self.category_slots),
+            "candidate_scope_counts": dict(self.candidate_scope_counts),
+            "comparison_group_counts": dict(self.comparison_group_counts),
+            "residual_attribution_run_ids": list(self.residual_attribution_run_ids),
+            "calibration_review_run_ids": list(self.calibration_review_run_ids),
+            "dry_run_simulation_run_ids": list(self.dry_run_simulation_run_ids),
+            "candidate_schema_versions": list(self.candidate_schema_versions),
+            "simulation_schema_versions": list(self.simulation_schema_versions),
+            "comparison_schema_versions": list(self.comparison_schema_versions),
+        }
+
+
+@dataclass(frozen=True)
+class CalibrationDryRunArtifacts:
+    output_dir: Path
+    manifest_path: Path
+    candidates_csv_path: Path
+    simulation_rows_csv_path: Path
+    comparison_rows_csv_path: Path
+    sqlite_path: Path
+    validation_summary_path: Path
+    validation_summary: CalibrationDryRunValidationSummary
+    candidates_table_name: str = CALIBRATION_ADJUSTMENT_CANDIDATES_TABLE
+    simulation_rows_table_name: str = CALIBRATION_DRY_RUN_SIMULATION_ROWS_TABLE
+    comparison_rows_table_name: str = CALIBRATION_DRY_RUN_COMPARISON_ROWS_TABLE
+    schema_version: str = CALIBRATION_DRY_RUN_ARTIFACT_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if self.schema_version != CALIBRATION_DRY_RUN_ARTIFACT_SCHEMA_VERSION:
+            raise ValueError(
+                "unsupported calibration dry-run artifact schema version: "
+                f"{self.schema_version}"
+            )
+
+    @property
+    def candidate_count(self) -> int:
+        return self.validation_summary.candidate_count
+
+    @property
+    def simulation_row_count(self) -> int:
+        return self.validation_summary.simulation_row_count
+
+    @property
+    def comparison_row_count(self) -> int:
+        return self.validation_summary.comparison_row_count
+
+    def to_record(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "output_dir": str(self.output_dir),
+            "manifest_path": str(self.manifest_path),
+            "candidates_csv_path": str(self.candidates_csv_path),
+            "simulation_rows_csv_path": str(self.simulation_rows_csv_path),
+            "comparison_rows_csv_path": str(self.comparison_rows_csv_path),
+            "sqlite_path": str(self.sqlite_path),
+            "validation_summary_path": str(self.validation_summary_path),
+            "candidates_table_name": self.candidates_table_name,
+            "simulation_rows_table_name": self.simulation_rows_table_name,
+            "comparison_rows_table_name": self.comparison_rows_table_name,
+            "candidate_count": self.candidate_count,
+            "simulation_row_count": self.simulation_row_count,
+            "comparison_row_count": self.comparison_row_count,
+            "validation_summary": self.validation_summary.to_record(),
+        }
+
+
+def calibration_dry_run_output_dir(
+    output_root: Path,
+    dry_run_simulation_run_id: str,
+) -> Path:
+    return (
+        output_root.expanduser()
+        / "calibration_dry_run"
+        / _safe_dry_run_simulation_run_id(dry_run_simulation_run_id)
+    )
+
+
+def write_calibration_dry_run_artifacts(
+    output_root: Path,
+    *,
+    candidates: tuple[CalibrationAdjustmentCandidateRow, ...],
+    simulation_rows: tuple[CalibrationDryRunSimulationRow, ...],
+    comparison_rows: tuple[CalibrationDryRunComparisonRow, ...],
+    dry_run_simulation_run_id: str = "calibration-dry-run",
+) -> CalibrationDryRunArtifacts:
+    output_dir = calibration_dry_run_output_dir(
+        output_root,
+        dry_run_simulation_run_id,
+    )
+    assert_not_live_runtime_path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    candidates_csv_path = output_dir / CALIBRATION_ADJUSTMENT_CANDIDATES_CSV_FILENAME
+    simulation_rows_csv_path = (
+        output_dir / CALIBRATION_DRY_RUN_SIMULATION_ROWS_CSV_FILENAME
+    )
+    comparison_rows_csv_path = (
+        output_dir / CALIBRATION_DRY_RUN_COMPARISON_ROWS_CSV_FILENAME
+    )
+    sqlite_path = output_dir / CALIBRATION_DRY_RUN_SQLITE_FILENAME
+    validation_summary_path = (
+        output_dir / CALIBRATION_DRY_RUN_VALIDATION_SUMMARY_FILENAME
+    )
+    manifest_path = output_dir / CALIBRATION_DRY_RUN_MANIFEST_FILENAME
+
+    write_calibration_adjustment_candidates_csv(candidates_csv_path, candidates)
+    write_calibration_dry_run_simulation_rows_csv(
+        simulation_rows_csv_path,
+        simulation_rows,
+    )
+    write_calibration_dry_run_comparison_rows_csv(
+        comparison_rows_csv_path,
+        comparison_rows,
+    )
+    write_calibration_dry_run_sqlite(
+        sqlite_path,
+        candidates=candidates,
+        simulation_rows=simulation_rows,
+        comparison_rows=comparison_rows,
+    )
+
+    validation_summary = build_calibration_dry_run_validation_summary(
+        candidates,
+        simulation_rows,
+        comparison_rows,
+    )
+    artifacts = CalibrationDryRunArtifacts(
+        output_dir=output_dir,
+        manifest_path=manifest_path,
+        candidates_csv_path=candidates_csv_path,
+        simulation_rows_csv_path=simulation_rows_csv_path,
+        comparison_rows_csv_path=comparison_rows_csv_path,
+        sqlite_path=sqlite_path,
+        validation_summary_path=validation_summary_path,
+        validation_summary=validation_summary,
+    )
+
+    write_calibration_dry_run_validation_summary_json(
+        validation_summary_path,
+        validation_summary,
+    )
+    write_calibration_dry_run_manifest_json(manifest_path, artifacts)
+
+    return artifacts
+
+
+def build_calibration_dry_run_validation_summary(
+    candidates: tuple[CalibrationAdjustmentCandidateRow, ...],
+    simulation_rows: tuple[CalibrationDryRunSimulationRow, ...],
+    comparison_rows: tuple[CalibrationDryRunComparisonRow, ...],
+) -> CalibrationDryRunValidationSummary:
+    candidate_scope_counts = Counter(row.candidate_scope for row in candidates)
+    comparison_group_counts = Counter(row.group_name for row in comparison_rows)
+    applied_candidate_ids = sorted(
+        {
+            candidate_id
+            for row in simulation_rows
+            for candidate_id in row.applied_candidate_ids
+        }
+    )
+
+    return CalibrationDryRunValidationSummary(
+        candidate_count=len(candidates),
+        simulation_row_count=len(simulation_rows),
+        comparison_row_count=len(comparison_rows),
+        unique_applied_candidate_count=len(applied_candidate_ids),
+        symbols=tuple(sorted({row.symbol for row in simulation_rows})),
+        horizons=tuple(sorted({row.horizon for row in simulation_rows})),
+        category_slots=tuple(sorted({row.category_slot for row in simulation_rows})),
+        candidate_scope_counts=dict(sorted(candidate_scope_counts.items())),
+        comparison_group_counts=dict(sorted(comparison_group_counts.items())),
+        residual_attribution_run_ids=tuple(
+            sorted({row.residual_attribution_run_id for row in simulation_rows})
+        ),
+        calibration_review_run_ids=tuple(
+            sorted({row.calibration_review_run_id for row in simulation_rows})
+        ),
+        dry_run_simulation_run_ids=tuple(
+            sorted({row.dry_run_simulation_run_id for row in simulation_rows})
+        ),
+        candidate_schema_versions=tuple(
+            sorted({row.schema_version for row in candidates})
+            or [CALIBRATION_ADJUSTMENT_CANDIDATE_SCHEMA_VERSION]
+        ),
+        simulation_schema_versions=tuple(
+            sorted({row.schema_version for row in simulation_rows})
+            or [CALIBRATION_DRY_RUN_SIMULATION_SCHEMA_VERSION]
+        ),
+        comparison_schema_versions=tuple(
+            sorted({row.schema_version for row in comparison_rows})
+            or [CALIBRATION_DRY_RUN_COMPARISON_SCHEMA_VERSION]
+        ),
+    )
+
+
+def write_calibration_dry_run_validation_summary_json(
+    path: Path,
+    validation_summary: CalibrationDryRunValidationSummary,
+) -> Path:
+    _write_json(path, validation_summary.to_record())
+    return path
+
+
+def write_calibration_dry_run_manifest_json(
+    path: Path,
+    artifacts: CalibrationDryRunArtifacts,
+) -> Path:
+    _write_json(path, artifacts.to_record())
+    return path
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    assert_not_live_runtime_path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _safe_dry_run_simulation_run_id(value: str) -> str:
+    safe = value.strip()
+    if not safe:
+        raise ValueError("calibration dry-run simulation run id is required")
+    if not all(
+        character.isalnum() or character in {"-", "_", "."} for character in safe
+    ):
+        raise ValueError(f"unsafe calibration dry-run simulation run id: {value}")
+    return safe

--- a/market_health/calibration/calibration_adjustment_export.py
+++ b/market_health/calibration/calibration_adjustment_export.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import csv
+import sqlite3
+from collections.abc import Iterable
+from pathlib import Path
+
+from market_health.calibration.calibration_adjustments import (
+    CALIBRATION_ADJUSTMENT_CANDIDATE_COLUMNS,
+    CALIBRATION_DRY_RUN_COMPARISON_COLUMNS,
+    CALIBRATION_DRY_RUN_COMPARISON_GROUPS,
+    CALIBRATION_DRY_RUN_SIMULATION_COLUMNS,
+    CalibrationAdjustmentCandidateRow,
+    CalibrationDryRunComparisonRow,
+    CalibrationDryRunSimulationRow,
+)
+from market_health.calibration.defaults import assert_not_live_runtime_path
+
+CALIBRATION_ADJUSTMENT_CANDIDATES_TABLE = "calibration_adjustment_candidates"
+CALIBRATION_DRY_RUN_SIMULATION_ROWS_TABLE = "calibration_dry_run_simulation_rows"
+CALIBRATION_DRY_RUN_COMPARISON_ROWS_TABLE = "calibration_dry_run_comparison_rows"
+
+
+def calibration_adjustment_candidates_to_records(
+    rows: Iterable[CalibrationAdjustmentCandidateRow],
+) -> tuple[dict[str, object], ...]:
+    return tuple(row.to_record() for row in sorted(rows, key=_candidate_row_sort_key))
+
+
+def calibration_dry_run_simulation_rows_to_records(
+    rows: Iterable[CalibrationDryRunSimulationRow],
+) -> tuple[dict[str, object], ...]:
+    return tuple(row.to_record() for row in sorted(rows, key=_simulation_row_sort_key))
+
+
+def calibration_dry_run_comparison_rows_to_records(
+    rows: Iterable[CalibrationDryRunComparisonRow],
+) -> tuple[dict[str, object], ...]:
+    return tuple(row.to_record() for row in sorted(rows, key=_comparison_row_sort_key))
+
+
+def write_calibration_adjustment_candidates_csv(
+    path: Path,
+    rows: Iterable[CalibrationAdjustmentCandidateRow],
+) -> None:
+    _write_csv(
+        path,
+        calibration_adjustment_candidates_to_records(rows),
+        CALIBRATION_ADJUSTMENT_CANDIDATE_COLUMNS,
+    )
+
+
+def write_calibration_dry_run_simulation_rows_csv(
+    path: Path,
+    rows: Iterable[CalibrationDryRunSimulationRow],
+) -> None:
+    _write_csv(
+        path,
+        calibration_dry_run_simulation_rows_to_records(rows),
+        CALIBRATION_DRY_RUN_SIMULATION_COLUMNS,
+    )
+
+
+def write_calibration_dry_run_comparison_rows_csv(
+    path: Path,
+    rows: Iterable[CalibrationDryRunComparisonRow],
+) -> None:
+    _write_csv(
+        path,
+        calibration_dry_run_comparison_rows_to_records(rows),
+        CALIBRATION_DRY_RUN_COMPARISON_COLUMNS,
+    )
+
+
+def write_calibration_dry_run_sqlite(
+    path: Path,
+    *,
+    candidates: Iterable[CalibrationAdjustmentCandidateRow],
+    simulation_rows: Iterable[CalibrationDryRunSimulationRow],
+    comparison_rows: Iterable[CalibrationDryRunComparisonRow],
+    candidates_table_name: str = CALIBRATION_ADJUSTMENT_CANDIDATES_TABLE,
+    simulation_rows_table_name: str = CALIBRATION_DRY_RUN_SIMULATION_ROWS_TABLE,
+    comparison_rows_table_name: str = CALIBRATION_DRY_RUN_COMPARISON_ROWS_TABLE,
+) -> None:
+    assert_not_live_runtime_path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    candidate_records = calibration_adjustment_candidates_to_records(candidates)
+    simulation_records = calibration_dry_run_simulation_rows_to_records(simulation_rows)
+    comparison_records = calibration_dry_run_comparison_rows_to_records(comparison_rows)
+
+    with sqlite3.connect(path) as connection:
+        _write_table(
+            connection,
+            table_name=candidates_table_name,
+            columns=CALIBRATION_ADJUSTMENT_CANDIDATE_COLUMNS,
+            records=candidate_records,
+        )
+        _write_table(
+            connection,
+            table_name=simulation_rows_table_name,
+            columns=CALIBRATION_DRY_RUN_SIMULATION_COLUMNS,
+            records=simulation_records,
+        )
+        _write_table(
+            connection,
+            table_name=comparison_rows_table_name,
+            columns=CALIBRATION_DRY_RUN_COMPARISON_COLUMNS,
+            records=comparison_records,
+        )
+
+
+def sqlite_type_for_calibration_dry_run_column(column: str) -> str:
+    if column in {
+        "score_delta",
+        "mean_residual",
+        "mean_abs_residual",
+        "baseline_forecast_score",
+        "simulated_forecast_score",
+        "realized_current_score",
+        "baseline_residual",
+        "simulated_residual",
+        "applied_score_delta",
+        "baseline_mean_residual",
+        "simulated_mean_residual",
+        "baseline_mean_abs_residual",
+        "simulated_mean_abs_residual",
+        "mean_abs_residual_delta",
+        "mean_abs_residual_improvement",
+    }:
+        return "REAL"
+    if column in {
+        "slot",
+        "observation_count",
+        "applied_candidate_count",
+        "improved_count",
+        "worsened_count",
+        "unchanged_count",
+        "baseline_hot_count",
+        "baseline_cold_count",
+        "baseline_neutral_count",
+        "simulated_hot_count",
+        "simulated_cold_count",
+        "simulated_neutral_count",
+        "unique_applied_candidate_count",
+    }:
+        return "INTEGER"
+    return "TEXT"
+
+
+def _write_csv(
+    path: Path,
+    records: tuple[dict[str, object], ...],
+    columns: tuple[str, ...],
+) -> None:
+    assert_not_live_runtime_path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=columns)
+        writer.writeheader()
+        for record in records:
+            writer.writerow(record)
+
+
+def _write_table(
+    connection: sqlite3.Connection,
+    *,
+    table_name: str,
+    columns: tuple[str, ...],
+    records: tuple[dict[str, object], ...],
+) -> None:
+    quoted_table = _quote_identifier(table_name)
+    connection.execute(f"DROP TABLE IF EXISTS {quoted_table}")
+    column_sql = ", ".join(
+        f"{_quote_identifier(column)} {sqlite_type_for_calibration_dry_run_column(column)}"
+        for column in columns
+    )
+    connection.execute(f"CREATE TABLE {quoted_table} ({column_sql})")
+
+    if not records:
+        return
+
+    placeholders = ", ".join("?" for _ in columns)
+    quoted_columns = ", ".join(_quote_identifier(column) for column in columns)
+    connection.executemany(
+        f"INSERT INTO {quoted_table} ({quoted_columns}) VALUES ({placeholders})",
+        [[record[column] for column in columns] for record in records],
+    )
+
+
+def _quote_identifier(value: str) -> str:
+    escaped = value.replace('"', '""')
+    return f'"{escaped}"'
+
+
+def _optional_date_sort_key(value: object) -> str:
+    return "" if value is None else str(value)
+
+
+def _candidate_row_sort_key(
+    row: CalibrationAdjustmentCandidateRow,
+) -> tuple[object, ...]:
+    return (row.candidate_id,)
+
+
+def _simulation_row_sort_key(
+    row: CalibrationDryRunSimulationRow,
+) -> tuple[object, ...]:
+    return (
+        row.replay_date.isoformat(),
+        row.symbol,
+        row.horizon,
+        row.category,
+        row.slot,
+        row.glyph,
+        row.named_check,
+    )
+
+
+def _comparison_row_sort_key(
+    row: CalibrationDryRunComparisonRow,
+) -> tuple[object, ...]:
+    return (
+        CALIBRATION_DRY_RUN_COMPARISON_GROUPS.index(row.group_name),
+        row.group_value,
+    )

--- a/tests/test_calibration_dry_run_artifacts.py
+++ b/tests/test_calibration_dry_run_artifacts.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import csv
+import json
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+
+from market_health.calibration.calibration_adjustment_artifacts import (
+    CALIBRATION_ADJUSTMENT_CANDIDATES_CSV_FILENAME,
+    CALIBRATION_DRY_RUN_COMPARISON_ROWS_CSV_FILENAME,
+    CALIBRATION_DRY_RUN_MANIFEST_FILENAME,
+    CALIBRATION_DRY_RUN_SIMULATION_ROWS_CSV_FILENAME,
+    CALIBRATION_DRY_RUN_SQLITE_FILENAME,
+    CALIBRATION_DRY_RUN_VALIDATION_SUMMARY_FILENAME,
+    build_calibration_dry_run_validation_summary,
+    calibration_dry_run_output_dir,
+    write_calibration_dry_run_artifacts,
+)
+from market_health.calibration.calibration_adjustment_export import (
+    CALIBRATION_ADJUSTMENT_CANDIDATES_TABLE,
+    CALIBRATION_DRY_RUN_COMPARISON_ROWS_TABLE,
+    CALIBRATION_DRY_RUN_SIMULATION_ROWS_TABLE,
+)
+from market_health.calibration.calibration_adjustments import (
+    build_calibration_dry_run_comparison_rows,
+)
+from tests.test_calibration_adjustments import glyph_candidate, named_check_candidate
+from tests.test_calibration_dry_run_simulation import (
+    apply_calibration_adjustment_candidates_dry_run,
+    residual_row,
+)
+
+
+class CalibrationDryRunArtifactsTest(unittest.TestCase):
+    def test_validation_summary_has_stable_shape_and_counts(self) -> None:
+        candidates, simulation_rows, comparison_rows = dry_run_tables()
+
+        summary = build_calibration_dry_run_validation_summary(
+            candidates,
+            simulation_rows,
+            comparison_rows,
+        )
+        record = summary.to_record()
+
+        self.assertEqual(record["candidate_count"], 2)
+        self.assertEqual(record["simulation_row_count"], 2)
+        self.assertEqual(record["comparison_row_count"], 1)
+        self.assertEqual(record["unique_applied_candidate_count"], 2)
+        self.assertEqual(record["symbols"], ["QQQ", "SPY"])
+        self.assertEqual(record["symbol_count"], 2)
+        self.assertEqual(record["horizons"], ["H1"])
+        self.assertEqual(record["category_slots"], ["B4", "C2"])
+        self.assertEqual(
+            record["candidate_scope_counts"],
+            {"glyph": 1, "named_check": 1},
+        )
+        self.assertEqual(record["comparison_group_counts"], {"overall": 1})
+        self.assertEqual(record["residual_attribution_run_ids"], ["residual-test"])
+        self.assertEqual(record["calibration_review_run_ids"], ["review-test"])
+        self.assertEqual(record["dry_run_simulation_run_ids"], ["dry-run-test"])
+
+    def test_output_dir_is_stable(self) -> None:
+        self.assertEqual(
+            calibration_dry_run_output_dir(Path("/tmp/out"), "dry-run-1"),
+            Path("/tmp/out/calibration_dry_run/dry-run-1"),
+        )
+
+    def test_invalid_run_id_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "unsafe"):
+            calibration_dry_run_output_dir(Path("/tmp/out"), "../bad")
+
+    def test_write_calibration_dry_run_artifacts_outputs_files(self) -> None:
+        candidates, simulation_rows, comparison_rows = dry_run_tables()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            artifacts = write_calibration_dry_run_artifacts(
+                Path(tmpdir),
+                candidates=candidates,
+                simulation_rows=simulation_rows,
+                comparison_rows=comparison_rows,
+                dry_run_simulation_run_id="dry-run-test",
+            )
+
+            self.assertEqual(artifacts.candidate_count, 2)
+            self.assertEqual(artifacts.simulation_row_count, 2)
+            self.assertEqual(artifacts.comparison_row_count, 1)
+            self.assertEqual(
+                artifacts.candidates_csv_path.name,
+                CALIBRATION_ADJUSTMENT_CANDIDATES_CSV_FILENAME,
+            )
+            self.assertEqual(
+                artifacts.simulation_rows_csv_path.name,
+                CALIBRATION_DRY_RUN_SIMULATION_ROWS_CSV_FILENAME,
+            )
+            self.assertEqual(
+                artifacts.comparison_rows_csv_path.name,
+                CALIBRATION_DRY_RUN_COMPARISON_ROWS_CSV_FILENAME,
+            )
+            self.assertEqual(
+                artifacts.sqlite_path.name,
+                CALIBRATION_DRY_RUN_SQLITE_FILENAME,
+            )
+            self.assertEqual(
+                artifacts.validation_summary_path.name,
+                CALIBRATION_DRY_RUN_VALIDATION_SUMMARY_FILENAME,
+            )
+            self.assertEqual(
+                artifacts.manifest_path.name,
+                CALIBRATION_DRY_RUN_MANIFEST_FILENAME,
+            )
+
+            with artifacts.candidates_csv_path.open(
+                newline="",
+                encoding="utf-8",
+            ) as handle:
+                candidate_rows = list(csv.DictReader(handle))
+            with artifacts.simulation_rows_csv_path.open(
+                newline="",
+                encoding="utf-8",
+            ) as handle:
+                simulation_csv_rows = list(csv.DictReader(handle))
+            with artifacts.comparison_rows_csv_path.open(
+                newline="",
+                encoding="utf-8",
+            ) as handle:
+                comparison_csv_rows = list(csv.DictReader(handle))
+
+            validation_payload = json.loads(
+                artifacts.validation_summary_path.read_text(encoding="utf-8")
+            )
+            manifest_payload = json.loads(
+                artifacts.manifest_path.read_text(encoding="utf-8")
+            )
+
+            with sqlite3.connect(artifacts.sqlite_path) as connection:
+                candidate_count = connection.execute(
+                    f"SELECT COUNT(*) FROM {CALIBRATION_ADJUSTMENT_CANDIDATES_TABLE}"
+                ).fetchone()[0]
+                simulation_count = connection.execute(
+                    f"SELECT COUNT(*) FROM {CALIBRATION_DRY_RUN_SIMULATION_ROWS_TABLE}"
+                ).fetchone()[0]
+                comparison_count = connection.execute(
+                    f"SELECT COUNT(*) FROM {CALIBRATION_DRY_RUN_COMPARISON_ROWS_TABLE}"
+                ).fetchone()[0]
+
+        self.assertEqual(len(candidate_rows), artifacts.candidate_count)
+        self.assertEqual(len(simulation_csv_rows), artifacts.simulation_row_count)
+        self.assertEqual(len(comparison_csv_rows), artifacts.comparison_row_count)
+        self.assertEqual(candidate_count, artifacts.candidate_count)
+        self.assertEqual(simulation_count, artifacts.simulation_row_count)
+        self.assertEqual(comparison_count, artifacts.comparison_row_count)
+        self.assertEqual(validation_payload["candidate_count"], 2)
+        self.assertEqual(manifest_payload["candidate_count"], 2)
+        self.assertEqual(manifest_payload["simulation_row_count"], 2)
+
+
+def dry_run_tables():
+    candidates = (
+        glyph_candidate(
+            score_delta=-0.25,
+            mean_residual=0.25,
+            calibration_review_run_id="review-test",
+        ),
+        named_check_candidate(
+            horizon="H1",
+            named_check="breadth_confirmed",
+            category="C",
+            slot=2,
+            glyph="-",
+            review_classification="cold",
+            adjustment_direction="increase_score",
+            score_delta=0.25,
+            mean_residual=-0.25,
+            calibration_review_run_id="review-test",
+        ),
+    )
+    residual_rows = (
+        residual_row(
+            symbol="SPY",
+            category="B",
+            slot=4,
+            glyph="+",
+            named_check="trend_confirmed",
+        ),
+        residual_row(
+            symbol="QQQ",
+            category="C",
+            slot=2,
+            glyph="-",
+            named_check="breadth_confirmed",
+            forecast_score=7.5,
+            realized_current_score=8.0,
+            residual=-0.5,
+            residual_direction="cold",
+        ),
+    )
+    simulation_rows = apply_calibration_adjustment_candidates_dry_run(
+        residual_rows,
+        candidates,
+        dry_run_simulation_run_id="dry-run-test",
+    )
+    comparison_rows = build_calibration_dry_run_comparison_rows(
+        simulation_rows,
+        groupings=("overall",),
+    )
+    return candidates, simulation_rows, comparison_rows
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds M54 dry-run calibration artifacts.

Includes CSV and SQLite exporters for adjustment candidates, simulation rows, and comparison rows; dry-run artifact output layout; manifest and validation summary JSON; stable output directory handling; run-id validation; deterministic record ordering; and tests.

Refs #493