### PR TITLE
Align the Python UI exporter with the full contract

### DIFF
--- a/scripts/ui_export_ui_contract_v1.py
+++ b/scripts/ui_export_ui_contract_v1.py
@@ -1,7 +1,15 @@
 import json
 import os
+import subprocess
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from market_health.ui_contract_meta import DIMENSIONS_META_V1
 
 out_json = Path(os.path.expanduser("~/.cache/jerboa/market_health.ui.v1.json"))
 out_json.parent.mkdir(parents=True, exist_ok=True)
@@ -11,6 +19,8 @@ state_p = Path(
 env_p = Path(os.path.expanduser("~/.cache/jerboa/environment.v1.json"))
 sect_p = Path(os.path.expanduser("~/.cache/jerboa/market_health.sectors.json"))
 pos_p = Path(os.path.expanduser("~/.cache/jerboa/positions.v1.json"))
+rec_p = Path(os.path.expanduser("~/.cache/jerboa/recommendations.v1.json"))
+forecast_p = Path(os.path.expanduser("~/.cache/jerboa/forecast_scores.v1.json"))
 
 
 def read_json(p: Path):
@@ -54,8 +64,6 @@ status_cmd = os.path.expanduser("~/bin/jerboa-market-health-status")
 status_line = None
 if os.path.exists(status_cmd) and os.access(status_cmd, os.X_OK):
     try:
-        import subprocess
-
         status_line = subprocess.check_output([status_cmd], text=True).strip()
     except Exception:
         status_line = None
@@ -64,6 +72,26 @@ state = read_json(state_p)
 env = read_json(env_p)
 sect = read_json(sect_p)
 pos = read_json(pos_p)
+rec_raw = read_json(rec_p)
+forecast_raw = read_json(forecast_p)
+
+rec_status = "ok"
+rec = rec_raw
+if rec_raw is None:
+    rec_status = "missing"
+    rec = None
+elif isinstance(rec_raw, dict) and rec_raw.get("_error"):
+    rec_status = "unreadable"
+    rec = None
+
+forecast_status = "ok"
+forecast = forecast_raw
+if forecast_raw is None:
+    forecast_status = "missing"
+    forecast = None
+elif isinstance(forecast_raw, dict) and forecast_raw.get("_error"):
+    forecast_status = "unreadable"
+    forecast = None
 
 if not status_line:
     status_line = status_line_fallback(state)
@@ -173,11 +201,15 @@ payload = {
         "environment": meta(env_p),
         "sectors": meta(sect_p),
         "positions": meta(pos_p),
+        "recommendations": meta(rec_p),
+        "forecast_scores": meta(forecast_p),
         "events_provider": meta(ev_cfg_p),
     },
     "summary": {
         "symbols_sample": symbols,
         "positions_count": len(pos_list),
+        "recommendations_status": rec_status,
+        "forecast_scores_status": forecast_status,
         "events_count": len(events_list),
         "events_status": (
             events.get("status", "?") if isinstance(events, dict) else "?"
@@ -189,6 +221,9 @@ payload = {
         "environment": env,
         "sectors": sect,
         "positions": pos,
+        "dimensions_meta": DIMENSIONS_META_V1,
+        "recommendations": rec,
+        "forecast_scores": forecast,
         "events": events,
     },
 }

--- a/tests/test_ui_contract_v1.py
+++ b/tests/test_ui_contract_v1.py
@@ -8,14 +8,17 @@ from datetime import datetime
 VOLATILE_KEYS = {"asof", "generated_at", "updated_at", "timestamp", "ts"}
 
 
-def _run_export(tmp_path: Path):
+def _run_export(tmp_path: Path, *, direct_python: bool = False):
     env = os.environ.copy()
     env["HOME"] = str(tmp_path)
     env["USERPROFILE"] = str(tmp_path)
 
-    cmd = ["bash", "scripts/jerboa/bin/jerboa-market-health-ui-export"]
-    if os.name == "nt":
+    if direct_python:
         cmd = [sys.executable, "scripts/ui_export_ui_contract_v1.py"]
+    else:
+        cmd = ["bash", "scripts/jerboa/bin/jerboa-market-health-ui-export"]
+        if os.name == "nt":
+            cmd = [sys.executable, "scripts/ui_export_ui_contract_v1.py"]
 
     subprocess.run(cmd, check=True, env=env)
 
@@ -73,6 +76,7 @@ def test_contract_empty_home_is_valid(tmp_path):
         "sectors",
         "state",
         "recommendations",
+        "forecast_scores",
         "events_provider",
     ]:
         m = contract["meta"][k]
@@ -87,7 +91,13 @@ def test_contract_empty_home_is_valid(tmp_path):
     assert contract["data"]["sectors"] is None
     assert contract["data"]["state"] is None
     assert contract["data"]["recommendations"] is None
+    assert contract["data"]["forecast_scores"] is None
     assert contract["summary"]["recommendations_status"] in {
+        "ok",
+        "missing",
+        "unreadable",
+    }
+    assert contract["summary"]["forecast_scores_status"] in {
         "ok",
         "missing",
         "unreadable",
@@ -120,8 +130,30 @@ def test_contract_with_fixtures_is_populated_and_signature_stable(tmp_path):
     assert isinstance(contract["data"]["positions"], dict)
     assert isinstance(contract["data"]["sectors"], list)
     assert isinstance(contract["data"]["state"], dict)
+    assert isinstance(contract["data"]["recommendations"], dict)
+    assert isinstance(contract["data"]["forecast_scores"], dict)
 
     expected_path = Path("tests/fixtures/expected/ui_contract.signature.tsv")
     expected = expected_path.read_text().splitlines()
     got = _shape_signature(contract)
     assert got == expected
+
+
+def test_contract_standalone_python_export_path_has_full_shape(tmp_path):
+    src = Path("tests/fixtures/scenarios/bullish/jerboa_cache")
+    dst = tmp_path / ".cache" / "jerboa"
+    (dst / "state").mkdir(parents=True, exist_ok=True)
+
+    for f in src.glob("*.json"):
+        (dst / f.name).write_text(f.read_text())
+    for f in (src / "state").glob("*.json"):
+        (dst / "state" / f.name).write_text(f.read_text())
+
+    contract = _run_export(tmp_path, direct_python=True)
+    _assert_envelope(contract)
+
+    assert "recommendations" in contract["meta"]
+    assert "forecast_scores" in contract["meta"]
+    assert contract["data"]["dimensions_meta"]["F"]["display_name"] == "Plan"
+    assert isinstance(contract["data"]["recommendations"], dict)
+    assert isinstance(contract["data"]["forecast_scores"], dict)


### PR DESCRIPTION
## Summary

The standalone Python UI exporter was missing recommendation and forecast-score contract data that the shell path already emitted, so fallback execution could produce a reduced UI contract; it now reads both cache files, publishes their metadata, status, and payload entries, uses canonical A-F dimension metadata, and has direct-Python test coverage.

## Changes

- Added recommendations.v1.json and forecast_scores.v1.json reads to the standalone Python UI exporter and emitted their meta, summary status, and data payload fields.
- Switched the exported data.dimensions_meta to the canonical A-F metadata while preserving the existing envelope and idempotent write behavior.
- Extended the UI contract test to exercise the direct Python entrypoint and assert the richer contract shape.

## Verification

- **PASS — syntax check:** python -m compileall -q market_health scripts tests completed successfully
- **PASS — direct Python export:** Temp-home run of scripts/ui_export_ui_contract_v1.py produced recommendations, forecast_scores, and data.dimensions_meta.F
- **PASS — shell wrapper export:** Temp-home run of scripts/runtime/bin/runtime-market-health-ui-export produced the same added keys
- **SKIPPED — focused pytest file:** pytest is not installed in this environment