### PR TITLE
Add dry-run calibration CLI entrypoint

### DIFF
--- a/market_health/calibration/cli.py
+++ b/market_health/calibration/cli.py
@@ -21,6 +21,15 @@ from market_health.calibration.calibration_review import (
 from market_health.calibration.calibration_review_artifacts import (
     write_calibration_review_artifacts,
 )
+from market_health.calibration.calibration_adjustment_artifacts import (
+    write_calibration_dry_run_artifacts,
+)
+from market_health.calibration.calibration_adjustments import (
+    DEFAULT_CALIBRATION_ADJUSTMENT_MIN_OBSERVATION_COUNT,
+    apply_calibration_adjustment_candidates_dry_run,
+    build_calibration_adjustment_candidates_from_review_tables,
+    build_calibration_dry_run_comparison_rows,
+)
 from market_health.calibration.check_output import (
     CheckReplayRow,
     build_fixture_check_replay_rows,
@@ -147,6 +156,55 @@ def build_parser() -> argparse.ArgumentParser:
     )
     calibration_review.add_argument("--no-full-window", action="store_true")
 
+    calibration_dry_run = subparsers.add_parser(
+        "calibration-dry-run",
+        help="Build dry-run calibration adjustment candidates and simulation artifacts.",
+    )
+    calibration_dry_run.add_argument("--price-cache", type=Path, required=True)
+    calibration_dry_run.add_argument("--start-date", type=_parse_date, required=True)
+    calibration_dry_run.add_argument("--end-date", type=_parse_date, required=True)
+    calibration_dry_run.add_argument("--symbols", nargs="+", required=True)
+    calibration_dry_run.add_argument("--lookback-rows", type=int, default=20)
+    calibration_dry_run.add_argument("--out", type=Path, default=default_output_root())
+    calibration_dry_run.add_argument(
+        "--dataset-run-id",
+        default="authoritative-replay-dataset",
+    )
+    calibration_dry_run.add_argument(
+        "--residual-attribution-run-id",
+        default="residual-attribution",
+    )
+    calibration_dry_run.add_argument(
+        "--calibration-review-run-id",
+        default="calibration-review",
+    )
+    calibration_dry_run.add_argument(
+        "--dry-run-simulation-run-id",
+        default="calibration-dry-run",
+    )
+    calibration_dry_run.add_argument(
+        "--review-min-observation-count",
+        type=int,
+        default=DEFAULT_CALIBRATION_REVIEW_MIN_OBSERVATION_COUNT,
+    )
+    calibration_dry_run.add_argument(
+        "--adjustment-min-observation-count",
+        type=int,
+        default=DEFAULT_CALIBRATION_ADJUSTMENT_MIN_OBSERVATION_COUNT,
+    )
+    calibration_dry_run.add_argument(
+        "--max-examples-per-group",
+        type=int,
+        default=DEFAULT_CALIBRATION_REVIEW_EXAMPLES_PER_GROUP,
+    )
+    calibration_dry_run.add_argument(
+        "--window-days",
+        nargs="*",
+        type=int,
+        default=list(DEFAULT_CALIBRATION_REVIEW_WINDOW_DAY_COUNTS),
+    )
+    calibration_dry_run.add_argument("--no-full-window", action="store_true")
+
     return parser
 
 
@@ -181,6 +239,11 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "calibration-review":
         payload = _run_calibration_review_command(args)
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0
+
+    if args.command == "calibration-dry-run":
+        payload = _run_calibration_dry_run_command(args)
         print(json.dumps(payload, indent=2, sort_keys=True))
         return 0
 
@@ -384,6 +447,89 @@ def _run_calibration_review_command(args: argparse.Namespace) -> dict[str, objec
         "named_check_review_row_count": artifacts.named_check_review_row_count,
         "glyph_example_row_count": artifacts.glyph_example_row_count,
         "named_check_example_row_count": artifacts.named_check_example_row_count,
+        "artifacts": artifacts.to_record(),
+    }
+
+
+def _run_calibration_dry_run_command(args: argparse.Namespace) -> dict[str, object]:
+    output_root = args.out.expanduser()
+    assert_not_live_runtime_path(output_root)
+
+    price_cache_path = args.price_cache.expanduser()
+    price_cache = read_historical_price_cache_csv(
+        price_cache_path,
+        symbols=args.symbols,
+    )
+    range_request = build_range_replay_request(
+        start_date=args.start_date,
+        end_date=args.end_date,
+        symbols=args.symbols,
+        lookback_rows=args.lookback_rows,
+        output_root=output_root,
+    )
+    range_result = run_range_replay(
+        request=range_request,
+        price_rows=price_cache.rows,
+    )
+    check_rows = _build_authoritative_dataset_check_rows(range_result)
+    dataset_rows = build_authoritative_replay_dataset_rows(
+        range_result=range_result,
+        check_rows=check_rows,
+        price_rows=price_cache.rows,
+        dataset_run_id=args.dataset_run_id,
+    )
+    residual_rows = build_residual_attribution_rows(
+        dataset_rows,
+        residual_attribution_run_id=args.residual_attribution_run_id,
+    )
+    windows = build_trailing_calibration_review_windows(
+        residual_rows,
+        day_counts=args.window_days,
+        include_full_window=not args.no_full_window,
+    )
+    windowed_tables = build_windowed_calibration_review_tables(
+        residual_rows,
+        windows=windows,
+        min_observation_count=args.review_min_observation_count,
+        max_examples_per_group=args.max_examples_per_group,
+    )
+    candidates = build_calibration_adjustment_candidates_from_review_tables(
+        glyph_review_rows=tuple(
+            row for table in windowed_tables for row in table.glyph_review_rows
+        ),
+        named_check_review_rows=tuple(
+            row for table in windowed_tables for row in table.named_check_review_rows
+        ),
+        calibration_review_run_id=args.calibration_review_run_id,
+        min_observation_count=args.adjustment_min_observation_count,
+    )
+    simulation_rows = apply_calibration_adjustment_candidates_dry_run(
+        residual_rows,
+        candidates,
+        dry_run_simulation_run_id=args.dry_run_simulation_run_id,
+    )
+    comparison_rows = build_calibration_dry_run_comparison_rows(simulation_rows)
+    artifacts = write_calibration_dry_run_artifacts(
+        output_root,
+        candidates=candidates,
+        simulation_rows=simulation_rows,
+        comparison_rows=comparison_rows,
+        dry_run_simulation_run_id=args.dry_run_simulation_run_id,
+    )
+
+    return {
+        "status": "ok",
+        "command": "calibration-dry-run",
+        "price_cache_path": str(price_cache_path),
+        "dataset_run_id": args.dataset_run_id,
+        "residual_attribution_run_id": args.residual_attribution_run_id,
+        "calibration_review_run_id": args.calibration_review_run_id,
+        "dry_run_simulation_run_id": args.dry_run_simulation_run_id,
+        "dataset_row_count": len(dataset_rows),
+        "residual_observation_count": len(residual_rows),
+        "candidate_count": artifacts.candidate_count,
+        "simulation_row_count": artifacts.simulation_row_count,
+        "comparison_row_count": artifacts.comparison_row_count,
         "artifacts": artifacts.to_record(),
     }
 

--- a/tests/test_calibration_dry_run_cli.py
+++ b/tests/test_calibration_dry_run_cli.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import csv
+import io
+import json
+import sqlite3
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from datetime import date
+from pathlib import Path
+
+from market_health.calibration.calibration_adjustment_export import (
+    CALIBRATION_ADJUSTMENT_CANDIDATES_TABLE,
+    CALIBRATION_DRY_RUN_COMPARISON_ROWS_TABLE,
+    CALIBRATION_DRY_RUN_SIMULATION_ROWS_TABLE,
+)
+from market_health.calibration.cli import build_parser, main
+from market_health.calibration.price_cache import HISTORICAL_PRICE_CACHE_COLUMNS
+
+
+class CalibrationDryRunCliTest(unittest.TestCase):
+    def test_calibration_dry_run_help_is_registered(self) -> None:
+        parser = build_parser()
+
+        self.assertIn("calibration-dry-run", parser.format_help())
+
+    def test_calibration_dry_run_command_writes_artifacts_and_outputs_json(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            price_cache_path = tmp_path / "prices.csv"
+            output_root = tmp_path / "calibration"
+            _write_price_cache(price_cache_path)
+
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                exit_code = main(
+                    [
+                        "calibration-dry-run",
+                        "--price-cache",
+                        str(price_cache_path),
+                        "--start-date",
+                        "2026-05-20",
+                        "--end-date",
+                        "2026-05-20",
+                        "--symbols",
+                        "SPY",
+                        "--lookback-rows",
+                        "1",
+                        "--out",
+                        str(output_root),
+                        "--dataset-run-id",
+                        "dataset-test",
+                        "--residual-attribution-run-id",
+                        "residual-test",
+                        "--calibration-review-run-id",
+                        "review-test",
+                        "--dry-run-simulation-run-id",
+                        "dry-run-test",
+                        "--review-min-observation-count",
+                        "1",
+                        "--adjustment-min-observation-count",
+                        "1",
+                        "--max-examples-per-group",
+                        "1",
+                        "--window-days",
+                        "1",
+                    ]
+                )
+
+            payload = json.loads(stdout.getvalue())
+            artifacts = payload["artifacts"]
+            candidates_csv_path = Path(artifacts["candidates_csv_path"])
+            simulation_rows_csv_path = Path(artifacts["simulation_rows_csv_path"])
+            comparison_rows_csv_path = Path(artifacts["comparison_rows_csv_path"])
+            sqlite_path = Path(artifacts["sqlite_path"])
+            validation_summary_path = Path(artifacts["validation_summary_path"])
+            manifest_path = Path(artifacts["manifest_path"])
+
+            with candidates_csv_path.open(newline="", encoding="utf-8") as handle:
+                candidate_rows = list(csv.DictReader(handle))
+            with simulation_rows_csv_path.open(newline="", encoding="utf-8") as handle:
+                simulation_rows = list(csv.DictReader(handle))
+            with comparison_rows_csv_path.open(newline="", encoding="utf-8") as handle:
+                comparison_rows = list(csv.DictReader(handle))
+
+            with sqlite3.connect(sqlite_path) as connection:
+                sqlite_candidate_count = connection.execute(
+                    f"SELECT COUNT(*) FROM {CALIBRATION_ADJUSTMENT_CANDIDATES_TABLE}"
+                ).fetchone()[0]
+                sqlite_simulation_count = connection.execute(
+                    f"SELECT COUNT(*) FROM {CALIBRATION_DRY_RUN_SIMULATION_ROWS_TABLE}"
+                ).fetchone()[0]
+                sqlite_comparison_count = connection.execute(
+                    f"SELECT COUNT(*) FROM {CALIBRATION_DRY_RUN_COMPARISON_ROWS_TABLE}"
+                ).fetchone()[0]
+
+            validation_summary = json.loads(
+                validation_summary_path.read_text(encoding="utf-8")
+            )
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(payload["command"], "calibration-dry-run")
+        self.assertEqual(payload["dataset_run_id"], "dataset-test")
+        self.assertEqual(payload["residual_attribution_run_id"], "residual-test")
+        self.assertEqual(payload["calibration_review_run_id"], "review-test")
+        self.assertEqual(payload["dry_run_simulation_run_id"], "dry-run-test")
+        self.assertEqual(payload["dataset_row_count"], 90)
+        self.assertEqual(payload["residual_observation_count"], 60)
+        self.assertGreater(payload["candidate_count"], 0)
+        self.assertGreater(payload["simulation_row_count"], 0)
+        self.assertGreater(payload["comparison_row_count"], 0)
+
+        self.assertEqual(len(candidate_rows), payload["candidate_count"])
+        self.assertEqual(len(simulation_rows), payload["simulation_row_count"])
+        self.assertEqual(len(comparison_rows), payload["comparison_row_count"])
+        self.assertEqual(sqlite_candidate_count, payload["candidate_count"])
+        self.assertEqual(sqlite_simulation_count, payload["simulation_row_count"])
+        self.assertEqual(sqlite_comparison_count, payload["comparison_row_count"])
+        self.assertEqual(
+            validation_summary["candidate_count"], payload["candidate_count"]
+        )
+        self.assertEqual(
+            validation_summary["dry_run_simulation_run_ids"],
+            ["dry-run-test"],
+        )
+        self.assertEqual(manifest["candidate_count"], payload["candidate_count"])
+        self.assertEqual(
+            manifest["simulation_row_count"], payload["simulation_row_count"]
+        )
+
+    def test_calibration_dry_run_rejects_bad_date(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            price_cache_path = Path(tmp) / "prices.csv"
+            _write_price_cache(price_cache_path)
+
+            with self.assertRaises(SystemExit) as raised:
+                main(
+                    [
+                        "calibration-dry-run",
+                        "--price-cache",
+                        str(price_cache_path),
+                        "--start-date",
+                        "2026/05/20",
+                        "--end-date",
+                        "2026-05-20",
+                        "--symbols",
+                        "SPY",
+                    ]
+                )
+
+        self.assertEqual(raised.exception.code, 2)
+
+
+def _write_price_cache(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    rows = [
+        _price_row(date(2026, 5, 20), 100.0),
+        _price_row(date(2026, 5, 21), 103.0),
+        _price_row(date(2026, 5, 22), 104.0),
+        _price_row(date(2026, 5, 26), 106.0),
+        _price_row(date(2026, 5, 27), 108.0),
+        _price_row(date(2026, 5, 28), 110.0),
+    ]
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=HISTORICAL_PRICE_CACHE_COLUMNS)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _price_row(price_date: date, close: float) -> dict[str, str]:
+    return {
+        "schema_version": "historical_price_cache.v1",
+        "source": "fixture",
+        "symbol": "SPY",
+        "date": price_date.isoformat(),
+        "open": str(close - 1.0),
+        "high": str(close + 1.0),
+        "low": str(close - 2.0),
+        "close": str(close),
+        "adjusted_close": str(close),
+        "volume": "1000",
+    }
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds the M54 calibration-dry-run CLI entrypoint.

The command runs the existing offline replay/calibration pipeline through authoritative dataset construction, residual attribution, calibration review tables, adjustment candidate construction, dry-run simulation, comparison summaries, and artifact writing. It includes run-id and observation-count options, JSON command output, help/argument validation coverage, and tests.

Refs #494