### PR TITLE
Refresh README for current CLI and JSON workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,250 +1,12 @@
 # Market Health CLI
 
-A terminal-first, color‑coded dashboard that summarizes sector “market health” at a glance.  
-Built with [Rich](https://github.com/Textualize/rich) and designed to look great on a Raspberry Pi.
+Terminal-first sector health dashboard and score exporter.
 
-> Educational tool only — not investment advice.
-
----
-
-## Highlights
-
-- **Pi Grid**: ultra-compact, single‑grid view for small displays (e.g., Raspberry Pi).
-- **Color coding**: intuitive heat-style backgrounds from **weak → strong**.
-- **Live or offline**: fetches data via `yfinance`, or render from a local JSON file.
-- **Zero-friction demo**: generate realistic demo data with `--demo`.
-
----
-
-## Quickstart (run locally)
-
-```bash
-# Create and activate a virtual environment (Windows PowerShell shown)
-python -m venv .venv
-.venv\Scripts\Activate.ps1
-
-# Install dependencies
-pip install -r requirements.txt
-
-# Run the compact Pi grid with demo data (auto-fit columns)
-python market_ui.py --demo --pi-grid --grid-cols 0
-```
-
-### Live data (no demo)
-```bash
-python market_ui.py --pi-grid --grid-cols 0
-```
-> Requires internet access; data is pulled via `yfinance`.
-
----
-
-## Raspberry Pi notes
-
-On Raspberry Pi, using the community **piwheels** index speeds up installation for heavy packages like NumPy/Pandas:
-
-```bash
-# Optional: use piwheels for much faster installs on Raspberry Pi
-export PIP_EXTRA_INDEX_URL=https://www.piwheels.org/simple
-
-python3 -m venv .venv
-source .venv/bin/activate
-pip install --upgrade pip wheel
-pip install -r requirements.txt
-
-# Compact grid tuned for small screens
-python market_ui.py --pi-grid --grid-cols 0 --watch 30
-```
-
-You can fine‑tune the grid density by changing `--grid-cols` (e.g., `--grid-cols 4`).  
-Use `--mono` for a monochrome look (no colors).
-
----
-
-## CLI usage
-
-`market_ui.py` controls what you see in the terminal. The most useful flags:
-
-| Flag | Type / Default | What it does |
-| --- | --- | --- |
-| `--pi-grid` | `bool` | Show the compact single‑grid (best for Pi screens). |
-| `--grid-cols` | `int` (default **4**; use **0** to auto‑fit) | Number of columns in the grid. |
-| `--demo` | `bool` | Use generated demo data. |
-| `--json` | `str` | Load data from a JSON file instead of live fetch. |
-| `--sectors` | `list[str]` | Override default sector tickers (e.g., `--sectors XLK XLF XLV`). |
-| `--topk` | `int` (default **3**) | In the standard (non‑grid) view, show details for the top‑K sectors. |
-| `--mono` | `bool` | Monochrome output (no color). |
-| `--watch` | `int` | Auto‑refresh every _N_ seconds. |
-| `--period` | `str` (default **1y**) | `yfinance` lookback period (e.g., `6mo`, `1y`). |
-| `--interval` | `str` (default **1d**) | `yfinance` interval (e.g., `1d`, `1h`). |
-| `--ttl` | `int` (default **300**) | In‑process cache TTL (seconds) for live fetch. |
-
-Examples:
-
-```bash
-# Minimal Pi grid with auto-fit columns
-python market_ui.py --pi-grid --grid-cols 0
-
-# Demo grid with a fixed 4‑column layout
-python market_ui.py --demo --pi-grid --grid-cols 4
-
-# Standard view with details (no grid)
-python market_ui.py --sectors XLK XLF XLY XLV
-```
-
----
-
-## Dimensions (A–E)
-
-The UI uses five mnemonic **Dimensions (A–E)**. The letter codes are stable identifiers; the human-facing names come from the ui.v1 contract (`dimensions_meta`).
-
-| Code | Dimension | Meaning |
-|---|---|---|
-| A | Announcements | catalysts/events/news/earnings/macro |
-| B | Backdrop | context/regime (currently reflected across trend/structure + environment/regime) |
-| C | Crowding | flow/positioning/participation (“who’s in this”) |
-| D | Danger | risk/volatility/correlation stress |
-| E | Execution | frictions, liquidity, sizing constraints (migration in progress) |
-
-Migration note:
-- The scoring engine currently computes **A–F check groups** (6 × 6 = 36 checks).
-- During the transition, **Backdrop** is effectively represented by today’s **B** (Trend & Structure) and **E** (Environment & Regime).
-- **Execution** is currently **F** (Execution & Frictions) and is planned to migrate into **E**.
-
-## Scoring framework (current A–F check groups)
-
-
-Your framework is organized into **6 categories (A–F)**. Each category contains **6 checks/variables** for a total of **36 distinct factors**. These roll up into each sector’s score and color.
-
-### A — Announcements
-**Focus:** external events, sentiment, and “catalysts.”  
-**Variables:**
-- **News** — recent headlines, sentiment, or price/volume proxy spikes
-- **Analysts** — upgrades/downgrades, price targets, recommendations
-- **Event** — scheduled catalysts (earnings, product launches, regulatory)
-- **Insiders** — insider buying/selling activity
-- **Peers/Macro** — sector‑wide or macro catalysts impacting the symbol
-- **Guidance** — outlook revisions and earnings guidance
-
-### B — Backdrop (Trend & Structure)
-**Focus:** technical price/volume structure.  
-**Variables:**
-- **Stacked MAs** — alignment 9EMA > 20EMA > 50SMA
-- **RS vs SPY** — 5‑day relative strength versus SPY
-- **BB Mid** — reclaim of the 20‑day SMA (Bollinger mid)
-- **20D Break** — breakout above the 20‑day high
-- **Vol ×** — volume expansion vs. 20‑day average
-- **Hold 20EMA** — pullbacks respecting the 20EMA
-
-### C — Crowding (Position & Flow)
-**Focus:** positioning, flows, participation.  
-**Variables:**
-- **EM Fit** — fit to an exponential moving structure
-- **OI/Flow** — options open interest & flow activity
-- **Blocks/DP** — large prints / dark‑pool activity
-- **Leaders% > 20D** — % of leaders above 20‑day MA
-- **Money Flow** — net inflows/outflows
-- **SI/Days** — short interest vs. average daily volume
-
-### D — Danger (Risk & Volatility)
-**Focus:** volatility, correlation, risk control.  
-**Variables:**
-- **ATR%** — Average True Range as % of price
-- **IV%** — implied volatility proxy (e.g., BB width)
-- **Correlation** — 20‑day correlation vs. SPY
-- **Event Risk** — earnings/event risk placeholder
-- **Gap Plan** — gap‑risk strategy placeholder
-- **Sizing/RR** — position sizing & risk/reward vs ATR/EMA
-
-### E — Environment & Regime (Backdrop)
-**Focus:** broader market/sector regime.  
-**Variables:**
-- **SPY Trend** — SPY alignment with 20/50‑day averages
-- **Sector Rank** — relative rank of sector ETF (e.g., 5‑bar return)
-- **Breadth** — sector breadth / internal trend health
-- **VIX Regime** — VIX vs. its 20‑day SMA (calm vs stressed)
-- **3‑Day RS** — short‑term RS vs. SPY
-- **Drivers** — macro drivers alignment (placeholder)
-
-### F — Execution & Frictions (future: E Execution)
-**Focus:** trade management and execution discipline.  
-**Variables:**
-- **Trigger** — defined trade trigger present
-- **Invalidation** — clear stop/invalid level
-- **Targets** — realistic upside targets
-- **Time Stop** — time‑based exit rule
-- **Slippage** — liquidity / bid‑ask cost
-- **Alerts** — monitoring/alerting in place
-
-> **Summary:** 36 checks total (6 × 6). A = Announcements; B/E form Backdrop context; C = Crowding; D = Danger; F = Execution (planned to move into E).
-
----
-
-## Rendering from JSON
-
-You can render without fetching live data by pointing to a JSON file:
-
-```bash
-python market_ui.py --json scores.json --pi-grid --grid-cols 0
-```
-
-**JSON format** (per sector), roughly:
-
-```json
-[
-  {
-    "symbol": "XLK",
-    "A": [{"label": "News", "score": 2}, {"label": "Analysts", "score": 1}],
-    "B": [{"label": "...", "score": 0}],
-    "C": [{"label": "...", "score": 2}],
-    "D": [{"label": "...", "score": 1}],
-    "E": [{"label": "...", "score": 1}],
-    "F": [{"label": "...", "score": 0}]
-  }
-]
-```
-
-To generate `scores.json` yourself using the compute engine:
-
-```bash
-# Module form
-python -m market_health.mh_cli --out scores.json
-
-# Or script form
-python market_health/mh_cli.py --out scores.json
-```
-
-Then render it:
-```bash
-python market_ui.py --json scores.json --pi-grid --grid-cols 0
-```
-
----
-
-## Project layout (key files)
-
-```
-market_health/           # scoring engine and CLI
-  engine.py              # computes category checks from price data
-  mh_cli.py              # writes scores.json (yfinance)
-market_ui.py             # terminal UI (Rich) – includes Pi Grid mode
-requirements.txt
-```
-
----
-
-## Troubleshooting
-
-- **No colors in terminal**: try a different terminal or omit `--mono`. Windows Terminal and PowerShell work well.
-- **Slow installs on Pi**: use `PIP_EXTRA_INDEX_URL=https://www.piwheels.org/simple`.
-- **Network hiccups**: use `--json` to render previously saved `scores.json` offline.
-
----
-
-## License
-
-MIT © Christopher Dudley
+Educational tool only - not investment advice.
 
 ## Install
+
+From the repository root:
 
 ```bash
 python -m venv .venv
@@ -253,35 +15,145 @@ python -m pip install -U pip
 python -m pip install -e ".[dev]"
 ```
 
+`.[dev]` installs the runtime dependencies plus the local test and lint tools. If you only want the runtime app, use `python -m pip install -e .` instead.
 
-## Quick start
+## Quickstart
 
-Run the UI (Pi Grid):
-
-```bash
-python -m market_health.market_ui --pi-grid
-```
-
-Export the UI contract (writes to `~/.cache/jerboa/market_health.ui.v1.json`):
+Run the live UI in compact Pi mode:
 
 ```bash
-bash scripts/jerboa/bin/jerboa-market-health-ui-export
+market-health --pi-grid --grid-cols 0
 ```
 
+The same UI can also be launched with:
+
+```bash
+market-health-pi --pi-grid --grid-cols 0
+python market_ui.py --pi-grid --grid-cols 0
+python -m market_health.market_ui --pi-grid --grid-cols 0
+```
+
+If you want generated sample data instead of live scoring, add `--demo`.
+
+## Supported Commands
+
+Packaging exposes these console scripts:
+
+- `market-health`
+- `market-health-pi`
+
+Both scripts point to the terminal UI entry point in `market_ui.py`.
+
+Supported direct Python entry points:
+
+- `python market_ui.py`
+- `python -m market_health.market_ui`
+- `python -m market_health`
+- `python -m market_health.mh_cli`
+
+`python -m market_health` delegates to `market_health.mh_cli` through `market_health/__main__.py`.
+
+## Live UI vs Offline JSON
+
+The UI has two distinct data paths:
+
+- Live mode: when neither `--demo` nor `--json` is used, the UI calls `compute_scores(...)` in the engine and renders those live scores directly.
+- Demo mode: `--demo` replaces live data with generated sample rows.
+- Offline mode: `--json` bypasses live scoring and renders prebuilt JSON artifacts.
+
+That separation matters:
+
+- The score export written by `market-health`, `python -m market_health`, or `python -m market_health.mh_cli` is an exported artifact, not a live input source for the UI.
+- `--json` is for offline rendering from already-produced JSON.
+
+The JSON renderer accepts:
+
+- score JSON with sector rows and `categories/checks`
+- environment JSON such as `~/.cache/jerboa/environment.v1.json`, which contains a top-level `sectors` array
+- UI contract JSON such as `~/.cache/jerboa/market_health.ui.v1.json`, which carries `data.sectors`
+
+Examples:
+
+```bash
+# Write score JSON from the engine
+python -m market_health.mh_cli --out scores.json
+
+# Render that JSON offline
+market-health --json scores.json --pi-grid --grid-cols 0
+
+# Render the UI contract export offline
+market-health --json ~/.cache/jerboa/market_health.ui.v1.json --pi-grid --grid-cols 0
+```
+
+## Raspberry Pi And Wrapper Scripts
+
+The repo includes Pi-friendly cache and wrapper scripts under `scripts/jerboa/`.
+
+Install the repo-managed wrappers and user units:
+
+```bash
+bash scripts/jerboa/install_market_health.sh
+```
+
+That installs symlinks in `~/bin` for:
+
+- `jerboa-market-health-refresh`
+- `jerboa-market-health-positions-refresh`
+- `jerboa-market-health-refresh-all`
+- `jerboa-market-health-ui-export`
+- `jerboa-market-health-status`
+- `jerboa-market-health-alert`
+
+Typical Pi workflow:
+
+```bash
+# Refresh the cache bundle
+jerboa-market-health-refresh-all --force
+
+# Write the UI contract cache artifact
+jerboa-market-health-ui-export
+
+# Render the cached UI contract offline in the terminal
+market-health --json ~/.cache/jerboa/market_health.ui.v1.json --pi-grid --grid-cols 0
+```
+
+For slower hardware, `--grid-cols 0` auto-fits the compact grid to the terminal width. `--mono` switches to monochrome output.
+
+## Project Layout
+
+```text
+market_health/
+  engine.py           score computation and data shaping
+  market_ui.py        Rich-based terminal UI and JSON renderer
+  mh_cli.py           score export CLI
+  __main__.py         package entry point -> mh_cli
+market_ui.py          top-level launcher for the UI
+scripts/
+  jerboa/             repo-managed wrappers, install script, systemd units
+  cache/              local cache refresh helpers
+docs/
+  SCORING.md          scoring model and dimensions
+  UI_CONTRACT.md      UI contract shape and stability notes
+  TESTING.md          fixture and regeneration workflow
+```
 
 ## Architecture
 
-- Refresh/export pipeline writes cache artifacts under `~/.cache/jerboa/...`
-- The UI reads one contract: `market_health.ui.v1.json`
-- Recommendations are embedded from `recommendations.v1.json`
+The current app has a clear split between computation and presentation:
 
-Key entry points:
-- `scripts/jerboa/bin/jerboa-market-health-ui-export`
-- `scripts/export_recommendations_v1.py`
-- `market_health/market_ui.py`
+- `market_health.engine.compute_scores(...)` produces the live sector scores.
+- `market_health.market_ui` renders those scores in Rich tables or the Pi grid.
+- `market_health.mh_cli` exports score JSON and optional CSV from the engine.
+- `market_ui.py` is a compatibility launcher for the UI, while `market_health/__main__.py` launches the score-export CLI.
 
-## Docs
+When the UI runs in live mode, it computes scores directly from the engine. When it runs with `--json`, it becomes an offline renderer for score JSON, environment JSON, or the UI contract artifact.
 
-- `docs/SCORING.md` — scoring semantics + A/C/D feature flags
-- `docs/UI_CONTRACT.md` — UI contract fields + example
-- `docs/TESTING.md` — local gates + fixture regeneration
+## Documentation
+
+- [Scoring model](docs/SCORING.md)
+- [UI contract](docs/UI_CONTRACT.md)
+- [Testing and fixtures](docs/TESTING.md)
+- [UI contract example](docs/examples/market_health.ui.v1.example.json)
+- [Pi wrapper installer](scripts/jerboa/install_market_health.sh)
+- [UI contract exporter](scripts/jerboa/bin/jerboa-market-health-ui-export)
+- [Cache refresh helper](scripts/cache/refresh_market_health_cache.sh)


### PR DESCRIPTION
## Summary

The README had duplicated install and quickstart guidance plus stale workflow notes; it now reflects the current packaging, supported CLI and module entry points, live-vs-offline JSON behavior, Raspberry Pi wrappers, project layout, and docs links while preserving the educational disclaimer.

## Changes

- Replaced duplicated README sections with one coherent install and quickstart path using editable install instructions.
- Documented the packaged console scripts `market-health` and `market-health-pi` plus the supported Python entry points for the UI and score-export CLI.
- Clarified that live UI mode computes scores through the engine, while `--json` renders offline score, environment, or UI-contract JSON artifacts.
- Added Raspberry Pi wrapper usage, project layout, architecture notes, and current documentation links.

## Verification

- **PASS — changed-file inventory:** `git status --short` shows only `README.md` modified.
- **PASS — markdown diff hygiene:** `git diff --check README.md` returned clean after removing the trailing blank line.
- **SKIPPED — CLI help attempts:** Documented help paths could not run because this environment is missing runtime dependencies (`rich` for the UI and `numpy` for the score exporter).