### PR TITLE
Add reviewed calibration adjustment JSON loader

### DIFF
--- a/market_health/calibration/reviewed_adjustment_io.py
+++ b/market_health/calibration/reviewed_adjustment_io.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from market_health.calibration.check_output import (
+    REVIEWED_CHECK_SCORE_CALIBRATION_ADJUSTMENT_SCHEMA_VERSION,
+    ReviewedCheckScoreCalibrationAdjustment,
+)
+from market_health.calibration.defaults import assert_not_live_runtime_path
+
+
+def reviewed_check_score_adjustments_to_records(
+    adjustments: tuple[ReviewedCheckScoreCalibrationAdjustment, ...],
+) -> list[dict[str, object]]:
+    return [adjustment.to_record() for adjustment in adjustments]
+
+
+def reviewed_check_score_adjustments_payload(
+    adjustments: tuple[ReviewedCheckScoreCalibrationAdjustment, ...],
+) -> dict[str, object]:
+    return {
+        "schema_version": REVIEWED_CHECK_SCORE_CALIBRATION_ADJUSTMENT_SCHEMA_VERSION,
+        "row_count": len(adjustments),
+        "rows": reviewed_check_score_adjustments_to_records(adjustments),
+    }
+
+
+def write_reviewed_check_score_adjustments_json(
+    path: Path,
+    adjustments: tuple[ReviewedCheckScoreCalibrationAdjustment, ...],
+) -> Path:
+    assert_not_live_runtime_path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            reviewed_check_score_adjustments_payload(adjustments),
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def read_reviewed_check_score_adjustments_json(
+    path: Path,
+) -> tuple[ReviewedCheckScoreCalibrationAdjustment, ...]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("reviewed check score adjustment payload must be an object")
+
+    schema_version = payload.get("schema_version")
+    if schema_version != REVIEWED_CHECK_SCORE_CALIBRATION_ADJUSTMENT_SCHEMA_VERSION:
+        raise ValueError(
+            "unsupported reviewed check score adjustment payload schema version: "
+            f"{schema_version}"
+        )
+
+    rows = payload.get("rows")
+    if not isinstance(rows, list):
+        raise ValueError("reviewed check score adjustment payload rows must be a list")
+
+    row_count = payload.get("row_count")
+    if row_count != len(rows):
+        raise ValueError(
+            "reviewed check score adjustment payload row_count does not match rows"
+        )
+
+    adjustments = tuple(_adjustment_from_record(row) for row in rows)
+    _validate_unique_scopes(adjustments)
+    return adjustments
+
+
+def _adjustment_from_record(
+    record: Any,
+) -> ReviewedCheckScoreCalibrationAdjustment:
+    if not isinstance(record, dict):
+        raise ValueError("reviewed check score adjustment row must be an object")
+
+    return ReviewedCheckScoreCalibrationAdjustment(
+        schema_version=str(record.get("schema_version", "")),
+        horizon=str(record.get("horizon", "")),
+        category=str(record.get("category", "")),
+        slot=_int_field(record, "slot"),
+        score_delta=_float_field(record, "score_delta"),
+        calibration_review_run_id=str(record.get("calibration_review_run_id", "")),
+        dry_run_simulation_run_id=str(record.get("dry_run_simulation_run_id", "")),
+        approved_by=str(record.get("approved_by", "")),
+        rationale=str(record.get("rationale", "")),
+    )
+
+
+def _int_field(record: dict[str, Any], field_name: str) -> int:
+    try:
+        value = int(record[field_name])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError(
+            f"reviewed check score adjustment {field_name} must be an integer"
+        ) from exc
+    return value
+
+
+def _float_field(record: dict[str, Any], field_name: str) -> float:
+    try:
+        value = float(record[field_name])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError(
+            f"reviewed check score adjustment {field_name} must be numeric"
+        ) from exc
+    return value
+
+
+def _validate_unique_scopes(
+    adjustments: tuple[ReviewedCheckScoreCalibrationAdjustment, ...],
+) -> None:
+    scopes = {
+        (adjustment.horizon, adjustment.category, adjustment.slot)
+        for adjustment in adjustments
+    }
+    if len(scopes) != len(adjustments):
+        raise ValueError(
+            "reviewed check score adjustment payload contains duplicate "
+            "horizon/category/slot scopes"
+        )

--- a/tests/test_calibration_reviewed_adjustment_io.py
+++ b/tests/test_calibration_reviewed_adjustment_io.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from market_health.calibration.check_output import (
+    REVIEWED_CHECK_SCORE_CALIBRATION_ADJUSTMENT_SCHEMA_VERSION,
+    ReviewedCheckScoreCalibrationAdjustment,
+)
+from market_health.calibration.reviewed_adjustment_io import (
+    read_reviewed_check_score_adjustments_json,
+    reviewed_check_score_adjustments_payload,
+    reviewed_check_score_adjustments_to_records,
+    write_reviewed_check_score_adjustments_json,
+)
+
+
+class ReviewedAdjustmentIoTest(unittest.TestCase):
+    def test_records_and_payload_have_stable_shape(self) -> None:
+        adjustments = (reviewed_adjustment(),)
+
+        records = reviewed_check_score_adjustments_to_records(adjustments)
+        payload = reviewed_check_score_adjustments_payload(adjustments)
+
+        self.assertEqual(records[0]["category_slot"], "B3")
+        self.assertEqual(
+            payload["schema_version"],
+            REVIEWED_CHECK_SCORE_CALIBRATION_ADJUSTMENT_SCHEMA_VERSION,
+        )
+        self.assertEqual(payload["row_count"], 1)
+        self.assertEqual(payload["rows"], records)
+
+    def test_write_and_read_round_trip(self) -> None:
+        adjustments = (
+            reviewed_adjustment(),
+            reviewed_adjustment(horizon="H1", category="C", slot=5, score_delta=0.15),
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "reviewed_check_score_adjustments.json"
+            written_path = write_reviewed_check_score_adjustments_json(
+                path,
+                adjustments,
+            )
+            loaded = read_reviewed_check_score_adjustments_json(written_path)
+
+        self.assertEqual(loaded, adjustments)
+        self.assertEqual(loaded[0].category_slot, "B3")
+        self.assertEqual(loaded[1].category_slot, "C5")
+
+    def test_reader_rejects_bad_schema(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "bad.json"
+            path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "wrong",
+                        "row_count": 0,
+                        "rows": [],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ValueError, "schema version"):
+                read_reviewed_check_score_adjustments_json(path)
+
+    def test_reader_rejects_row_count_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "bad.json"
+            path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": REVIEWED_CHECK_SCORE_CALIBRATION_ADJUSTMENT_SCHEMA_VERSION,
+                        "row_count": 2,
+                        "rows": [reviewed_adjustment().to_record()],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ValueError, "row_count"):
+                read_reviewed_check_score_adjustments_json(path)
+
+    def test_reader_rejects_duplicate_scopes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "duplicate.json"
+            path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": REVIEWED_CHECK_SCORE_CALIBRATION_ADJUSTMENT_SCHEMA_VERSION,
+                        "row_count": 2,
+                        "rows": [
+                            reviewed_adjustment().to_record(),
+                            reviewed_adjustment(score_delta=-0.1).to_record(),
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ValueError, "duplicate"):
+                read_reviewed_check_score_adjustments_json(path)
+
+
+def reviewed_adjustment(
+    *,
+    horizon: str = "H5",
+    category: str = "B",
+    slot: int = 3,
+    score_delta: float = -0.25,
+) -> ReviewedCheckScoreCalibrationAdjustment:
+    return ReviewedCheckScoreCalibrationAdjustment(
+        horizon=horizon,
+        category=category,
+        slot=slot,
+        score_delta=score_delta,
+        calibration_review_run_id="review-test",
+        dry_run_simulation_run_id="dry-run-test",
+        approved_by="m55-review",
+        rationale="Dry-run evidence supported a reviewed adjustment.",
+    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds JSON read/write support for reviewed check-score calibration adjustments.

This provides a stable payload shape for reviewed_check_score_adjustments.json, validates schema version, row counts, numeric fields, required review metadata, and duplicate horizon/category/slot scopes.

This is the next M55 step toward carrying a reviewed calibration decision from dry-run evidence into a controlled replay path. It does not enable automatic self-tuning.