### PR TITLE
Isolate refresh-wrapper test invocation mode

### DIFF
--- a/tests/test_refresh_all_wrapper.py
+++ b/tests/test_refresh_all_wrapper.py
@@ -62,6 +62,7 @@ exit 0
     )
 
     env = os.environ.copy()
+    env.pop("INVOCATION_ID", None)
     env["HOME"] = str(tmp_path)
     env["PATH"] = str(bin_dir) + os.pathsep + env.get("PATH", "")
 


### PR DESCRIPTION
## Summary

Makes the refresh-wrapper regression test deterministic across local and GitHub Actions environments.

## Change

- Remove inherited `INVOCATION_ID` from the subprocess environment so the test consistently exercises the verbose non-journald output path it asserts

## Verification

- `INVOCATION_ID=github-actions python -m pytest -q tests/test_refresh_all_wrapper.py`
- `python -m ruff --version`
- `python -m ruff format --check .`
- `python -m ruff check .`
- `python -m pytest -q`
- `git diff --check`

## Scope

Exactly one file changes: `tests/test_refresh_all_wrapper.py`.