### PR TITLE
Discover all `market_health` subpackages at build time

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,12 @@ market-health = "market_health.dashboard_legacy:main"
 market-health-pi = "market_health.dashboard_legacy:main"
 mh = "market_health.dashboard_legacy:main"
 [tool.setuptools]
-packages = ["market_health"]
 py-modules = ["market_ui"]
 include-package-data = true
+
+[tool.setuptools.packages.find]
+include = ["market_health*"]
+exclude = ["tests*"]
 
 # setuptools-scm pulls version from Git tags like v0.2.3
 [tool.setuptools_scm]

--- a/tests/test_packaging_config.py
+++ b/tests/test_packaging_config.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import tomllib
 from pathlib import Path
 
+from setuptools import find_packages
+
 
 ROOT = Path(__file__).resolve().parents[1]
 PYPROJECT = ROOT / "pyproject.toml"
@@ -17,6 +19,16 @@ def _market_health_packages() -> set[str]:
     for init_file in (ROOT / "market_health").glob("**/__init__.py"):
         packages.add(".".join(init_file.parent.relative_to(ROOT).parts))
     return packages
+
+
+def _discovered_market_health_packages() -> set[str]:
+    return set(
+        find_packages(
+            where=str(ROOT),
+            include=["market_health*"],
+            exclude=["tests*"],
+        )
+    )
 
 
 def test_setuptools_discovers_all_market_health_packages() -> None:
@@ -36,6 +48,7 @@ def test_setuptools_discovers_all_market_health_packages() -> None:
     assert package_find.get("exclude", []) == ["tests*"]
 
     expected_packages = _market_health_packages()
+    assert _discovered_market_health_packages() == expected_packages
     assert expected_packages == {
         "market_health",
         "market_health.brokers",

--- a/tests/test_packaging_config.py
+++ b/tests/test_packaging_config.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from pathlib import Path
 import tomllib
+from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]

--- a/tests/test_packaging_config.py
+++ b/tests/test_packaging_config.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from pathlib import Path
+import tomllib
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT = ROOT / "pyproject.toml"
+
+
+def _load_pyproject() -> dict[str, object]:
+    return tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+
+
+def _market_health_packages() -> set[str]:
+    packages: set[str] = set()
+    for init_file in (ROOT / "market_health").glob("**/__init__.py"):
+        packages.add(".".join(init_file.parent.relative_to(ROOT).parts))
+    return packages
+
+
+def test_setuptools_discovers_all_market_health_packages() -> None:
+    pyproject = _load_pyproject()
+    setuptools = pyproject["tool"]["setuptools"]
+
+    assert setuptools["py-modules"] == ["market_ui"]
+
+    package_find = setuptools["packages"]["find"]
+    assert setuptools["packages"] == {
+        "find": {
+            "include": ["market_health*"],
+            "exclude": ["tests*"],
+        }
+    }
+    assert package_find["include"] == ["market_health*"]
+    assert package_find.get("exclude", []) == ["tests*"]
+
+    expected_packages = _market_health_packages()
+    assert expected_packages == {
+        "market_health",
+        "market_health.brokers",
+        "market_health.calibration",
+        "market_health.providers",
+    }
+
+
+def test_console_scripts_remain_intact() -> None:
+    project = _load_pyproject()["project"]
+
+    assert project["scripts"] == {
+        "market-health": "market_health.dashboard_legacy:main",
+        "market-health-pi": "market_health.dashboard_legacy:main",
+        "mh": "market_health.dashboard_legacy:main",
+    }


### PR DESCRIPTION
## Summary

The build metadata was only bundling the top-level package, which would leave installed subpackages out of distributable builds. Setuptools now discovers the full `market_health*` package tree, and a regression test locks that behavior while preserving the existing console-script entries.

## Changes

- Switched setuptools packaging from a hard-coded package list to discovery via `tool.setuptools.packages.find` for the `market_health*` namespace.
- Added a regression test that parses `pyproject.toml`, verifies the discovery pattern, and checks that existing console scripts remain unchanged.
- Confirmed the installed package set covers `market_health`, `market_health.brokers`, `market_health.calibration`, and `market_health.providers`.

## Verification

- **PASS — Packaging config parse check:** Parsed `pyproject.toml` and confirmed `tool.setuptools.packages.find` includes `market_health*` with the expected `tests*` exclusion.
- **PASS — Focused packaging regression:** Direct invocation of the new packaging test functions passed.
- **PASS — Import sanity:** Imported `market_health.providers`, `market_health.brokers`, and `market_health.calibration` successfully.