### PR TITLE
Clarify Market Health CLI launch and export paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,248 +1,15 @@
 # Market Health CLI
 
-A terminal-first, color‑coded dashboard that summarizes sector “market health” at a glance.  
-Built with [Rich](https://github.com/Textualize/rich) and designed to look great on a Raspberry Pi.
+A terminal-first, color-coded dashboard that summarizes sector market health at a glance. Built with [Rich](https://github.com/Textualize/rich) and designed to work well on small screens, including Raspberry Pi displays.
 
-> Educational tool only — not investment advice.
-
----
+> Educational tool only - not investment advice.
 
 ## Highlights
 
-- **Pi Grid**: ultra-compact, single‑grid view for small displays (e.g., Raspberry Pi).
-- **Color coding**: intuitive heat-style backgrounds from **weak → strong**.
-- **Live or offline**: fetches data via `yfinance`, or render from a local JSON file.
-- **Zero-friction demo**: generate realistic demo data with `--demo`.
-
----
-
-## Quickstart (run locally)
-
-```bash
-# Create and activate a virtual environment (Windows PowerShell shown)
-python -m venv .venv
-.venv\Scripts\Activate.ps1
-
-# Install dependencies
-pip install -r requirements.txt
-
-# Run the compact Pi grid with demo data (auto-fit columns)
-python market_ui.py --demo --pi-grid --grid-cols 0
-```
-
-### Live data (no demo)
-```bash
-python market_ui.py --pi-grid --grid-cols 0
-```
-> Requires internet access; data is pulled via `yfinance`.
-
----
-
-## Raspberry Pi notes
-
-On Raspberry Pi, using the community **piwheels** index speeds up installation for heavy packages like NumPy/Pandas:
-
-```bash
-# Optional: use piwheels for much faster installs on Raspberry Pi
-export PIP_EXTRA_INDEX_URL=https://www.piwheels.org/simple
-
-python3 -m venv .venv
-source .venv/bin/activate
-pip install --upgrade pip wheel
-pip install -r requirements.txt
-
-# Compact grid tuned for small screens
-python market_ui.py --pi-grid --grid-cols 0 --watch 30
-```
-
-You can fine‑tune the grid density by changing `--grid-cols` (e.g., `--grid-cols 4`).  
-Use `--mono` for a monochrome look (no colors).
-
----
-
-## CLI usage
-
-`market_ui.py` controls what you see in the terminal. The most useful flags:
-
-| Flag | Type / Default | What it does |
-| --- | --- | --- |
-| `--pi-grid` | `bool` | Show the compact single‑grid (best for Pi screens). |
-| `--grid-cols` | `int` (default **4**; use **0** to auto‑fit) | Number of columns in the grid. |
-| `--demo` | `bool` | Use generated demo data. |
-| `--json` | `str` | Load data from a JSON file instead of live fetch. |
-| `--sectors` | `list[str]` | Override default sector tickers (e.g., `--sectors XLK XLF XLV`). |
-| `--topk` | `int` (default **3**) | In the standard (non‑grid) view, show details for the top‑K sectors. |
-| `--mono` | `bool` | Monochrome output (no color). |
-| `--watch` | `int` | Auto‑refresh every _N_ seconds. |
-| `--period` | `str` (default **1y**) | `yfinance` lookback period (e.g., `6mo`, `1y`). |
-| `--interval` | `str` (default **1d**) | `yfinance` interval (e.g., `1d`, `1h`). |
-| `--ttl` | `int` (default **300**) | In‑process cache TTL (seconds) for live fetch. |
-
-Examples:
-
-```bash
-# Minimal Pi grid with auto-fit columns
-python market_ui.py --pi-grid --grid-cols 0
-
-# Demo grid with a fixed 4‑column layout
-python market_ui.py --demo --pi-grid --grid-cols 4
-
-# Standard view with details (no grid)
-python market_ui.py --sectors XLK XLF XLY XLV
-```
-
----
-
-## Dimensions (A–E)
-
-The UI uses five mnemonic **Dimensions (A–E)**. The letter codes are stable identifiers; the human-facing names come from the ui.v1 contract (`dimensions_meta`).
-
-| Code | Dimension | Meaning |
-|---|---|---|
-| A | Announcements | catalysts/events/news/earnings/macro |
-| B | Backdrop | context/regime (currently reflected across trend/structure + environment/regime) |
-| C | Crowding | flow/positioning/participation (“who’s in this”) |
-| D | Danger | risk/volatility/correlation stress |
-| E | Execution | frictions, liquidity, sizing constraints (migration in progress) |
-
-Migration note:
-- The scoring engine currently computes **A–F check groups** (6 × 6 = 36 checks).
-- During the transition, **Backdrop** is effectively represented by today’s **B** (Trend & Structure) and **E** (Environment & Regime).
-- **Execution** is currently **F** (Execution & Frictions) and is planned to migrate into **E**.
-
-## Scoring framework (current A–F check groups)
-
-
-Your framework is organized into **6 categories (A–F)**. Each category contains **6 checks/variables** for a total of **36 distinct factors**. These roll up into each sector’s score and color.
-
-### A — Announcements
-**Focus:** external events, sentiment, and “catalysts.”  
-**Variables:**
-- **News** — recent headlines, sentiment, or price/volume proxy spikes
-- **Analysts** — upgrades/downgrades, price targets, recommendations
-- **Event** — scheduled catalysts (earnings, product launches, regulatory)
-- **Insiders** — insider buying/selling activity
-- **Peers/Macro** — sector‑wide or macro catalysts impacting the symbol
-- **Guidance** — outlook revisions and earnings guidance
-
-### B — Backdrop (Trend & Structure)
-**Focus:** technical price/volume structure.  
-**Variables:**
-- **Stacked MAs** — alignment 9EMA > 20EMA > 50SMA
-- **RS vs SPY** — 5‑day relative strength versus SPY
-- **BB Mid** — reclaim of the 20‑day SMA (Bollinger mid)
-- **20D Break** — breakout above the 20‑day high
-- **Vol ×** — volume expansion vs. 20‑day average
-- **Hold 20EMA** — pullbacks respecting the 20EMA
-
-### C — Crowding (Position & Flow)
-**Focus:** positioning, flows, participation.  
-**Variables:**
-- **EM Fit** — fit to an exponential moving structure
-- **OI/Flow** — options open interest & flow activity
-- **Blocks/DP** — large prints / dark‑pool activity
-- **Leaders% > 20D** — % of leaders above 20‑day MA
-- **Money Flow** — net inflows/outflows
-- **SI/Days** — short interest vs. average daily volume
-
-### D — Danger (Risk & Volatility)
-**Focus:** volatility, correlation, risk control.  
-**Variables:**
-- **ATR%** — Average True Range as % of price
-- **IV%** — implied volatility proxy (e.g., BB width)
-- **Correlation** — 20‑day correlation vs. SPY
-- **Event Risk** — earnings/event risk placeholder
-- **Gap Plan** — gap‑risk strategy placeholder
-- **Sizing/RR** — position sizing & risk/reward vs ATR/EMA
-
-### E — Environment & Regime (Backdrop)
-**Focus:** broader market/sector regime.  
-**Variables:**
-- **SPY Trend** — SPY alignment with 20/50‑day averages
-- **Sector Rank** — relative rank of sector ETF (e.g., 5‑bar return)
-- **Breadth** — sector breadth / internal trend health
-- **VIX Regime** — VIX vs. its 20‑day SMA (calm vs stressed)
-- **3‑Day RS** — short‑term RS vs. SPY
-- **Drivers** — macro drivers alignment (placeholder)
-
-### F — Execution & Frictions (future: E Execution)
-**Focus:** trade management and execution discipline.  
-**Variables:**
-- **Trigger** — defined trade trigger present
-- **Invalidation** — clear stop/invalid level
-- **Targets** — realistic upside targets
-- **Time Stop** — time‑based exit rule
-- **Slippage** — liquidity / bid‑ask cost
-- **Alerts** — monitoring/alerting in place
-
-> **Summary:** 36 checks total (6 × 6). A = Announcements; B/E form Backdrop context; C = Crowding; D = Danger; F = Execution (planned to move into E).
-
----
-
-## Rendering from JSON
-
-You can render without fetching live data by pointing to a JSON file:
-
-```bash
-python market_ui.py --json scores.json --pi-grid --grid-cols 0
-```
-
-**JSON format** (per sector), roughly:
-
-```json
-[
-  {
-    "symbol": "XLK",
-    "A": [{"label": "News", "score": 2}, {"label": "Analysts", "score": 1}],
-    "B": [{"label": "...", "score": 0}],
-    "C": [{"label": "...", "score": 2}],
-    "D": [{"label": "...", "score": 1}],
-    "E": [{"label": "...", "score": 1}],
-    "F": [{"label": "...", "score": 0}]
-  }
-]
-```
-
-To generate `scores.json` yourself using the compute engine:
-
-```bash
-# Module form
-python -m market_health.mh_cli --out scores.json
-
-# Or script form
-python market_health/mh_cli.py --out scores.json
-```
-
-Then render it:
-```bash
-python market_ui.py --json scores.json --pi-grid --grid-cols 0
-```
-
----
-
-## Project layout (key files)
-
-```
-market_health/           # scoring engine and CLI
-  engine.py              # computes category checks from price data
-  mh_cli.py              # writes scores.json (yfinance)
-market_ui.py             # terminal UI (Rich) – includes Pi Grid mode
-requirements.txt
-```
-
----
-
-## Troubleshooting
-
-- **No colors in terminal**: try a different terminal or omit `--mono`. Windows Terminal and PowerShell work well.
-- **Slow installs on Pi**: use `PIP_EXTRA_INDEX_URL=https://www.piwheels.org/simple`.
-- **Network hiccups**: use `--json` to render previously saved `scores.json` offline.
-
----
-
-## License
-
-MIT © Christopher Dudley
+- Pi Grid mode for compact, single-grid terminal layouts.
+- Live, demo, or offline JSON rendering.
+- Separate score-export CLI paths and UI launcher paths.
+- Raspberry Pi wrapper scripts plus systemd units for refresh and local serving.
 
 ## Install
 
@@ -253,35 +20,121 @@ python -m pip install -U pip
 python -m pip install -e ".[dev]"
 ```
 
-
-## Quick start
-
-Run the UI (Pi Grid):
+On Raspberry Pi, you can optionally point pip at piwheels before installing:
 
 ```bash
-python -m market_health.market_ui --pi-grid
+export PIP_EXTRA_INDEX_URL=https://www.piwheels.org/simple
+python -m pip install -e ".[dev]"
 ```
 
-Export the UI contract (writes to `~/.cache/jerboa/market_health.ui.v1.json`):
+## Run the UI
+
+The installed console commands are UI launchers:
+
+- `market-health`
+- `market-health-pi`
+
+Both are mapped to `market_ui:main` in `pyproject.toml`, so they launch the Rich UI and do not write score exports.
 
 ```bash
-bash scripts/jerboa/bin/jerboa-market-health-ui-export
+market-health --pi-grid --grid-cols 0
+market-health-pi --pi-grid --grid-cols 0
+
+# Direct module/script launch also works
+python market_ui.py --pi-grid --grid-cols 0
 ```
 
+## UI Modes
+
+- Live UI: default mode when neither `--demo` nor `--json` is set. This fetches live scores through the engine.
+- Demo UI: `--demo` generates repeatable sample data and ignores live or JSON input.
+- Offline JSON: `--json PATH` renders sector data from a file without fetching live data.
+
+The offline path can render score exports, the UI contract at `~/.cache/jerboa/market_health.ui.v1.json`, or another JSON file that contains sector entries in the shape the UI expects. When the input is a UI contract, the UI can also show the embedded recommendation summary.
+
+Useful flags:
+
+- `--pi-grid`: compact single-grid view for small displays.
+- `--grid-cols N`: number of grid columns; use `0` to auto-fit.
+- `--watch N`: auto-refresh every `N` seconds.
+- `--mono`: monochrome output.
+
+Examples:
+
+```bash
+# Live Pi Grid
+market-health --pi-grid --grid-cols 0
+
+# Deterministic demo layout
+market-health --demo --pi-grid --grid-cols 4
+
+# Offline render from a previously exported file
+market-health --json scores.json --pi-grid --grid-cols 0
+```
+
+## Export Score JSON
+
+Score export is separate from the UI launchers. Use one of these equivalent entry points:
+
+```bash
+python -m market_health --out scores.json
+python -m market_health.mh_cli --out scores.json
+python market_health/mh_cli.py --out scores.json
+```
+
+Each command writes score JSON to the path given by `--out` and can also emit CSV with `--out-csv` if needed.
+
+## Raspberry Pi Wrappers
+
+Repository scripts under `scripts/jerboa/bin/` wire the cache refresh flow together:
+
+- `scripts/jerboa/bin/jerboa-market-health-ui-export` writes `~/.cache/jerboa/market_health.ui.v1.json`.
+- `scripts/jerboa/bin/jerboa-market-health-refresh-all` refreshes market data, positions, recommendations, forecast scores, and then runs the UI export.
+- `scripts/jerboa/bin/jerboa-market-health-refresh` refreshes the market cache.
+- `scripts/jerboa/bin/jerboa-market-health-status` reports the current refresh state.
+
+The matching systemd user units under `scripts/jerboa/systemd/user/` are:
+
+- `jerboa-market-health-refresh-all.service` to run the refresh pipeline.
+- `jerboa-market-health-refresh-all.timer` to run it every 30 minutes after boot.
+- `jerboa-market-health-ui.service` to serve `~/.cache/jerboa` on `127.0.0.1:8765`.
+- `jerboa-market-health-refresh-all-failure.service` to trigger the alert wrapper on failure.
 
 ## Architecture
 
-- Refresh/export pipeline writes cache artifacts under `~/.cache/jerboa/...`
-- The UI reads one contract: `market_health.ui.v1.json`
-- Recommendations are embedded from `recommendations.v1.json`
+- `market_health/engine.py` computes the sector checks and totals.
+- `market_health/mh_cli.py` is the score-export CLI.
+- `market_health/__main__.py` delegates `python -m market_health` to the exporter.
+- `market_health/market_ui.py` renders the Rich dashboard, including Pi Grid mode and offline `--json` rendering.
+- `market_ui.py` is the top-level UI launcher used by the installed console scripts.
+- Cache artifacts live under `~/.cache/jerboa/`, and the UI reads from those exported files when available.
 
-Key entry points:
-- `scripts/jerboa/bin/jerboa-market-health-ui-export`
-- `scripts/export_recommendations_v1.py`
-- `market_health/market_ui.py`
+## Project Layout
+
+```text
+market_health/                  scoring engine, exporter CLI, and UI renderer
+market_health/engine.py         score computation
+market_health/mh_cli.py         score export CLI
+market_health/__main__.py       package entrypoint for score export
+market_health/market_ui.py      Rich terminal UI and Pi Grid
+market_ui.py                    top-level UI launcher
+scripts/jerboa/bin/             Raspberry Pi wrapper scripts
+scripts/jerboa/systemd/user/    user-level systemd units
+docs/                           scoring, UI contract, and testing docs
+```
 
 ## Docs
 
-- `docs/SCORING.md` — scoring semantics + A/C/D feature flags
-- `docs/UI_CONTRACT.md` — UI contract fields + example
-- `docs/TESTING.md` — local gates + fixture regeneration
+- `docs/SCORING.md` - scoring semantics and feature flags.
+- `docs/UI_CONTRACT.md` - UI contract fields and shape.
+- `docs/TESTING.md` - local checks and fixture regeneration.
+
+## Troubleshooting
+
+- No colors in terminal: try a different terminal or add `--mono`.
+- Slow installs on Pi: set `PIP_EXTRA_INDEX_URL=https://www.piwheels.org/simple`.
+- Offline rendering: use `--json` with a previously exported JSON file.
+
+## License
+
+MIT Copyright Christopher Dudley


### PR DESCRIPTION
## Summary

Reworked `README.md` to separate UI launchers from score-export entry points, collapse duplicate setup guidance, and document live, demo, offline JSON, Raspberry Pi wrapper, and docs paths in the current repository layout.

## Changes

- Collapsed duplicate install and quickstart guidance into one editable setup flow
- Documented `market-health` and `market-health-pi` as UI launchers mapped to `market_ui:main`
- Documented score export only through `python -m market_health`, `python -m market_health.mh_cli`, and `python market_health/mh_cli.py`
- Updated offline JSON, Raspberry Pi wrapper, systemd, project layout, architecture, and docs sections to match the repository

## Verification

- **PASS — changed-file inventory:** `git status --short` shows only `README.md` modified.
- **PASS — markdown diff sanity:** `git diff --check -- README.md` returned clean and the diff stayed confined to `README.md`.
- **SKIPPED — CLI help probe:** `python -m market_health --help` and `python -m market_health.mh_cli --help` stopped at import time because `numpy` is not installed in this environment.