### PR TITLE
Restore deterministic Ruff CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,4 +34,7 @@ local_scheme = "no-local-version"
 fallback_version = "0.2.3"
 
 [project.optional-dependencies]
-dev = ["ruff>=0.6", "pytest>=8"]
+dev = ["ruff==0.16.0", "pytest>=8"]
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]


### PR DESCRIPTION
## Summary

Restores deterministic CI linting after Ruff expanded its default rule set and fixes an environment-sensitive regression test introduced on the current `pi-grid` base.

## Changes

- Pin the dev dependency to `ruff==0.16.0`
- Configure Ruff lint selection as `E4`, `E7`, `E9`, and `F`
- Remove inherited `INVOCATION_ID` from the refresh-wrapper test environment so it deterministically exercises the verbose non-journald output path

## Verification

- `python -m ruff --version`
- `python -m ruff format --check .`
- `python -m ruff check .`
- `python -m pytest -q`
- `INVOCATION_ID=github-actions python -m pytest -q tests/test_refresh_all_wrapper.py`
- `git diff --check`

## Scope note

The Ruff configuration remains isolated to `pyproject.toml`. The test-only adjustment is a separate commit required because the already-merged refresh-wrapper test inherited GitHub Actions' `INVOCATION_ID` and asserted output from the opposite wrapper mode.