### PR TITLE
Apply reviewed calibration adjustments in dry-run CLI

### DIFF
--- a/market_health/calibration/cli.py
+++ b/market_health/calibration/cli.py
@@ -57,6 +57,9 @@ from market_health.calibration.residuals import (
     build_residual_attribution_rows,
     summarize_residual_attribution_rows,
 )
+from market_health.calibration.reviewed_adjustment_io import (
+    read_reviewed_check_score_adjustments_json,
+)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -204,6 +207,15 @@ def build_parser() -> argparse.ArgumentParser:
         default=list(DEFAULT_CALIBRATION_REVIEW_WINDOW_DAY_COUNTS),
     )
     calibration_dry_run.add_argument("--no-full-window", action="store_true")
+    calibration_dry_run.add_argument(
+        "--reviewed-check-score-adjustments",
+        type=Path,
+        default=None,
+        help=(
+            "Optional reviewed_check_score_adjustments.json file to apply "
+            "during explicit calibration dry-run replay."
+        ),
+    )
 
     return parser
 
@@ -456,6 +468,18 @@ def _run_calibration_dry_run_command(args: argparse.Namespace) -> dict[str, obje
     assert_not_live_runtime_path(output_root)
 
     price_cache_path = args.price_cache.expanduser()
+    reviewed_check_score_adjustments_path = (
+        args.reviewed_check_score_adjustments.expanduser()
+        if args.reviewed_check_score_adjustments is not None
+        else None
+    )
+    reviewed_check_score_adjustments = (
+        read_reviewed_check_score_adjustments_json(
+            reviewed_check_score_adjustments_path
+        )
+        if reviewed_check_score_adjustments_path is not None
+        else ()
+    )
     price_cache = read_historical_price_cache_csv(
         price_cache_path,
         symbols=args.symbols,
@@ -471,7 +495,10 @@ def _run_calibration_dry_run_command(args: argparse.Namespace) -> dict[str, obje
         request=range_request,
         price_rows=price_cache.rows,
     )
-    check_rows = _build_authoritative_dataset_check_rows(range_result)
+    check_rows = _build_authoritative_dataset_check_rows(
+        range_result,
+        reviewed_check_score_adjustments=reviewed_check_score_adjustments,
+    )
     dataset_rows = build_authoritative_replay_dataset_rows(
         range_result=range_result,
         check_rows=check_rows,
@@ -514,6 +541,7 @@ def _run_calibration_dry_run_command(args: argparse.Namespace) -> dict[str, obje
         candidates=candidates,
         simulation_rows=simulation_rows,
         comparison_rows=comparison_rows,
+        reviewed_check_score_adjustments=reviewed_check_score_adjustments,
         dry_run_simulation_run_id=args.dry_run_simulation_run_id,
     )
 
@@ -530,12 +558,22 @@ def _run_calibration_dry_run_command(args: argparse.Namespace) -> dict[str, obje
         "candidate_count": artifacts.candidate_count,
         "simulation_row_count": artifacts.simulation_row_count,
         "comparison_row_count": artifacts.comparison_row_count,
+        "reviewed_check_score_adjustment_count": (
+            artifacts.reviewed_check_score_adjustment_count
+        ),
+        "reviewed_check_score_adjustments_path": (
+            str(reviewed_check_score_adjustments_path)
+            if reviewed_check_score_adjustments_path is not None
+            else None
+        ),
         "artifacts": artifacts.to_record(),
     }
 
 
 def _build_authoritative_dataset_check_rows(
     range_result: RangeReplayResult,
+    *,
+    reviewed_check_score_adjustments: tuple = (),
 ) -> tuple[CheckReplayRow, ...]:
     rows: list[CheckReplayRow] = []
     for result in range_result.results:
@@ -549,6 +587,7 @@ def _build_authoritative_dataset_check_rows(
             build_fixture_check_replay_rows(
                 replay_date=result.replay_date,
                 symbols=symbols,
+                reviewed_calibration_adjustments=reviewed_check_score_adjustments,
             )
         )
 

--- a/tests/test_calibration_dry_run_cli.py
+++ b/tests/test_calibration_dry_run_cli.py
@@ -15,7 +15,13 @@ from market_health.calibration.calibration_adjustment_export import (
     CALIBRATION_DRY_RUN_COMPARISON_ROWS_TABLE,
     CALIBRATION_DRY_RUN_SIMULATION_ROWS_TABLE,
 )
+from market_health.calibration.check_output import (
+    ReviewedCheckScoreCalibrationAdjustment,
+)
 from market_health.calibration.cli import build_parser, main
+from market_health.calibration.reviewed_adjustment_io import (
+    write_reviewed_check_score_adjustments_json,
+)
 from market_health.calibration.price_cache import HISTORICAL_PRICE_CACHE_COLUMNS
 
 
@@ -32,7 +38,14 @@ class CalibrationDryRunCliTest(unittest.TestCase):
             tmp_path = Path(tmp)
             price_cache_path = tmp_path / "prices.csv"
             output_root = tmp_path / "calibration"
+            reviewed_adjustments_path = (
+                tmp_path / "reviewed_check_score_adjustments.json"
+            )
             _write_price_cache(price_cache_path)
+            write_reviewed_check_score_adjustments_json(
+                reviewed_adjustments_path,
+                (_reviewed_adjustment(),),
+            )
 
             stdout = io.StringIO()
             with redirect_stdout(stdout):
@@ -67,6 +80,8 @@ class CalibrationDryRunCliTest(unittest.TestCase):
                         "1",
                         "--window-days",
                         "1",
+                        "--reviewed-check-score-adjustments",
+                        str(reviewed_adjustments_path),
                     ]
                 )
 
@@ -78,6 +93,9 @@ class CalibrationDryRunCliTest(unittest.TestCase):
             sqlite_path = Path(artifacts["sqlite_path"])
             validation_summary_path = Path(artifacts["validation_summary_path"])
             manifest_path = Path(artifacts["manifest_path"])
+            reviewed_adjustments_output_path = Path(
+                artifacts["reviewed_check_score_adjustments_path"]
+            )
 
             with candidates_csv_path.open(newline="", encoding="utf-8") as handle:
                 candidate_rows = list(csv.DictReader(handle))
@@ -101,6 +119,9 @@ class CalibrationDryRunCliTest(unittest.TestCase):
                 validation_summary_path.read_text(encoding="utf-8")
             )
             manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            reviewed_adjustments_output = json.loads(
+                reviewed_adjustments_output_path.read_text(encoding="utf-8")
+            )
 
         self.assertEqual(exit_code, 0)
         self.assertEqual(payload["status"], "ok")
@@ -114,6 +135,11 @@ class CalibrationDryRunCliTest(unittest.TestCase):
         self.assertGreater(payload["candidate_count"], 0)
         self.assertGreater(payload["simulation_row_count"], 0)
         self.assertGreater(payload["comparison_row_count"], 0)
+        self.assertEqual(payload["reviewed_check_score_adjustment_count"], 1)
+        self.assertEqual(
+            Path(payload["reviewed_check_score_adjustments_path"]),
+            reviewed_adjustments_path,
+        )
 
         self.assertEqual(len(candidate_rows), payload["candidate_count"])
         self.assertEqual(len(simulation_rows), payload["simulation_row_count"])
@@ -131,6 +157,12 @@ class CalibrationDryRunCliTest(unittest.TestCase):
         self.assertEqual(manifest["candidate_count"], payload["candidate_count"])
         self.assertEqual(
             manifest["simulation_row_count"], payload["simulation_row_count"]
+        )
+        self.assertEqual(manifest["reviewed_check_score_adjustment_count"], 1)
+        self.assertEqual(reviewed_adjustments_output["row_count"], 1)
+        self.assertEqual(
+            reviewed_adjustments_output["rows"][0]["category_slot"],
+            "B3",
         )
 
     def test_calibration_dry_run_rejects_bad_date(self) -> None:
@@ -154,6 +186,19 @@ class CalibrationDryRunCliTest(unittest.TestCase):
                 )
 
         self.assertEqual(raised.exception.code, 2)
+
+
+def _reviewed_adjustment() -> ReviewedCheckScoreCalibrationAdjustment:
+    return ReviewedCheckScoreCalibrationAdjustment(
+        horizon="H5",
+        category="B",
+        slot=3,
+        score_delta=-0.25,
+        calibration_review_run_id="review-test",
+        dry_run_simulation_run_id="dry-run-test",
+        approved_by="m55-review",
+        rationale="Dry-run evidence supported a reviewed B3 H5 adjustment.",
+    )
 
 
 def _write_price_cache(path: Path) -> None:


### PR DESCRIPTION
Adds an explicit calibration-dry-run CLI option for reviewed check-score adjustment JSON.

The command can now read reviewed_check_score_adjustments.json, apply those reviewed horizon/category/slot adjustments while building dry-run check rows, include the reviewed adjustment records in dry-run artifacts, and report the reviewed adjustment count and source path in command output.

This keeps M55 reviewed calibration manual and explicit.